### PR TITLE
feat : sentry 및 로깅 전략 결정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -43,6 +43,7 @@ dependencies {
 	implementation 'org.apache.poi:poi-ooxml:5.2.0'
 	implementation 'org.springframework.boot:spring-boot-configuration-processor'
 
+	implementation 'io.sentry:sentry-logback:7.6.0'
 
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.h2database:h2'

--- a/src/main/java/ddingdong/ddingdongBE/domain/activityreport/controller/ClubActivityReportApiController.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/activityreport/controller/ClubActivityReportApiController.java
@@ -20,7 +20,6 @@ import java.util.stream.IntStream;
 
 import lombok.RequiredArgsConstructor;
 
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -25,3 +25,8 @@ jwt:
   issuer: "ddingdong"
   secret: ${JWT_SECRET}
   expiration: 36000
+
+sentry:
+  dsn: ${SENTRY_DSN_KEY}
+  enable-tracing: true
+  environment: dev

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -35,3 +35,8 @@ cloud:
       static: ${AWS_DEFAULT_REGION}
     stack:
       auto: false
+
+sentry:
+  dsn: ${SENTRY_KEY}
+  enable-tracing: true
+  environment: dev

--- a/src/main/resources/console-appender.xml
+++ b/src/main/resources/console-appender.xml
@@ -1,0 +1,7 @@
+<included>
+  <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+    <encoder>
+      <pattern>${CONSOLE_LOG_PATTERN}</pattern>
+    </encoder>
+  </appender>
+</included>

--- a/src/main/resources/file-error-appender.xml
+++ b/src/main/resources/file-error-appender.xml
@@ -1,0 +1,16 @@
+<included>
+  <appender name="FILE-ERROR" class="ch.qos.logback.core.rolling.RollingFileAppender">
+    <filter class="ch.qos.logback.classic.filter.LevelFilter">
+      <level>ERROR</level>
+    </filter>
+    <encoder>
+      <pattern>${FILE_LOG_PATTERN}</pattern>
+    </encoder>
+    <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
+      <fileNamePattern>./log/pium-prod-%d{yyyy-MM-dd}.%i.log</fileNamePattern>
+      <maxFileSize>50MB</maxFileSize>
+      <maxHistory>50</maxHistory>
+      <totalSizeCap>3GB</totalSizeCap>
+    </rollingPolicy>
+  </appender>
+</included>

--- a/src/main/resources/file-info-appender.xml
+++ b/src/main/resources/file-info-appender.xml
@@ -1,0 +1,13 @@
+<included>
+  <appender name="FILE-INFO" class="ch.qos.logback.core.rolling.RollingFileAppender">
+    <encoder>
+      <pattern>${FILE_LOG_PATTERN}</pattern>
+    </encoder>
+    <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
+      <fileNamePattern>./log/pium-dev-%d{yyyy-MM-dd}.%i.log</fileNamePattern>
+      <maxFileSize>50MB</maxFileSize>
+      <maxHistory>100</maxHistory>
+      <totalSizeCap>1GB</totalSizeCap>
+    </rollingPolicy>
+  </appender>
+</included>

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+  <property name="CONSOLE_LOG_PATTERN"
+    value="%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] %clr(%5level) %cyan(%logger) - %msg%n"/>
+  <property name="FILE_LOG_PATTERN" value="%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] %5level %logger - %msg%n"/>
+
+  <springProfile name="local">
+    <include resource="console-appender.xml"/>
+
+    <root level="INFO">
+      <appender-ref ref="CONSOLE"/>
+    </root>
+  </springProfile>
+
+  <springProfile name="dev">
+    <include resource="file-info-appender.xml"/>
+    <include resource="file-error-appender.xml"/>
+    <include resource="sentry-appender.xml"/>
+
+    <root level="INFO">
+      <appender-ref ref="FILE-INFO"/>
+    </root>
+
+    <root level="ERROR">
+      <appender-ref ref="FILE-ERROR"/>
+      <appender-ref ref="SENTRY"/>
+    </root>
+  </springProfile>
+</configuration>

--- a/src/main/resources/sentry-appender.xml
+++ b/src/main/resources/sentry-appender.xml
@@ -1,0 +1,8 @@
+<appender name="SENTRY" class="io.sentry.logback.SentryAppender">
+  <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
+    <level>ERROR</level>
+  </filter>
+  <encoder>
+    <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+  </encoder>
+</appender>


### PR DESCRIPTION
## 🔥 연관 이슈

- close #55 

## 🚀 작업 내용
sentry 및 로깅 전략 결정

우선 local환경에서는 console에 로그 찍히도록 설정했습니다.
dev 환경에서는 롤링 방식으로 file에 모든 로그 저장하도록 설정했습니다.
Sentry는 error level의 log만 수집합니다.

### PS
SENTRY 계정 정보는 notion > 계정 정보에 올려두었습니다!