### PR TITLE
[DEV-000] jacoco 의존성 제거

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,6 @@ plugins {
     id 'java'
     id 'org.springframework.boot' version '2.7.12'
     id 'io.spring.dependency-management' version '1.0.15.RELEASE'
-    id 'jacoco'
 }
 
 group = 'ddingdong'
@@ -52,25 +51,9 @@ dependencies {
     runtimeOnly 'com.h2database:h2'
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
-	testImplementation 'org.springframework.security:spring-security-test'
+    testImplementation 'org.springframework.security:spring-security-test'
 }
 
 tasks.named('test') {
     useJUnitPlatform()
-}
-
-jacoco {
-    toolVersion = '0.8.10'
-}
-
-test {
-    finalizedBy jacocoTestReport
-}
-
-jacocoTestReport {
-    reports {
-        html.enabled true
-        xml.enabled true
-        csv.enabled true
-    }
 }


### PR DESCRIPTION
## 🚀 작업 내용
* 도커파일 빌드 실패 원인을 분석해 보니, 아래 코드 중 html.enabled true 부분에서 빌드 에러가 발생합니다. 명확한 이유는 모르겠지만 마침 익숙하지 않은 codecov대신 sonarcloud로 대체하는 방향이 좀 더 나을 것 같아서 우선 빌드 파일 내 스크립트만 먼저 제거했습니다!

```
jacocoTestReport {
    reports {
        html.enabled true
        xml.enabled true
        csv.enabled true
    }
}
```