### PR TITLE
[DEV-000] 픽스존 상세 조회에서 동아리 위치와 이름 조회 가능하도록 변경

### DIFF
--- a/src/main/java/ddingdong/ddingdongBE/domain/fixzone/controller/api/ClubFixZoneApi.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/fixzone/controller/api/ClubFixZoneApi.java
@@ -16,6 +16,7 @@ import org.springframework.http.MediaType;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -46,7 +47,7 @@ public interface ClubFixZoneApi {
     @SecurityRequirement(name = "AccessToken")
     void createFixZone(
         @AuthenticationPrincipal PrincipalDetails principalDetails,
-        @RequestPart CreateFixZoneRequest request,
+        @ModelAttribute CreateFixZoneRequest request,
         @RequestPart(name = "images", required = false) List<MultipartFile> images
     );
 
@@ -57,7 +58,7 @@ public interface ClubFixZoneApi {
     void updateFixZone(
         @AuthenticationPrincipal PrincipalDetails principalDetails,
         @PathVariable("fixZoneId") Long fixZoneId,
-        @RequestPart UpdateFixZoneRequest request,
+        @ModelAttribute UpdateFixZoneRequest request,
         @RequestPart(name = "images", required = false) List<MultipartFile> images
     );
 

--- a/src/main/java/ddingdong/ddingdongBE/domain/fixzone/controller/dto/response/GetDetailFixZoneResponse.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/fixzone/controller/dto/response/GetDetailFixZoneResponse.java
@@ -11,6 +11,12 @@ public record GetDetailFixZoneResponse(
     @Schema(description = "픽스존 id")
     Long id,
 
+    @Schema(description = "동아리 위치")
+    String clubLocation,
+
+    @Schema(description = "동아리명")
+    String clubName,
+
     @Schema(description = "제목")
     String title,
 
@@ -33,6 +39,8 @@ public record GetDetailFixZoneResponse(
 
     public static GetDetailFixZoneResponse of(
         Long id,
+        String clubLocation,
+        String clubName,
         String title,
         LocalDateTime createdAt,
         String content,
@@ -42,6 +50,8 @@ public record GetDetailFixZoneResponse(
     ) {
         return new GetDetailFixZoneResponse(
             id,
+            clubLocation,
+            clubName,
             title,
             content,
             isCompleted,

--- a/src/main/java/ddingdong/ddingdongBE/domain/fixzone/service/FixZoneService.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/fixzone/service/FixZoneService.java
@@ -45,6 +45,8 @@ public class FixZoneService {
 
         return GetDetailFixZoneResponse.of(
             fixZone.getId(),
+            fixZone.getClub().getLocation().getValue(),
+            fixZone.getClub().getName(),
             fixZone.getTitle(),
             fixZone.getCreatedAt(),
             fixZone.getContent(),


### PR DESCRIPTION
## 🚀 작업 내용
* 픽스존 상세 조회에서 clubName, clubLocation이 누락되어 해당 컬럼 추가 조치하였습니다!