### PR TITLE
[DEV-32] 로컬 db mysql 변환 및 TestContainer 설정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,32 +26,42 @@ repositories {
 }
 
 dependencies {
-    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    //develop
     implementation 'org.springframework.boot:spring-boot-starter-web'
-    implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
-
-    implementation 'io.hypersistence:hypersistence-utils-hibernate-55:3.7.2'
-
-    implementation 'com.auth0:java-jwt:4.2.1'
-
-    implementation 'io.awspring.cloud:spring-cloud-starter-aws:2.4.4'
-    implementation 'com.mysql:mysql-connector-j'
-
-    implementation 'org.apache.poi:poi:5.2.0'
-    implementation 'org.apache.poi:poi-ooxml:5.2.0'
+    compileOnly 'org.projectlombok:lombok'
+    annotationProcessor 'org.projectlombok:lombok'
+    implementation 'org.springdoc:springdoc-openapi-ui:1.6.11'
     implementation 'org.springframework.boot:spring-boot-configuration-processor'
 
-    implementation 'io.sentry:sentry-logback:7.6.0'
-    implementation 'org.springdoc:springdoc-openapi-ui:1.6.11'
+    //db
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'com.mysql:mysql-connector-j'
+    runtimeOnly 'com.h2database:h2'
 
+    //etc(기타)
+    implementation 'io.awspring.cloud:spring-cloud-starter-aws:2.4.4'
+    implementation 'org.apache.poi:poi:5.2.0'
+    implementation 'org.apache.poi:poi-ooxml:5.2.0'
+    implementation 'io.hypersistence:hypersistence-utils-hibernate-55:3.7.2'
+    implementation 'io.sentry:sentry-logback:7.6.0'
     implementation 'com.fasterxml.jackson.core:jackson-core:2.17.0'
 
-    compileOnly 'org.projectlombok:lombok'
-    runtimeOnly 'com.h2database:h2'
-    annotationProcessor 'org.projectlombok:lombok'
+
+    //security
+    implementation 'org.springframework.boot:spring-boot-starter-security'
+    implementation 'com.auth0:java-jwt:4.2.1'
+
+    //test
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.security:spring-security-test'
+    testCompileOnly 'org.projectlombok:lombok'
+    testAnnotationProcessor 'org.projectlombok:lombok'
+    // TestContainer
+    testImplementation 'org.testcontainers:testcontainers:1.20.0'
+    testImplementation 'org.testcontainers:junit-jupiter:1.20.0'
+    // mysql 컨테이너
+    testImplementation 'org.testcontainers:mysql:1.20.0'
 }
 
 tasks.named('test') {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,17 @@
+services:    # 컨테이너 정의(컨테이너의 집합체를 보주로 서비스라고 함)
+  ddingdong-local-db:
+    image: mysql:8.0
+    container_name: ddingdong_local_mysql
+    platform: linux/x86_64
+    environment:   # 환경 변수 설정
+      MYSQL_ROOT_PASSWORD: 1234
+      MYSQL_DATABASE: ddingdong_local_db
+      MYSQL_CHARSET: utf8mb4
+      MYSQL_COLLATION: utf8mb4_unicode_ci
+      TZ: Asia/Seoul
+    ports:
+      - "3307:3306"
+    volumes:
+      - backup-store:/var/lib/mysql
+volumes:
+  backup-store :

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -4,10 +4,10 @@ spring:
       on-profile: local
 
   datasource:
-    url: jdbc:h2:tcp://localhost/~/projects/ddingdong/ddingdong
-    driver-class-name: org.h2.Driver
-    username: sa
-    password:
+    url: jdbc:mysql://localhost:3307/ddingdong_local_db
+    driver-class-name: com.mysql.cj.jdbc.Driver
+    username: root
+    password: 1234
 
   jpa:
     hibernate:

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -15,7 +15,7 @@ spring:
     properties:
       hibernate:
         format_sql: true
-        dialect: org.hibernate.dialect.MySQLDialect
+        dialect: org.hibernate.dialect.MySQL5InnoDBDialect
         show-sql: true
     defer-datasource-initialization: true
 

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -12,16 +12,13 @@ spring:
   jpa:
     hibernate:
       ddl-auto: create
-    show-sql: true
     properties:
       hibernate:
         format_sql: true
+        dialect: org.hibernate.dialect.MySQLDialect
+        show-sql: true
     defer-datasource-initialization: true
 
   sql:
     init:
       mode: always
-
-  h2:
-    console:
-      enabled: true

--- a/src/main/resources/application-test.yml
+++ b/src/main/resources/application-test.yml
@@ -3,20 +3,15 @@ spring:
     activate:
       on-profile: test
 
-  datasource:
-    url: jdbc:h2:mem:ddingdongdb;
-    driver-class-name: org.h2.Driver
-    username: sa
-    password:
-
   jpa:
     hibernate:
       ddl-auto: create
-    show-sql: true
     properties:
       hibernate:
+        show-sql: true
         format_sql: true
         auto_quote_keyword: true
+        dialect: org.hibernate.dialect.MySQL5InnoDBDialect
 
   sql:
     init:

--- a/src/test/java/ddingdong/ddingdongBE/common/config/TestConfig.java
+++ b/src/test/java/ddingdong/ddingdongBE/common/config/TestConfig.java
@@ -1,0 +1,10 @@
+package ddingdong.ddingdongBE.common.config;
+
+import ddingdong.ddingdongBE.common.support.DataInitializer;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Import;
+
+@TestConfiguration
+@Import(DataInitializer.class)
+public class TestConfig {
+}

--- a/src/test/java/ddingdong/ddingdongBE/common/support/DataInitializer.java
+++ b/src/test/java/ddingdong/ddingdongBE/common/support/DataInitializer.java
@@ -1,0 +1,49 @@
+package ddingdong.ddingdongBE.common.support;
+
+import javax.persistence.PersistenceContext;
+import javax.persistence.Query;
+import java.util.ArrayList;
+import java.util.List;
+import javax.persistence.EntityManager;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+@Profile("test")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Component
+public class DataInitializer {
+
+  private static final String OFF_FOREIGN_CONSTRAINTS = "SET foreign_key_checks = false";
+  private static final String ON_FOREIGN_CONSTRAINTS = "SET foreign_key_checks = true";
+  private static final String TRUNCATE_SQL_FORMAT = "TRUNCATE %s";
+
+  private static final List<String> truncationDMLs = new ArrayList<>();
+
+  @PersistenceContext
+  private EntityManager em;
+
+  @Transactional(propagation = Propagation.REQUIRES_NEW)
+  public void deleteAll() {
+    if (truncationDMLs.isEmpty()) {
+      init();
+    }
+
+    em.createNativeQuery(OFF_FOREIGN_CONSTRAINTS).executeUpdate();
+    truncationDMLs.stream()
+        .map(em::createNativeQuery)
+        .forEach(Query::executeUpdate);
+    em.createNativeQuery(ON_FOREIGN_CONSTRAINTS).executeUpdate();
+  }
+
+  private void init() {
+    final List<String> tableNames = em.createNativeQuery("SHOW TABLES ").getResultList();
+
+    tableNames.stream()
+        .map(tableName -> String.format(TRUNCATE_SQL_FORMAT, tableName))
+        .forEach(truncationDMLs::add);
+  }
+}

--- a/src/test/java/ddingdong/ddingdongBE/common/support/DataJpaTestSupport.java
+++ b/src/test/java/ddingdong/ddingdongBE/common/support/DataJpaTestSupport.java
@@ -1,0 +1,14 @@
+package ddingdong.ddingdongBE.common.support;
+
+import ddingdong.ddingdongBE.common.config.TestConfig;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+
+//repository용
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+public abstract class DataJpaTestSupport extends TestContainerSupport {
+}

--- a/src/test/java/ddingdong/ddingdongBE/common/support/TestContainerSupport.java
+++ b/src/test/java/ddingdong/ddingdongBE/common/support/TestContainerSupport.java
@@ -1,0 +1,51 @@
+package ddingdong.ddingdongBE.common.support;
+
+
+import static lombok.AccessLevel.PROTECTED;
+
+import ddingdong.ddingdongBE.common.config.TestConfig;
+import lombok.NoArgsConstructor;
+import org.junit.jupiter.api.BeforeEach;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.containers.JdbcDatabaseContainer;
+import org.testcontainers.containers.MySQLContainer;
+
+@NoArgsConstructor(access = PROTECTED)
+@ActiveProfiles("test")
+@Import(TestConfig.class)
+public abstract class TestContainerSupport {
+
+  private static final String MYSQL_IMAGE = "mysql:8";
+  private static final int MYSQL_PORT = 3306;
+  private static final JdbcDatabaseContainer<?> MYSQL;
+
+  @Autowired
+  private DataInitializer dataInitializer;
+
+  // 싱글톤
+  static {
+    MYSQL = new MySQLContainer<>(MYSQL_IMAGE)
+        .withExposedPorts(MYSQL_PORT)
+        .withReuse(true);
+
+    MYSQL.start();
+  }
+
+  // 동적으로 DB 속성 할당
+  @DynamicPropertySource
+  public static void setUp(DynamicPropertyRegistry registry) {
+    registry.add("spring.datasource.driver-class-name", MYSQL::getDriverClassName);
+    registry.add("spring.datasource.url", MYSQL::getJdbcUrl);
+    registry.add("spring.datasource.username", MYSQL::getUsername);
+    registry.add("spring.datasource.password", MYSQL::getPassword);
+  }
+
+  @BeforeEach
+  void delete() {
+    dataInitializer.deleteAll();
+  }
+}

--- a/src/test/java/ddingdong/ddingdongBE/common/support/WebApiIntegrationTestSupport.java
+++ b/src/test/java/ddingdong/ddingdongBE/common/support/WebApiIntegrationTestSupport.java
@@ -1,0 +1,25 @@
+package ddingdong.ddingdongBE.common.support;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.web.servlet.MockMvc;
+
+// 컨트롤러 단 통합테스트용
+@SpringBootTest
+@AutoConfigureMockMvc
+public abstract class WebApiIntegrationTestSupport extends TestContainerSupport {
+
+  @Autowired
+  protected MockMvc mockMvc;
+
+  @Autowired
+  protected ObjectMapper objectMapper;
+
+  protected String toJson(Object object) throws JsonProcessingException {
+    return objectMapper.writeValueAsString(object);
+  }
+
+}

--- a/src/test/java/ddingdong/ddingdongBE/common/support/WebApiUnitTestSupport.java
+++ b/src/test/java/ddingdong/ddingdongBE/common/support/WebApiUnitTestSupport.java
@@ -34,7 +34,7 @@ import org.springframework.web.context.WebApplicationContext;
     AdminScoreHistoryController.class,
     ClubScoreHistoryController.class
 })
-public abstract class WebApiTestSupport extends TestContainerSupport {
+public abstract class WebApiUnitTestSupport {
 
   @Autowired
   private WebApplicationContext context;

--- a/src/test/java/ddingdong/ddingdongBE/common/support/WebApiUnitTestSupport.java
+++ b/src/test/java/ddingdong/ddingdongBE/common/support/WebApiUnitTestSupport.java
@@ -1,4 +1,4 @@
-package ddingdong.ddingdongBE.support;
+package ddingdong.ddingdongBE.common.support;
 
 import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
 

--- a/src/test/java/ddingdong/ddingdongBE/common/support/WithMockAuthenticatedUser.java
+++ b/src/test/java/ddingdong/ddingdongBE/common/support/WithMockAuthenticatedUser.java
@@ -1,4 +1,4 @@
-package ddingdong.ddingdongBE.support;
+package ddingdong.ddingdongBE.common.support;
 
 import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;

--- a/src/test/java/ddingdong/ddingdongBE/common/support/WithMockAuthenticatedUserSecurityContextFactory.java
+++ b/src/test/java/ddingdong/ddingdongBE/common/support/WithMockAuthenticatedUserSecurityContextFactory.java
@@ -1,4 +1,4 @@
-package ddingdong.ddingdongBE.support;
+package ddingdong.ddingdongBE.common.support;
 
 import ddingdong.ddingdongBE.auth.PrincipalDetails;
 import ddingdong.ddingdongBE.domain.user.entity.Role;

--- a/src/test/java/ddingdong/ddingdongBE/domain/documents/controller/AdminDocumentControllerUnitTest.java
+++ b/src/test/java/ddingdong/ddingdongBE/domain/documents/controller/AdminDocumentControllerUnitTest.java
@@ -18,8 +18,8 @@ import ddingdong.ddingdongBE.domain.documents.controller.dto.request.GenerateDoc
 import ddingdong.ddingdongBE.domain.documents.controller.dto.request.ModifyDocumentRequest;
 import ddingdong.ddingdongBE.domain.documents.entity.Document;
 import ddingdong.ddingdongBE.file.dto.FileResponse;
-import ddingdong.ddingdongBE.support.WebApiTestSupport;
-import ddingdong.ddingdongBE.support.WithMockAuthenticatedUser;
+import ddingdong.ddingdongBE.common.support.WebApiUnitTestSupport;
+import ddingdong.ddingdongBE.common.support.WithMockAuthenticatedUser;
 import java.time.LocalDateTime;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
@@ -27,7 +27,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockMultipartFile;
 
-public class AdminDocumentControllerTest extends WebApiTestSupport {
+public class AdminDocumentControllerUnitTest extends WebApiUnitTestSupport {
 
     @WithMockAuthenticatedUser(role = "ADMIN")
     @DisplayName("document 자료 생성 요청을 수행한다.")

--- a/src/test/java/ddingdong/ddingdongBE/domain/documents/controller/DocumentControllerUnitTest.java
+++ b/src/test/java/ddingdong/ddingdongBE/domain/documents/controller/DocumentControllerUnitTest.java
@@ -11,14 +11,14 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import ddingdong.ddingdongBE.domain.documents.entity.Document;
 import ddingdong.ddingdongBE.file.dto.FileResponse;
-import ddingdong.ddingdongBE.support.WebApiTestSupport;
-import ddingdong.ddingdongBE.support.WithMockAuthenticatedUser;
+import ddingdong.ddingdongBE.common.support.WebApiUnitTestSupport;
+import ddingdong.ddingdongBE.common.support.WithMockAuthenticatedUser;
 import java.time.LocalDateTime;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
-class DocumentControllerTest extends WebApiTestSupport {
+class DocumentControllerUnitTest extends WebApiUnitTestSupport {
 
 
     @WithMockAuthenticatedUser

--- a/src/test/java/ddingdong/ddingdongBE/domain/question/controller/AdminQuestionControllerUnitTest.java
+++ b/src/test/java/ddingdong/ddingdongBE/domain/question/controller/AdminQuestionControllerUnitTest.java
@@ -17,15 +17,15 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import ddingdong.ddingdongBE.domain.question.controller.dto.request.GenerateQuestionRequest;
 import ddingdong.ddingdongBE.domain.question.controller.dto.request.ModifyQuestionRequest;
 import ddingdong.ddingdongBE.domain.question.entity.Question;
-import ddingdong.ddingdongBE.support.WebApiTestSupport;
-import ddingdong.ddingdongBE.support.WithMockAuthenticatedUser;
+import ddingdong.ddingdongBE.common.support.WebApiUnitTestSupport;
+import ddingdong.ddingdongBE.common.support.WithMockAuthenticatedUser;
 import java.time.LocalDateTime;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.MediaType;
 
-class AdminQuestionControllerTest extends WebApiTestSupport {
+class AdminQuestionControllerUnitTest extends WebApiUnitTestSupport {
 
     @WithMockAuthenticatedUser(role = "ADMIN")
     @DisplayName("question 생성 요청을 수행한다.")

--- a/src/test/java/ddingdong/ddingdongBE/domain/question/controller/QuestionControllerUnitTest.java
+++ b/src/test/java/ddingdong/ddingdongBE/domain/question/controller/QuestionControllerUnitTest.java
@@ -9,14 +9,14 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import ddingdong.ddingdongBE.domain.question.entity.Question;
-import ddingdong.ddingdongBE.support.WebApiTestSupport;
-import ddingdong.ddingdongBE.support.WithMockAuthenticatedUser;
+import ddingdong.ddingdongBE.common.support.WebApiUnitTestSupport;
+import ddingdong.ddingdongBE.common.support.WithMockAuthenticatedUser;
 import java.time.LocalDateTime;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
-class QuestionControllerTest extends WebApiTestSupport {
+class QuestionControllerUnitTest extends WebApiUnitTestSupport {
 
     @WithMockAuthenticatedUser
     @DisplayName("questions 조회 요청을 수행한다.")

--- a/src/test/java/ddingdong/ddingdongBE/domain/scorehistory/controller/AdminScoreHistoryControllerUnitTest.java
+++ b/src/test/java/ddingdong/ddingdongBE/domain/scorehistory/controller/AdminScoreHistoryControllerUnitTest.java
@@ -14,16 +14,16 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import ddingdong.ddingdongBE.domain.club.entity.Club;
 import ddingdong.ddingdongBE.domain.scorehistory.entity.Score;
 import ddingdong.ddingdongBE.domain.scorehistory.entity.ScoreHistory;
-import ddingdong.ddingdongBE.support.WebApiTestSupport;
-import ddingdong.ddingdongBE.support.WithMockAuthenticatedUser;
+import ddingdong.ddingdongBE.common.support.WebApiUnitTestSupport;
+import ddingdong.ddingdongBE.common.support.WithMockAuthenticatedUser;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
-class ClubScoreHistoryControllerTest extends WebApiTestSupport {
+class AdminScoreHistoryControllerUnitTest extends WebApiUnitTestSupport {
 
-    @WithMockAuthenticatedUser(role = "CLUB")
-    @DisplayName("동아리- 내 점수 내역 조회 요청을 수행한다.")
+    @WithMockAuthenticatedUser(role = "ADMIN")
+    @DisplayName("동아리 점수 내역 조회 요청을 수행한다.")
     @Test
     void getScoreHistories() throws Exception {
         //given
@@ -40,11 +40,11 @@ class ClubScoreHistoryControllerTest extends WebApiTestSupport {
                         .scoreCategory(ACTIVITY_REPORT)
                         .amount(5)
                         .reason("reasonB").build());
-        when(clubService.getByUserId(anyLong())).thenReturn(club);
-        when(scoreHistoryService.getMyScoreHistories(club.getId())).thenReturn(scoreHistories);
+        when(clubService.getByClubId(anyLong())).thenReturn(club);
+        when(scoreHistoryService.getScoreHistories(club.getId())).thenReturn(scoreHistories);
 
         //when //then
-        mockMvc.perform(get("/server/club/my/score")
+        mockMvc.perform(get("/server/admin/{clubId}/score", 1L)
                         .with(csrf()))
                 .andDo(print())
                 .andExpect(status().isOk())
@@ -54,5 +54,4 @@ class ClubScoreHistoryControllerTest extends WebApiTestSupport {
                 .andExpect(jsonPath("$.scoreHistories[0].reason").value("reasonA"))
                 .andExpect(jsonPath("$.scoreHistories[0].amount").value(5));
     }
-
 }

--- a/src/test/java/ddingdong/ddingdongBE/domain/scorehistory/controller/ClubScoreHistoryControllerUnitTest.java
+++ b/src/test/java/ddingdong/ddingdongBE/domain/scorehistory/controller/ClubScoreHistoryControllerUnitTest.java
@@ -14,16 +14,16 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import ddingdong.ddingdongBE.domain.club.entity.Club;
 import ddingdong.ddingdongBE.domain.scorehistory.entity.Score;
 import ddingdong.ddingdongBE.domain.scorehistory.entity.ScoreHistory;
-import ddingdong.ddingdongBE.support.WebApiTestSupport;
-import ddingdong.ddingdongBE.support.WithMockAuthenticatedUser;
+import ddingdong.ddingdongBE.common.support.WebApiUnitTestSupport;
+import ddingdong.ddingdongBE.common.support.WithMockAuthenticatedUser;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
-class AdminScoreHistoryControllerTest extends WebApiTestSupport {
+class ClubScoreHistoryControllerUnitTest extends WebApiUnitTestSupport {
 
-    @WithMockAuthenticatedUser(role = "ADMIN")
-    @DisplayName("동아리 점수 내역 조회 요청을 수행한다.")
+    @WithMockAuthenticatedUser(role = "CLUB")
+    @DisplayName("동아리- 내 점수 내역 조회 요청을 수행한다.")
     @Test
     void getScoreHistories() throws Exception {
         //given
@@ -40,11 +40,11 @@ class AdminScoreHistoryControllerTest extends WebApiTestSupport {
                         .scoreCategory(ACTIVITY_REPORT)
                         .amount(5)
                         .reason("reasonB").build());
-        when(clubService.getByClubId(anyLong())).thenReturn(club);
-        when(scoreHistoryService.getScoreHistories(club.getId())).thenReturn(scoreHistories);
+        when(clubService.getByUserId(anyLong())).thenReturn(club);
+        when(scoreHistoryService.getMyScoreHistories(club.getId())).thenReturn(scoreHistories);
 
         //when //then
-        mockMvc.perform(get("/server/admin/{clubId}/score", 1L)
+        mockMvc.perform(get("/server/club/my/score")
                         .with(csrf()))
                 .andDo(print())
                 .andExpect(status().isOk())
@@ -54,4 +54,5 @@ class AdminScoreHistoryControllerTest extends WebApiTestSupport {
                 .andExpect(jsonPath("$.scoreHistories[0].reason").value("reasonA"))
                 .andExpect(jsonPath("$.scoreHistories[0].amount").value(5));
     }
+
 }

--- a/src/test/java/ddingdong/ddingdongBE/domain/user/repository/UserRepositoryTest.java
+++ b/src/test/java/ddingdong/ddingdongBE/domain/user/repository/UserRepositoryTest.java
@@ -3,6 +3,7 @@ package ddingdong.ddingdongBE.domain.user.repository;
 import static ddingdong.ddingdongBE.domain.user.entity.Role.*;
 import static org.assertj.core.api.Assertions.*;
 
+import ddingdong.ddingdongBE.common.support.DataJpaTestSupport;
 import ddingdong.ddingdongBE.domain.user.entity.User;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
@@ -11,9 +12,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.test.context.ActiveProfiles;
 
-@ActiveProfiles("test")
-@DataJpaTest
-class UserRepositoryTest {
+class UserRepositoryTest extends DataJpaTestSupport {
 
     @Autowired
     private UserRepository userRepository;

--- a/src/test/java/ddingdong/ddingdongBE/support/WebApiTestSupport.java
+++ b/src/test/java/ddingdong/ddingdongBE/support/WebApiTestSupport.java
@@ -2,6 +2,8 @@ package ddingdong.ddingdongBE.support;
 
 import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import ddingdong.ddingdongBE.domain.club.service.ClubService;
 import ddingdong.ddingdongBE.domain.documents.controller.AdminDocumentController;
 import ddingdong.ddingdongBE.domain.documents.controller.DocumentController;
@@ -25,37 +27,44 @@ import org.springframework.web.context.WebApplicationContext;
 
 @ActiveProfiles("test")
 @WebMvcTest(controllers = {
-        AdminDocumentController.class,
-        DocumentController.class,
-        AdminQuestionController.class,
-        QuestionController.class,
-        AdminScoreHistoryController.class,
-        ClubScoreHistoryController.class
+    AdminDocumentController.class,
+    DocumentController.class,
+    AdminQuestionController.class,
+    QuestionController.class,
+    AdminScoreHistoryController.class,
+    ClubScoreHistoryController.class
 })
-public abstract class WebApiTestSupport {
+public abstract class WebApiTestSupport extends TestContainerSupport {
 
-    @Autowired
-    private WebApplicationContext context;
-    @Autowired
-    protected MockMvc mockMvc;
-    @MockBean
-    protected DocumentService documentService;
-    @MockBean
-    protected FileService fileService;
-    @MockBean
-    protected FileInformationService fileInformationService;
-    @MockBean
-    protected QuestionService questionService;
-    @MockBean
-    protected ClubService clubService;
-    @MockBean
-    protected ScoreHistoryService scoreHistoryService;
+  @Autowired
+  private WebApplicationContext context;
+  @Autowired
+  protected MockMvc mockMvc;
+  @MockBean
+  protected DocumentService documentService;
+  @MockBean
+  protected FileService fileService;
+  @MockBean
+  protected FileInformationService fileInformationService;
+  @MockBean
+  protected QuestionService questionService;
+  @MockBean
+  protected ClubService clubService;
+  @MockBean
+  protected ScoreHistoryService scoreHistoryService;
 
-    @BeforeEach
-    void setUp() {
-        mockMvc = MockMvcBuilders.webAppContextSetup(context)
-                .apply(springSecurity())
-                .build();
-    }
+  @Autowired
+  protected ObjectMapper objectMapper;
+
+  protected String toJson(Object object) throws JsonProcessingException {
+    return objectMapper.writeValueAsString(object);
+  }
+
+  @BeforeEach
+  void setUp() {
+    mockMvc = MockMvcBuilders.webAppContextSetup(context)
+        .apply(springSecurity())
+        .build();
+  }
 
 }


### PR DESCRIPTION
## 🚀 작업 내용
1. local db를 docker-compose를 사용하여 h2에서 mysql로 변환하였습니다.
2. testcontainer 설정해놨습니다.
3. repository 테스트를 위한 support클래스 추가로 구현했고,
4. 컨트롤러 통합테스트를 위한 support클래스를 추가로 구현했습니다.
5. 데이터 초기화를 위한 Datainitializer를 구현했습니다.

## 🤔 고민했던 내용
1. 로컬 db를 docker-compose로 구축하면서, 실행시 docker compose up -d 명령어를 해줘야하는데, 이 부분을 docker-compose support가 해결해준다고 합니다. 근데 이번에 적용을 안시켰는데, 그 이유가 저번에 따로 해봤을 때 배포시 해당 의존성 때문에 배포가 실패했습니다. compose의 경로를 찾지 못해서입니다. 그 이유를 아직 해결하지 못해 의존성은 추가 안했습니다.

2. application-local.yml 파일의 정보들을 숨길 까 고민하다 로컬 정보이기 때문에.. 숨기지 않았습니다.

3. 컨트롤러 테스트가 이미 많이 구현되어있는데, 유닛테스트와 통합테스트 중 고민해봐야 할 것 같아서 통합테스트 support클래스도 만들었습니다

4. 데이터 초기화 클래스로 DataInitializer가 괜찮은지 고민입니다. 각 메소드 실행 전에 모든 테이블 데이터 초기화 해주는 역할을 하는데, 하나의 테이블만 초기화 시켜도 되는 경우에도 적용되는 것에서 고민했습니다. 성능에 크게 문제가 있는지를 잘 모르겠습니다.

## 💬 리뷰 중점사항
- application-local.yml 정보 숨겨야하는지!
- DataInitializer클래스 괜찮은지!