### PR TITLE
[DEV-27] 활동보고서 API validation, swagger 명세 및 메서드 컨벤션 적용

### DIFF
--- a/src/main/java/ddingdong/ddingdongBE/domain/activityreport/api/AdminActivityReportApi.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/activityreport/api/AdminActivityReportApi.java
@@ -1,8 +1,8 @@
 package ddingdong.ddingdongBE.domain.activityreport.api;
 
 import ddingdong.ddingdongBE.domain.activityreport.controller.dto.request.CreateActivityTermInfoRequest;
+import ddingdong.ddingdongBE.domain.activityreport.controller.dto.response.ActivityReportListResponse;
 import ddingdong.ddingdongBE.domain.activityreport.controller.dto.response.ActivityReportTermInfoResponse;
-import ddingdong.ddingdongBE.domain.activityreport.controller.dto.response.AllActivityReportResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -21,7 +21,8 @@ public interface AdminActivityReportApi {
     @Operation(summary = "활동 보고서 전체 조회")
     @GetMapping
     @ResponseStatus(HttpStatus.OK)
-    List<AllActivityReportResponse> getActivityReports();
+    @SecurityRequirement(name = "AccessToken")
+    List<ActivityReportListResponse> getActivityReports();
 
     @Operation(summary = "활동 보고서 회차별 기간 조회 API")
     @GetMapping("/term")

--- a/src/main/java/ddingdong/ddingdongBE/domain/activityreport/api/ClubActivityReportApi.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/activityreport/api/ClubActivityReportApi.java
@@ -1,0 +1,86 @@
+package ddingdong.ddingdongBE.domain.activityreport.api;
+
+import ddingdong.ddingdongBE.auth.PrincipalDetails;
+import ddingdong.ddingdongBE.domain.activityreport.controller.dto.request.CreateActivityReportRequest;
+import ddingdong.ddingdongBE.domain.activityreport.controller.dto.request.UpdateActivityReportRequest;
+import ddingdong.ddingdongBE.domain.activityreport.controller.dto.response.ActivityReportListResponse;
+import ddingdong.ddingdongBE.domain.activityreport.controller.dto.response.ActivityReportResponse;
+import ddingdong.ddingdongBE.domain.activityreport.controller.dto.response.CurrentTermResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.List;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RequestPart;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.multipart.MultipartFile;
+
+@Tag(name = "Activity Report - Club", description = "Activity Report Club API")
+@RequestMapping("/server/club")
+public interface ClubActivityReportApi {
+
+    @Operation(summary = "현재 활동보고서 회차 조회")
+    @GetMapping("/activity-reports/current-term")
+    @ResponseStatus(HttpStatus.OK)
+    @SecurityRequirement(name = "AccessToken")
+    CurrentTermResponse getCurrentTerm();
+
+    @Operation(summary = "본인 동아리 활동보고서 전체 조회")
+    @GetMapping("/my/activity-reports")
+    @ResponseStatus(HttpStatus.OK)
+    @SecurityRequirement(name = "AccessToken")
+    List<ActivityReportListResponse> getMyActivityReports(
+        @AuthenticationPrincipal PrincipalDetails principalDetails
+    );
+
+    @Operation(summary = "활동보고서 상세 조회")
+    @GetMapping("/activity-reports")
+    @ResponseStatus(HttpStatus.OK)
+    @SecurityRequirement(name = "AccessToken")
+    List<ActivityReportResponse> getActivityReport(
+        @RequestParam("term") String term,
+        @RequestParam("club_name") String clubName
+    );
+
+    @Operation(summary = "활동보고서 등록")
+    @PostMapping(value = "/my/activity-reports", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    @SecurityRequirement(name = "AccessToken")
+    void createActivityReport(
+        @AuthenticationPrincipal PrincipalDetails principalDetails,
+        @ModelAttribute(value = "reportData") List<CreateActivityReportRequest> requests,
+        @RequestPart(value = "uploadFiles1", required = false) MultipartFile firstImage,
+        @RequestPart(value = "uploadFiles2", required = false) MultipartFile secondImage
+    );
+
+    @Operation(summary = "활동보고서 수정")
+    @PatchMapping(value = "/my/activity-reports", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    @SecurityRequirement(name = "AccessToken")
+    void updateActivityReport(
+        @AuthenticationPrincipal PrincipalDetails principalDetails,
+        @RequestParam(value = "term") String term,
+        @ModelAttribute(value = "reportData") List<UpdateActivityReportRequest> requests,
+        @RequestPart(value = "uploadFiles1", required = false) MultipartFile firstImage,
+        @RequestPart(value = "uploadFiles2", required = false) MultipartFile secondImage
+    );
+
+    @Operation(summary = "활동보고서 삭제")
+    @DeleteMapping("/my/activity-reports")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    @SecurityRequirement(name = "AccessToken")
+    void deleteActivityReport(
+        @AuthenticationPrincipal PrincipalDetails principalDetails,
+        @RequestParam(value = "term") String term
+    );
+
+}

--- a/src/main/java/ddingdong/ddingdongBE/domain/activityreport/controller/AdminActivityReportApiController.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/activityreport/controller/AdminActivityReportApiController.java
@@ -2,8 +2,8 @@ package ddingdong.ddingdongBE.domain.activityreport.controller;
 
 import ddingdong.ddingdongBE.domain.activityreport.api.AdminActivityReportApi;
 import ddingdong.ddingdongBE.domain.activityreport.controller.dto.request.CreateActivityTermInfoRequest;
+import ddingdong.ddingdongBE.domain.activityreport.controller.dto.response.ActivityReportListResponse;
 import ddingdong.ddingdongBE.domain.activityreport.controller.dto.response.ActivityReportTermInfoResponse;
-import ddingdong.ddingdongBE.domain.activityreport.controller.dto.response.AllActivityReportResponse;
 import ddingdong.ddingdongBE.domain.activityreport.service.ActivityReportService;
 import ddingdong.ddingdongBE.domain.activityreport.service.ActivityReportTermInfoService;
 import java.util.List;
@@ -19,7 +19,7 @@ public class AdminActivityReportApiController implements AdminActivityReportApi 
     private final ActivityReportTermInfoService activityReportTermInfoService;
 
     @GetMapping
-    public List<AllActivityReportResponse> getActivityReports() {
+    public List<ActivityReportListResponse> getActivityReports() {
         return activityReportService.getAll();
     }
 

--- a/src/main/java/ddingdong/ddingdongBE/domain/activityreport/controller/ClubActivityReportApiController.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/activityreport/controller/ClubActivityReportApiController.java
@@ -4,144 +4,111 @@ import static ddingdong.ddingdongBE.domain.fileinformation.entity.FileDomainCate
 import static ddingdong.ddingdongBE.domain.fileinformation.entity.FileTypeCategory.IMAGE;
 
 import ddingdong.ddingdongBE.auth.PrincipalDetails;
-import ddingdong.ddingdongBE.domain.activityreport.controller.dto.request.RegisterActivityReportRequest;
+import ddingdong.ddingdongBE.domain.activityreport.api.ClubActivityReportApi;
+import ddingdong.ddingdongBE.domain.activityreport.controller.dto.request.CreateActivityReportRequest;
 import ddingdong.ddingdongBE.domain.activityreport.controller.dto.request.UpdateActivityReportRequest;
 import ddingdong.ddingdongBE.domain.activityreport.controller.dto.response.ActivityReportDto;
-import ddingdong.ddingdongBE.domain.activityreport.controller.dto.response.AllActivityReportResponse;
+import ddingdong.ddingdongBE.domain.activityreport.controller.dto.response.ActivityReportListResponse;
+import ddingdong.ddingdongBE.domain.activityreport.controller.dto.response.ActivityReportResponse;
 import ddingdong.ddingdongBE.domain.activityreport.controller.dto.response.CurrentTermResponse;
-import ddingdong.ddingdongBE.domain.activityreport.controller.dto.response.DetailActivityReportResponse;
 import ddingdong.ddingdongBE.domain.activityreport.service.ActivityReportService;
 import ddingdong.ddingdongBE.domain.user.entity.User;
 import ddingdong.ddingdongBE.file.service.FileService;
-
 import java.util.Collections;
 import java.util.List;
 import java.util.stream.IntStream;
-
 import lombok.RequiredArgsConstructor;
-
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.DeleteMapping;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PatchMapping;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/server/club")
-public class ClubActivityReportApiController {
+public class ClubActivityReportApiController implements ClubActivityReportApi {
 
     private final ActivityReportService activityReportService;
     private final FileService fileService;
 
-    @GetMapping("activity-reports/current-term")
     public CurrentTermResponse getCurrentTerm() {
         return activityReportService.getCurrentTerm();
     }
 
-    @GetMapping("/my/activity-reports")
-    public List<AllActivityReportResponse> getMyActivityReports(
-            @AuthenticationPrincipal PrincipalDetails principalDetails
-    ) {
+    public List<ActivityReportListResponse> getMyActivityReports(PrincipalDetails principalDetails) {
         User user = principalDetails.getUser();
         return activityReportService.getMyActivityReports(user);
     }
 
-    @GetMapping("/activity-reports")
-    public List<DetailActivityReportResponse> getActivityReport(
-            @RequestParam("term") String term,
-            @RequestParam("club_name") String clubName
+    public List<ActivityReportResponse> getActivityReport(
+        String term,
+        String clubName
     ) {
         return activityReportService.getActivityReport(term, clubName);
     }
 
-    @PostMapping("/my/activity-reports")
-    public void registerReport(
-            @AuthenticationPrincipal PrincipalDetails principalDetails,
-            @RequestPart(value = "reportData", required = false) List<RegisterActivityReportRequest> requests,
-            @RequestPart(value = "uploadFiles1", required = false) MultipartFile firstImage,
-            @RequestPart(value = "uploadFiles2", required = false) MultipartFile secondImage
+    public void createActivityReport(
+        PrincipalDetails principalDetails,
+        List<CreateActivityReportRequest> requests,
+        MultipartFile firstImage,
+        MultipartFile secondImage
     ) {
         User user = principalDetails.getUser();
+
+        List<MultipartFile> images = List.of(firstImage, secondImage);
 
         IntStream.range(0, requests.size())
-                .forEach(index -> {
+            .forEach(index -> {
+                CreateActivityReportRequest request = requests.get(index);
+                Long registeredActivityReportId = activityReportService.create(user, request);
 
-                    RegisterActivityReportRequest request = requests.get(index);
-                    Long registeredActivityReportId = activityReportService.register(user, request);
+                if (index < images.size() && images.get(index) != null && !images.get(index).isEmpty()) {
+                    fileService.uploadFile(
+                        registeredActivityReportId,
+                        Collections.singletonList(images.get(index)),
+                        IMAGE,
+                        ACTIVITY_REPORT
+                    );
+                }
+            });
 
-                    if (index == 0 && firstImage != null && !firstImage.isEmpty()) {
-                        fileService.uploadFile(registeredActivityReportId,
-                                Collections.singletonList(firstImage),
-                                IMAGE, ACTIVITY_REPORT);
-                    }
-
-                    if (index == 1 && secondImage != null && !secondImage.isEmpty()) {
-                        fileService.uploadFile(registeredActivityReportId,
-                                Collections.singletonList(secondImage),
-                                IMAGE, ACTIVITY_REPORT);
-                    }
-                });
     }
 
-    @PatchMapping("my/activity-reports")
-    public void updateReport(
-            @AuthenticationPrincipal PrincipalDetails principalDetails,
-            @RequestParam("term") String term,
-            @RequestPart(value = "reportData", required = false) List<UpdateActivityReportRequest> requests,
-            @RequestPart(value = "uploadFiles1", required = false) MultipartFile firstImage,
-            @RequestPart(value = "uploadFiles2", required = false) MultipartFile secondImage
+    public void updateActivityReport(
+        PrincipalDetails principalDetails,
+        String term,
+        List<UpdateActivityReportRequest> requests,
+        MultipartFile firstImage,
+        MultipartFile secondImage
     ) {
         User user = principalDetails.getUser();
 
-        List<ActivityReportDto> updateActivityReportDtos = activityReportService.update(user, term,
-                requests);
+        List<ActivityReportDto> activityReportDtos = activityReportService.update(user, term, requests);
+        List<MultipartFile> images = List.of(firstImage, secondImage);
 
-        IntStream.range(0, updateActivityReportDtos.size())
-                .forEach(index -> {
-                            if (index == 0) {
+        IntStream.range(0, Math.min(activityReportDtos.size(), images.size()))
+            .filter(index -> images.get(index) != null && !images.get(index).isEmpty())
+            .forEach(index -> {
+                    fileService.deleteFile(
+                        activityReportDtos.get(index).getId(),
+                        IMAGE,
+                        ACTIVITY_REPORT
+                    );
 
-                                if (firstImage != null && !firstImage.isEmpty()) {
-                                    fileService.deleteFile(updateActivityReportDtos.get(index).getId(), IMAGE,
-                                            ACTIVITY_REPORT);
-                                    fileService.uploadFile(updateActivityReportDtos.get(index).getId(),
-                                            Collections.singletonList(firstImage),
-                                            IMAGE,
-                                            ACTIVITY_REPORT);
-                                }
-                            }
-                            if (index == 1) {
-
-                                if (secondImage != null && !secondImage.isEmpty()) {
-                                    fileService.deleteFile(updateActivityReportDtos.get(index).getId(), IMAGE,
-                                            ACTIVITY_REPORT);
-                                    fileService.uploadFile(updateActivityReportDtos.get(index).getId(),
-                                            Collections.singletonList(secondImage),
-                                            IMAGE,
-                                            ACTIVITY_REPORT);
-                                }
-                            }
-                        }
-                );
+                    fileService.uploadFile(
+                        activityReportDtos.get(index).getId(),
+                        Collections.singletonList(images.get(index)),
+                        IMAGE,
+                        ACTIVITY_REPORT
+                    );
+                }
+            );
     }
 
-    @DeleteMapping("my/activity-reports")
-    public void deleteReport(
-            @AuthenticationPrincipal PrincipalDetails principalDetails,
-            @RequestParam("term") String term
+    public void deleteActivityReport(
+        PrincipalDetails principalDetails,
+        String term
     ) {
         User user = principalDetails.getUser();
-        List<ActivityReportDto> deleteActivityReportDtos = activityReportService.delete(user, term);
 
-        deleteActivityReportDtos
-                .forEach(
-                        activityReportDto -> fileService.deleteFile(activityReportDto.getId(), IMAGE,
-                                ACTIVITY_REPORT)
-                );
+        activityReportService.delete(user, term)
+            .forEach(it -> fileService.deleteFile(it.getId(), IMAGE, ACTIVITY_REPORT));
     }
 }

--- a/src/main/java/ddingdong/ddingdongBE/domain/activityreport/controller/dto/request/UpdateActivityReportRequest.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/activityreport/controller/dto/request/UpdateActivityReportRequest.java
@@ -1,10 +1,9 @@
 package ddingdong.ddingdongBE.domain.activityreport.controller.dto.request;
 
-import com.fasterxml.jackson.annotation.JsonFormat;
+import ddingdong.ddingdongBE.domain.activityreport.domain.Participant;
+import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalDateTime;
 import java.util.List;
-
-import ddingdong.ddingdongBE.domain.activityreport.domain.Participant;
 import lombok.Getter;
 
 @Getter
@@ -12,12 +11,21 @@ public class UpdateActivityReportRequest {
 
     public static final String DATE_FORMAT = "yyyy-MM-dd HH:mm";
 
+    @Schema(description = "회차 정보")
     private String term;
+
+    @Schema(description = "내용")
     private String content;
+
+    @Schema(description = "활동 장소")
     private String place;
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = DATE_FORMAT, timezone = "Asia/Seoul")
+
+    @Schema(description = "활동 시작 일자")
     private LocalDateTime startDate;
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = DATE_FORMAT, timezone = "Asia/Seoul")
+
+    @Schema(description = "활동 종료 일자")
     private LocalDateTime endDate;
+
+    @Schema(description = "활동 참여자 목록")
     private List<Participant> participants;
 }

--- a/src/main/java/ddingdong/ddingdongBE/domain/activityreport/controller/dto/response/ActivityReportListResponse.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/activityreport/controller/dto/response/ActivityReportListResponse.java
@@ -5,7 +5,7 @@ import lombok.Builder;
 import lombok.Getter;
 
 @Getter
-public class AllActivityReportResponse {
+public class ActivityReportListResponse {
     private String name;
 
     private String term;
@@ -13,13 +13,13 @@ public class AllActivityReportResponse {
     private List<ActivityReportDto> activityReports;
 
     @Builder
-    public AllActivityReportResponse(String name, String term, List<ActivityReportDto> activityReportDtos) {
+    public ActivityReportListResponse(String name, String term, List<ActivityReportDto> activityReportDtos) {
         this.name = name;
         this.term = term;
         this.activityReports = activityReportDtos;
     }
 
-    public static AllActivityReportResponse of(String name, String term, List<ActivityReportDto> activityReportDtos) {
-        return new AllActivityReportResponse(name, term, activityReportDtos);
+    public static ActivityReportListResponse of(String name, String term, List<ActivityReportDto> activityReportDtos) {
+        return new ActivityReportListResponse(name, term, activityReportDtos);
     }
 }

--- a/src/main/java/ddingdong/ddingdongBE/domain/activityreport/controller/dto/response/ActivityReportResponse.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/activityreport/controller/dto/response/ActivityReportResponse.java
@@ -8,7 +8,7 @@ import java.util.List;
 import lombok.Getter;
 
 @Getter
-public class DetailActivityReportResponse {
+public class ActivityReportResponse {
 
 	private Long id;
 	@JsonFormat(pattern = "yyyy-MM-dd HH:mm")
@@ -23,8 +23,9 @@ public class DetailActivityReportResponse {
 	private List<String> imageUrls;
 	private List<Participant> participants;
 
-	public DetailActivityReportResponse(Long id, String name, String content, String place, LocalDateTime startDate,
-		LocalDateTime endDate, List<String> imageUrls, List<Participant> participants, LocalDateTime createdAt) {
+	public ActivityReportResponse(Long id, String name, String content, String place, LocalDateTime startDate,
+								  LocalDateTime endDate, List<String> imageUrls, List<Participant> participants,
+								  LocalDateTime createdAt) {
 		this.id = id;
 		this.name = name;
 		this.content = content;
@@ -36,8 +37,8 @@ public class DetailActivityReportResponse {
 		this.createdAt = createdAt;
 	}
 
-	public static DetailActivityReportResponse of(ActivityReport activityReport, List<String> imageUrls) {
-		return new DetailActivityReportResponse(
+	public static ActivityReportResponse of(ActivityReport activityReport, List<String> imageUrls) {
+		return new ActivityReportResponse(
 			activityReport.getId(),
 			activityReport.getClub().getName(),
 			activityReport.getContent(),

--- a/src/main/java/ddingdong/ddingdongBE/domain/documents/api/AdminDocumentApi.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/documents/api/AdminDocumentApi.java
@@ -1,6 +1,5 @@
 package ddingdong.ddingdongBE.domain.documents.api;
 
-
 import ddingdong.ddingdongBE.auth.PrincipalDetails;
 import ddingdong.ddingdongBE.domain.documents.controller.dto.request.GenerateDocumentRequest;
 import ddingdong.ddingdongBE.domain.documents.controller.dto.request.ModifyDocumentRequest;
@@ -35,7 +34,8 @@ public interface AdminDocumentApi {
     void generateDocument(
             @AuthenticationPrincipal PrincipalDetails principalDetails,
             @ModelAttribute GenerateDocumentRequest generateDocumentRequest,
-            @RequestPart(name = "uploadFiles") List<MultipartFile> uploadFiles);
+            @RequestPart(name = "uploadFiles") List<MultipartFile> uploadFiles
+    );
 
     @Operation(summary = "어드민 자료실 목록 조회 API")
     @GetMapping

--- a/src/main/java/ddingdong/ddingdongBE/domain/scorehistory/service/ScoreHistoryService.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/scorehistory/service/ScoreHistoryService.java
@@ -38,7 +38,7 @@ public class ScoreHistoryService {
         return scoreHistoryRepository.findByClubId(club.getId());
     }
 
-    private static float roundToThirdPoint(float value) {
+    private float roundToThirdPoint(float value) {
         return Math.round(value * 1000.0) / 1000.0F;
     }
 }


### PR DESCRIPTION
## 🚀 작업 내용
* 현재 presigned url 미 적용 시, swagger 상에서 파일과 request dto를 함께 보내는 상황에서 에러가 발생합니다. 따라서 해당 PR은 추후 presigned-url 적용 후에 변경사항에 맞춰 merge 할 예정입니다.(그 전까지는 draft로 유지하겠습니다)

* 활동 보고서 validation을 추가하였습니다.
* 활동 보고서 club 권한 API들 모두 명세 완료하였습니다.
* 기존에 서버에서 합의한 메서드 네이밍 convention을 적용했습니다.
