### PR TITLE
[DEV-000] 활동보고서 시작일자 변경 및 테스트 에러 해결

### DIFF
--- a/src/main/java/ddingdong/ddingdongBE/domain/activityreport/controller/dto/request/CreateActivityReportRequest.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/activityreport/controller/dto/request/CreateActivityReportRequest.java
@@ -4,15 +4,13 @@ import com.fasterxml.jackson.annotation.JsonFormat;
 import ddingdong.ddingdongBE.domain.activityreport.domain.ActivityReport;
 import ddingdong.ddingdongBE.domain.activityreport.domain.Participant;
 import ddingdong.ddingdongBE.domain.club.entity.Club;
-
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.List;
-
 import lombok.Getter;
 
 @Getter
-public class RegisterActivityReportRequest {
+public class CreateActivityReportRequest {
 
     public static final String DATE_FORMAT = "yyyy-MM-dd HH:mm";
 

--- a/src/main/java/ddingdong/ddingdongBE/domain/activityreport/service/ActivityReportService.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/activityreport/service/ActivityReportService.java
@@ -30,7 +30,7 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class ActivityReportService {
 
-    private static final String START_DATE = "2024-03-04";
+    private static final String START_DATE = "2024-09-02";
     private static final int DEFAULT_TERM = 1;
     private static final int CORRECTION_VALUE = 1;
     private static final int TERM_LENGTH_OF_DAYS = 14;


### PR DESCRIPTION
## 🚀 작업 내용
* 2024 - 2학기 활동보고서 시작일자에 맞게 2024.09.02일로 회차 계산 기준일을 변경하였습니다.
* 기존 ci test가 깨지는 현상을 해결하였습니다.