### PR TITLE
[DEV-56] 활동 보고서 활동 일자 update 케이스 정리 및 로직 작성

### DIFF
--- a/src/main/java/ddingdong/ddingdongBE/domain/activityreport/api/AdminActivityReportApi.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/activityreport/api/AdminActivityReportApi.java
@@ -2,7 +2,6 @@ package ddingdong.ddingdongBE.domain.activityreport.api;
 
 import ddingdong.ddingdongBE.domain.activityreport.controller.dto.request.CreateActivityTermInfoRequest;
 import ddingdong.ddingdongBE.domain.activityreport.controller.dto.response.ActivityReportListResponse;
-import ddingdong.ddingdongBE.domain.activityreport.controller.dto.response.ActivityReportTermInfoResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -23,12 +22,6 @@ public interface AdminActivityReportApi {
     @ResponseStatus(HttpStatus.OK)
     @SecurityRequirement(name = "AccessToken")
     List<ActivityReportListResponse> getActivityReports();
-
-    @Operation(summary = "활동 보고서 회차별 기간 조회 API")
-    @GetMapping("/term")
-    @ResponseStatus(HttpStatus.OK)
-    @SecurityRequirement(name = "AccessToken")
-    List<ActivityReportTermInfoResponse> getActivityTermInfos();
 
     @Operation(summary = "활동 보고서 회차별 기간 설정 API")
     @PostMapping("/term")

--- a/src/main/java/ddingdong/ddingdongBE/domain/activityreport/api/ClubActivityReportApi.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/activityreport/api/ClubActivityReportApi.java
@@ -5,6 +5,7 @@ import ddingdong.ddingdongBE.domain.activityreport.controller.dto.request.Create
 import ddingdong.ddingdongBE.domain.activityreport.controller.dto.request.UpdateActivityReportRequest;
 import ddingdong.ddingdongBE.domain.activityreport.controller.dto.response.ActivityReportListResponse;
 import ddingdong.ddingdongBE.domain.activityreport.controller.dto.response.ActivityReportResponse;
+import ddingdong.ddingdongBE.domain.activityreport.controller.dto.response.ActivityReportTermInfoResponse;
 import ddingdong.ddingdongBE.domain.activityreport.controller.dto.response.CurrentTermResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
@@ -81,5 +82,11 @@ public interface ClubActivityReportApi {
         @AuthenticationPrincipal PrincipalDetails principalDetails,
         @RequestParam(value = "term") String term
     );
+
+    @Operation(summary = "활동 보고서 회차별 기간 조회 API")
+    @GetMapping("/activity-reports/term")
+    @ResponseStatus(HttpStatus.OK)
+    @SecurityRequirement(name = "AccessToken")
+    List<ActivityReportTermInfoResponse> getActivityTermInfos();
 
 }

--- a/src/main/java/ddingdong/ddingdongBE/domain/activityreport/controller/AdminActivityReportApiController.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/activityreport/controller/AdminActivityReportApiController.java
@@ -3,7 +3,6 @@ package ddingdong.ddingdongBE.domain.activityreport.controller;
 import ddingdong.ddingdongBE.domain.activityreport.api.AdminActivityReportApi;
 import ddingdong.ddingdongBE.domain.activityreport.controller.dto.request.CreateActivityTermInfoRequest;
 import ddingdong.ddingdongBE.domain.activityreport.controller.dto.response.ActivityReportListResponse;
-import ddingdong.ddingdongBE.domain.activityreport.controller.dto.response.ActivityReportTermInfoResponse;
 import ddingdong.ddingdongBE.domain.activityreport.service.ActivityReportService;
 import ddingdong.ddingdongBE.domain.activityreport.service.ActivityReportTermInfoService;
 import java.util.List;
@@ -21,11 +20,6 @@ public class AdminActivityReportApiController implements AdminActivityReportApi 
     @GetMapping
     public List<ActivityReportListResponse> getActivityReports() {
         return activityReportService.getAll();
-    }
-
-    @Override
-    public List<ActivityReportTermInfoResponse> getActivityTermInfos() {
-        return activityReportTermInfoService.getAll();
     }
 
     @Override

--- a/src/main/java/ddingdong/ddingdongBE/domain/activityreport/controller/ClubActivityReportApiController.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/activityreport/controller/ClubActivityReportApiController.java
@@ -10,8 +10,10 @@ import ddingdong.ddingdongBE.domain.activityreport.controller.dto.request.Update
 import ddingdong.ddingdongBE.domain.activityreport.controller.dto.response.ActivityReportDto;
 import ddingdong.ddingdongBE.domain.activityreport.controller.dto.response.ActivityReportListResponse;
 import ddingdong.ddingdongBE.domain.activityreport.controller.dto.response.ActivityReportResponse;
+import ddingdong.ddingdongBE.domain.activityreport.controller.dto.response.ActivityReportTermInfoResponse;
 import ddingdong.ddingdongBE.domain.activityreport.controller.dto.response.CurrentTermResponse;
 import ddingdong.ddingdongBE.domain.activityreport.service.ActivityReportService;
+import ddingdong.ddingdongBE.domain.activityreport.service.ActivityReportTermInfoService;
 import ddingdong.ddingdongBE.domain.user.entity.User;
 import ddingdong.ddingdongBE.file.service.FileService;
 import java.util.ArrayList;
@@ -27,6 +29,7 @@ import org.springframework.web.multipart.MultipartFile;
 public class ClubActivityReportApiController implements ClubActivityReportApi {
 
     private final ActivityReportService activityReportService;
+    private final ActivityReportTermInfoService activityReportTermInfoService;
     private final FileService fileService;
 
     public CurrentTermResponse getCurrentTerm() {
@@ -117,4 +120,10 @@ public class ClubActivityReportApiController implements ClubActivityReportApi {
         activityReportService.delete(user, term)
             .forEach(it -> fileService.deleteFile(it.getId(), IMAGE, ACTIVITY_REPORT));
     }
+
+    @Override
+    public List<ActivityReportTermInfoResponse> getActivityTermInfos() {
+        return activityReportTermInfoService.getAll();
+    }
+
 }

--- a/src/main/java/ddingdong/ddingdongBE/domain/activityreport/controller/dto/request/CreateActivityReportRequest.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/activityreport/controller/dto/request/CreateActivityReportRequest.java
@@ -3,6 +3,7 @@ package ddingdong.ddingdongBE.domain.activityreport.controller.dto.request;
 import ddingdong.ddingdongBE.domain.activityreport.domain.ActivityReport;
 import ddingdong.ddingdongBE.domain.activityreport.domain.Participant;
 import ddingdong.ddingdongBE.domain.club.entity.Club;
+import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.List;
@@ -15,28 +16,45 @@ public class CreateActivityReportRequest {
 
     public static final String DATE_FORMAT = "yyyy-MM-dd HH:mm";
 
+    @Schema(description = "활동 보고서 회차 정보")
     private String term;
+
+    @Schema(description = "활동 보고서 내용")
     private String content;
+
+    @Schema(description = "활동 장소")
     private String place;
+
+    @Schema(description = "활동 시작 일시")
     private String startDate;
+
+    @Schema(description = "활동 종료 일시")
     private String endDate;
 
+    @Schema(description = "활동 참여자 명단")
     private List<Participant> participants;
 
     public ActivityReport toEntity(Club club) {
+        LocalDateTime startDateTime = parseToLocalDateTime(startDate);
+        LocalDateTime endDateTime = parseToLocalDateTime(endDate);
+
         return ActivityReport.builder()
-                .term(this.term)
-                .content(this.content)
-                .place(this.place)
-                .startDate(parseToDate(this.getStartDate()))
-                .endDate(parseToDate(this.getEndDate()))
-                .participants(this.participants)
-                .club(club)
-                .build();
+            .term(this.term)
+            .content(this.content)
+            .place(this.place)
+            .startDate(startDateTime)
+            .endDate(endDateTime)
+            .participants(this.participants)
+            .club(club)
+            .build();
     }
 
-    private LocalDateTime parseToDate(final String date) {
-        return LocalDateTime.parse(date, DateTimeFormatter.ofPattern(DATE_FORMAT));
+    private LocalDateTime parseToLocalDateTime(String dateString) {
+        if (dateString == null || dateString.isBlank()) {
+            return null;
+        }
+
+        return LocalDateTime.parse(dateString, DateTimeFormatter.ofPattern(DATE_FORMAT));
     }
 
 }

--- a/src/main/java/ddingdong/ddingdongBE/domain/activityreport/domain/ActivityReport.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/activityreport/domain/ActivityReport.java
@@ -69,20 +69,36 @@ public class ActivityReport extends BaseEntity {
 	}
 
 	public void update(final UpdateActivityReportRequest updateActivityReportRequest) {
-		this.content =
-			updateActivityReportRequest.getContent() != null ? updateActivityReportRequest.getContent() : this.content;
-		this.place =
-			updateActivityReportRequest.getPlace() != null ? updateActivityReportRequest.getPlace() : this.place;
-		this.startDate =
-			updateActivityReportRequest.getStartDate() != null ? LocalDateTime.parse(
-				updateActivityReportRequest.getStartDate(),
-				DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm")) : this.startDate;
-		this.endDate =
-			updateActivityReportRequest.getEndDate() != null ? LocalDateTime.parse(
-				updateActivityReportRequest.getEndDate(),
-				DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm")) : this.endDate;
-		this.participants =
-			updateActivityReportRequest.getParticipants() != null ? updateActivityReportRequest.getParticipants() :
-				this.participants;
+		this.content = updateActivityReportRequest.getContent() != null
+			? updateActivityReportRequest.getContent()
+			: this.content;
+
+		this.place = updateActivityReportRequest.getPlace() != null
+			? updateActivityReportRequest.getPlace()
+			: this.place;
+
+		this.startDate = processDate(updateActivityReportRequest.getStartDate(), this.startDate);
+		this.endDate = processDate(updateActivityReportRequest.getEndDate(), this.endDate);
+
+		this.participants = updateActivityReportRequest.getParticipants() != null
+			? updateActivityReportRequest.getParticipants()
+			: this.participants;
 	}
+
+	private LocalDateTime processDate(String dateString, LocalDateTime currentDate) {
+		if (dateString == null) {
+			return currentDate;
+		}
+
+		if (dateString.isBlank()) {
+			return null;
+		}
+
+		return parseToLocalDateTime(dateString);
+	}
+
+	private LocalDateTime parseToLocalDateTime(String dateString) {
+		return LocalDateTime.parse(dateString, DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm"));
+	}
+
 }


### PR DESCRIPTION
## 🎯 버그 제보 리포트
<img width="507" alt="스크린샷 2024-09-05 오전 12 27 14" src="https://github.com/user-attachments/assets/afaad92e-2c31-49af-b179-67ede3e79247">

활동 보고서의 활동 일자(startDate, endDate)를 작성, 및 수정하는 과정에서 빈 문자열을 허용해야 합니다.
이때, 기존 로직에서는 문자열 형태로 전달받아 LocalDateTime으로 변환하는 로직에서 빈 문자열이 들어온 경우 에러가 발생합니다.

### 왜 빈 문자열("")을 허용하는가?
* 활동 보고서의 활동 일자(startDate, endDate)를 작성 및 수정하는 경우 크게 세 가지 값이 입력될 수 있습니다.

1. null을 입력하는 경우
2. 빈 문자열 `""`을 입력하는 경우
3. 활동 일자(yyyy-MM-dd HH:mm) 와 같이 LocalDateTime 형식으로 입력하는 경우

활동 보고서 수정 API는 PATCH 메서드이므로, 업데이트하지 않는 값의 경우 클라이언트에서 필드 값을 제외하여 요청하게 되면 자체적으로 null이 할당된 것으로 간주합니다. 

이에 따라, null값이 들어온 경우 해당 필드는 기존 값을 유지하도록 되어 있습니다.

**따라서 null이 아닌, 수정을 통해 실제 값을 삭제할 수 있도록 빈 문자열 ""을 허용**하였고, 해당 케이스를 처리하기 위한 코드를 추가하였습니다.

---
++ 추가적으로, 클라이언트 요청에 따라 학기 내 회차 정보 전체 조회 API를 어드민 레벨에서 club 레벨에서도 사용 가능하도록 변경했습니다. 이에 따라 api path가 `server/admin/~` 에서 `server/club/~` 으로 변경될 예정이며 클라이언트에게 전달 완료하였습니다.