### PR TITLE
[DEV-000] Feed 엔티티 컬럼 제약 조건 제거

### DIFF
--- a/src/main/java/ddingdong/ddingdongBE/domain/feed/entity/Feed.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/feed/entity/Feed.java
@@ -32,7 +32,7 @@ public class Feed extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(nullable = false, length = 100)
+    @Column(nullable = false)
     private String activityContent;
 
     @Column(nullable = false)

--- a/src/main/resources/db/migration/V4__Create_feed.sql
+++ b/src/main/resources/db/migration/V4__Create_feed.sql
@@ -1,6 +1,6 @@
 CREATE TABLE feed (
         id BIGINT AUTO_INCREMENT PRIMARY KEY,
-        activity_content VARCHAR(100) NOT NULL,
+        activity_content VARCHAR(255) NOT NULL,
         thumbnail_url VARCHAR(255) NOT NULL,
         feed_type VARCHAR(10) NOT NULL,
         deleted_at DATETIME,

--- a/src/test/java/ddingdong/ddingdongBE/domain/club/service/FacadeClubMemberServiceTest.java
+++ b/src/test/java/ddingdong/ddingdongBE/domain/club/service/FacadeClubMemberServiceTest.java
@@ -88,7 +88,10 @@ class FacadeClubMemberServiceTest extends TestContainerSupport {
         );
 
         User savedUser = userRepository.save(fixtureMonkey.giveMeOne(User.class));
-        Club savedClub = clubRepository.save(fixtureMonkey.giveMeBuilder(Club.class).set("user", savedUser).sample());
+        Club savedClub = clubRepository.save(fixtureMonkey.giveMeBuilder(Club.class)
+                .set("user", savedUser)
+                .set("score", Score.from(BigDecimal.ZERO))
+                .sample());
         List<ClubMember> clubMembers = fixtureMonkey.giveMeBuilder(ClubMember.class)
                 .set("club", savedClub)
                 .sampleList(5);


### PR DESCRIPTION
## 🚀 작업 내용
- Feed 엔티티 activity_content 길이 조건 제거

## 🤔 고민했던 내용
- 엔티티 수정에 따라 flyway migration 스크립트 불일치와 테스트 시 fixtureMonkey의 랜덤값 생성에 의해 CI가 빈번하게 깨지는 일이 발생해서 우선 activity_content의 길이 조건은 제거해두었습니다.
- 위 사항을 리뷰 단계에서 서로 꼼꼼히 체크해주면 좋을거 같네요!

## 💬 리뷰 중점사항
