### PR TITLE
[DEV-000] 픽스존 댓글 content 필드 타입을 text로 변경하는 스크립트 작성

### DIFF
--- a/src/main/resources/db/migration/V9__alter_fix_zone_comment_content_type.sql
+++ b/src/main/resources/db/migration/V9__alter_fix_zone_comment_content_type.sql
@@ -1,0 +1,1 @@
+ALTER TABLE fix_zone_comment MODIFY content TEXT;


### PR DESCRIPTION
## 🚀 작업 내용
* 픽스존 댓글 content field의 type을 `varchar(255)`에서 `text`로 변경하는 flyway 스크립트를 작성하였습니다.