### PR TITLE
[DEV-000] 동아리 연락처 형식 검증을 위한 정규 표현식 변경

### DIFF
--- a/src/main/java/ddingdong/ddingdongBE/domain/club/entity/PhoneNumber.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/club/entity/PhoneNumber.java
@@ -2,11 +2,11 @@ package ddingdong.ddingdongBE.domain.club.entity;
 
 import static ddingdong.ddingdongBE.common.exception.ErrorMessage.ILLEGAL_CLUB_PHONE_NUMBER_PATTERN;
 
-import java.util.Objects;
 import jakarta.persistence.Access;
 import jakarta.persistence.AccessType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;
+import java.util.Objects;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -19,7 +19,7 @@ import lombok.NoArgsConstructor;
 @Builder
 public class PhoneNumber {
 
-    private static final String PHONE_NUMBER_REGEX = "010-\\d{3,4}-\\d{4}";
+    private static final String PHONE_NUMBER_REGEX = "\\d{2,3}-\\d{3,4}-\\d{4}";
 
     @Column(name = "phone_number")
     private String number;


### PR DESCRIPTION
## 🚀 작업 내용
* 동아리 연락처가 010-으로 시작하지 않는 경우까지 고려하여, 정규 표현식을 다음과 같이 수정했습니다.
* FE측에서 연락처 값 전달 시 중간의 하이픈(-)을 넣어 형식을 맞춰 받기로 합의했습니다.

기존 : `"010-\\d{3,4}-\\d{4}"
변경 : "\\d{2,3}-\\d{3,4}-\\d{4}" 

