### PR TITLE
[DEV-004] 모니터링을 위한 Grafana, Prometheus, Spring Actuator 설정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -58,9 +58,11 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'com.auth0:java-jwt:4.2.1'
 
-    // Sentry
+    // Monitoring
     implementation 'io.sentry:sentry-spring-boot-starter-jakarta:7.14.0'
     implementation 'io.sentry:sentry-logback:7.14.0'
+    implementation 'org.springframework.boot:spring-boot-starter-actuator'
+    implementation 'io.micrometer:micrometer-registry-prometheus'
 
     //test
     testImplementation 'org.springframework.boot:spring-boot-starter-test'

--- a/src/main/java/ddingdong/ddingdongBE/common/config/SecurityConfig.java
+++ b/src/main/java/ddingdong/ddingdongBE/common/config/SecurityConfig.java
@@ -6,6 +6,7 @@ import ddingdong.ddingdongBE.auth.service.JwtAuthService;
 import ddingdong.ddingdongBE.common.filter.JwtAuthenticationFilter;
 import ddingdong.ddingdongBE.common.handler.CustomAccessDeniedHandler;
 import ddingdong.ddingdongBE.common.handler.RestAuthenticationEntryPoint;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -25,58 +26,63 @@ public class SecurityConfig {
 
     private static final String API_PREFIX = "/server";
 
+    @Value("security.actuator.base-path")
+    private String actuatorPath;
+
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http, JwtAuthService authService, JwtConfig config)
             throws Exception {
         http
-                .authorizeHttpRequests(auth -> auth
-                        .requestMatchers(API_PREFIX + "/auth/**",
-                                API_PREFIX + "/events/**")
-                        .permitAll()
-                        .requestMatchers(API_PREFIX + "/admin/**").hasRole("ADMIN")
-                        .requestMatchers(API_PREFIX + "/club/**").hasRole("CLUB")
-                        .requestMatchers(GET,
-                                API_PREFIX + "/clubs/**",
-                                API_PREFIX + "/notices/**",
-                                API_PREFIX + "/banners/**",
-                                API_PREFIX + "/documents/**",
-                                API_PREFIX + "/questions/**",
-                                API_PREFIX + "/feeds/**")
-                        .permitAll()
-                        .requestMatchers("/v3/api-docs/**", "/swagger-ui/**", "/swagger-resources/**")
-                        .permitAll()
-                        .anyRequest()
-                        .authenticated()
-                )
-                .cors(cors -> cors
-                        .configurationSource(corsConfigurationSource())
-                )
-                /*
-                csrf, headers, http-basic, rememberMe, formLogin 비활성화
-                */
-                .csrf(AbstractHttpConfigurer::disable)
-                .headers(AbstractHttpConfigurer::disable)
-                .httpBasic(AbstractHttpConfigurer::disable)
-                .rememberMe(AbstractHttpConfigurer::disable)
-                .formLogin(AbstractHttpConfigurer::disable)
-                .logout(AbstractHttpConfigurer::disable)
-                /*
-                Session 설정
-                 */
-                .sessionManagement(session -> session
-                        .sessionCreationPolicy(SessionCreationPolicy.STATELESS)
-                )
-                /*
-                Jwt 필터
-                 */
-                .addFilterBefore(authenticationFilter(authService, config), UsernamePasswordAuthenticationFilter.class)
-                /*
-                exceptionHandling
-                 */
-                .exceptionHandling(exceptions -> exceptions
-                        .authenticationEntryPoint(restAuthenticationEntryPoint())
-                        .accessDeniedHandler(accessDeniedHandler())
-                );
+            .authorizeHttpRequests(auth -> auth
+                .requestMatchers(API_PREFIX + "/auth/**",
+                    API_PREFIX + "/events/**")
+                .permitAll()
+                .requestMatchers(API_PREFIX + "/admin/**").hasRole("ADMIN")
+                .requestMatchers(API_PREFIX + "/club/**").hasRole("CLUB")
+                .requestMatchers(actuatorPath).hasRole("ADMIN")
+                .requestMatchers(GET,
+                    API_PREFIX + "/clubs/**",
+                    API_PREFIX + "/notices/**",
+                    API_PREFIX + "/banners/**",
+                    API_PREFIX + "/documents/**",
+                    API_PREFIX + "/questions/**",
+                    API_PREFIX + "/feeds/**")
+                .permitAll()
+                .requestMatchers("/v3/api-docs/**", "/swagger-ui/**", "/swagger-resources/**")
+                .permitAll()
+                .anyRequest()
+                .authenticated()
+            )
+            .cors(cors -> cors
+                .configurationSource(corsConfigurationSource())
+            )
+            /*
+            csrf, headers, http-basic, rememberMe, formLogin 비활성화
+            */
+            .csrf(AbstractHttpConfigurer::disable)
+            .headers(AbstractHttpConfigurer::disable)
+            .httpBasic(AbstractHttpConfigurer::disable)
+            .rememberMe(AbstractHttpConfigurer::disable)
+            .formLogin(AbstractHttpConfigurer::disable)
+            .logout(AbstractHttpConfigurer::disable)
+            /*
+            Session 설정
+             */
+            .sessionManagement(session -> session
+                .sessionCreationPolicy(SessionCreationPolicy.STATELESS)
+            )
+            /*
+            Jwt 필터
+             */
+            .addFilterBefore(authenticationFilter(authService, config),
+                UsernamePasswordAuthenticationFilter.class)
+            /*
+            exceptionHandling
+             */
+            .exceptionHandling(exceptions -> exceptions
+                .authenticationEntryPoint(restAuthenticationEntryPoint())
+                .accessDeniedHandler(accessDeniedHandler())
+            );
 
         return http.build();
     }

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -31,3 +31,20 @@ jwt:
 sentry:
   dsn: ${SENTRY_DSN}
   environment: prod
+
+server:
+  tomcat:
+    mbeanregistry:
+      enabled: true
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: info, health
+      base-path: ${ACTUATOR_BASE_PATH}
+    jmx:
+      exposure:
+        exclude: "*"
+  server:
+    port: 9090

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -39,3 +39,8 @@ cloud:
 swagger:
   server:
     url: ${SERVER_URL:http://localhost:8080}
+
+
+security:
+  actuator:
+    base-path: ${ACTUATOR_ALLOWANCE_SECURITY_PATH:/default}


### PR DESCRIPTION
## 🚀 작업 내용
* 서버 모니터링을 위한 Grafana, Prometheus, Spring Actuator에 대한 spring 코드 레벨의 설정입니다.
* Production 환경에서만 우선 적용하고자 합니다. 추후에 성능 테스팅 등 개발서버에서 필요 시 변경이 필요합니다.

* 해당 PR 머지 후 Production 환경에 **릴리즈 후에, 연결에 성공하면 대시보드 설정이 가능**합니다!
* spring actuator을 통해 서버 모니터링, node_exporter를 통해 시스템(ec2) 환경 모니터링이 작업 범위입니다.
* 이후, mysql에 대해서 node_exporter 추가 후에 슬로우 쿼리 등 추가 모니터링 작업까지 조치하겠습니다.

## 🤔 고민했던 내용
* 작업 문서 [백엔드 이슈 - 모니터링 서버 구축기](https://www.notion.so/0b4448189ab342d6aa29c4cbb44dd2ea)에 문서화 중입니다!