### PR TITLE
[DEV-000] ActivityReport Facade 서비스 분리

### DIFF
--- a/src/main/java/ddingdong/ddingdongBE/domain/activityreport/controller/AdminActivityReportApiController.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/activityreport/controller/AdminActivityReportApiController.java
@@ -3,7 +3,7 @@ package ddingdong.ddingdongBE.domain.activityreport.controller;
 import ddingdong.ddingdongBE.domain.activityreport.api.AdminActivityReportApi;
 import ddingdong.ddingdongBE.domain.activityreport.controller.dto.request.CreateActivityTermInfoRequest;
 import ddingdong.ddingdongBE.domain.activityreport.controller.dto.response.ActivityReportListResponse;
-import ddingdong.ddingdongBE.domain.activityreport.service.FacadeActivityReportService;
+import ddingdong.ddingdongBE.domain.activityreport.service.FacadeAdminActivityReportService;
 import ddingdong.ddingdongBE.domain.activityreport.service.dto.query.ActivityReportListQuery;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -13,11 +13,11 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 public class AdminActivityReportApiController implements AdminActivityReportApi {
 
-    private final FacadeActivityReportService facadeActivityReportService;
+    private final FacadeAdminActivityReportService facadeAdminActivityReportService;
 
     @Override
     public List<ActivityReportListResponse> getActivityReports() {
-        List<ActivityReportListQuery> queries = facadeActivityReportService.getActivityReports();
+        List<ActivityReportListQuery> queries = facadeAdminActivityReportService.getActivityReports();
         return queries.stream()
             .map(ActivityReportListResponse::from)
             .toList();
@@ -25,6 +25,6 @@ public class AdminActivityReportApiController implements AdminActivityReportApi 
 
     @Override
     public void createActivityTermInfo(CreateActivityTermInfoRequest request) {
-        facadeActivityReportService.createActivityTermInfo(request.toCommand());
+        facadeAdminActivityReportService.createActivityTermInfo(request.toCommand());
     }
 }

--- a/src/main/java/ddingdong/ddingdongBE/domain/activityreport/controller/ClubActivityReportApiController.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/activityreport/controller/ClubActivityReportApiController.java
@@ -11,11 +11,11 @@ import ddingdong.ddingdongBE.domain.activityreport.controller.dto.response.Curre
 import ddingdong.ddingdongBE.domain.activityreport.service.FacadeClubActivityReportService;
 import ddingdong.ddingdongBE.domain.activityreport.service.dto.command.CreateActivityReportCommand;
 import ddingdong.ddingdongBE.domain.activityreport.service.dto.command.UpdateActivityReportCommand;
-import ddingdong.ddingdongBE.domain.activityreport.service.dto.query.ActivityReportInfo;
 import ddingdong.ddingdongBE.domain.activityreport.service.dto.query.ActivityReportListQuery;
 import ddingdong.ddingdongBE.domain.activityreport.service.dto.query.ActivityReportQuery;
 import ddingdong.ddingdongBE.domain.activityreport.service.dto.query.ActivityReportTermInfoQuery;
 import ddingdong.ddingdongBE.domain.user.entity.User;
+import java.util.Arrays;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.RestController;
@@ -66,11 +66,7 @@ public class ClubActivityReportApiController implements ClubActivityReportApi {
         List<CreateActivityReportCommand> commands = requests.stream()
             .map(CreateActivityReportRequest::toCommand)
             .toList();
-        facadeClubActivityReportService.create(user, commands);
-
-        String term = facadeClubActivityReportService.getRequestTerm(commands);
-        List<ActivityReportInfo> activityReportInfos = facadeClubActivityReportService.getActivityReportInfos(user, term);
-        facadeClubActivityReportService.uploadImages(activityReportInfos, firstImage, secondImage);
+        facadeClubActivityReportService.create(user, commands, Arrays.asList(firstImage, secondImage));
     }
 
     @Override
@@ -85,10 +81,7 @@ public class ClubActivityReportApiController implements ClubActivityReportApi {
         List<UpdateActivityReportCommand> commands = requests.stream()
             .map(UpdateActivityReportRequest::toCommand)
             .toList();
-        facadeClubActivityReportService.update(user, term, commands);
-        List<ActivityReportInfo> activityReportInfos = facadeClubActivityReportService.getActivityReportInfos(
-            user, term);
-        facadeClubActivityReportService.updateImages(activityReportInfos, firstImage, secondImage);
+        facadeClubActivityReportService.update(user, term, commands, Arrays.asList(firstImage, secondImage));
     }
 
     @Override
@@ -97,9 +90,6 @@ public class ClubActivityReportApiController implements ClubActivityReportApi {
         String term
     ) {
         User user = principalDetails.getUser();
-        List<ActivityReportInfo> activityReportInfos = facadeClubActivityReportService.getActivityReportInfos(
-            user, term);
-        facadeClubActivityReportService.deleteImages(activityReportInfos);
         facadeClubActivityReportService.delete(user, term);
     }
 

--- a/src/main/java/ddingdong/ddingdongBE/domain/activityreport/controller/ClubActivityReportApiController.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/activityreport/controller/ClubActivityReportApiController.java
@@ -8,7 +8,7 @@ import ddingdong.ddingdongBE.domain.activityreport.controller.dto.response.Activ
 import ddingdong.ddingdongBE.domain.activityreport.controller.dto.response.ActivityReportResponse;
 import ddingdong.ddingdongBE.domain.activityreport.controller.dto.response.ActivityReportTermInfoResponse;
 import ddingdong.ddingdongBE.domain.activityreport.controller.dto.response.CurrentTermResponse;
-import ddingdong.ddingdongBE.domain.activityreport.service.FacadeActivityReportService;
+import ddingdong.ddingdongBE.domain.activityreport.service.FacadeClubActivityReportService;
 import ddingdong.ddingdongBE.domain.activityreport.service.dto.command.CreateActivityReportCommand;
 import ddingdong.ddingdongBE.domain.activityreport.service.dto.command.UpdateActivityReportCommand;
 import ddingdong.ddingdongBE.domain.activityreport.service.dto.query.ActivityReportInfo;
@@ -25,18 +25,18 @@ import org.springframework.web.multipart.MultipartFile;
 @RequiredArgsConstructor
 public class ClubActivityReportApiController implements ClubActivityReportApi {
 
-    private final FacadeActivityReportService facadeActivityReportService;
+    private final FacadeClubActivityReportService facadeClubActivityReportService;
 
     @Override
     public CurrentTermResponse getCurrentTerm() {
-        String currentTerm = facadeActivityReportService.getCurrentTerm();
+        String currentTerm = facadeClubActivityReportService.getCurrentTerm();
         return CurrentTermResponse.from(currentTerm);
     }
 
     @Override
     public List<ActivityReportListResponse> getMyActivityReports(PrincipalDetails principalDetails) {
         User user = principalDetails.getUser();
-        List<ActivityReportListQuery> queries = facadeActivityReportService.getMyActivityReports(
+        List<ActivityReportListQuery> queries = facadeClubActivityReportService.getMyActivityReports(
             user);
         return queries.stream()
             .map(ActivityReportListResponse::from)
@@ -48,7 +48,7 @@ public class ClubActivityReportApiController implements ClubActivityReportApi {
         String term,
         String clubName
     ) {
-        List<ActivityReportQuery> queries = facadeActivityReportService.getActivityReport(term,
+        List<ActivityReportQuery> queries = facadeClubActivityReportService.getActivityReport(term,
             clubName);
         return queries.stream()
             .map(ActivityReportResponse::from)
@@ -66,11 +66,11 @@ public class ClubActivityReportApiController implements ClubActivityReportApi {
         List<CreateActivityReportCommand> commands = requests.stream()
             .map(CreateActivityReportRequest::toCommand)
             .toList();
-        facadeActivityReportService.create(user, commands);
+        facadeClubActivityReportService.create(user, commands);
 
-        String term = facadeActivityReportService.getRequestTerm(commands);
-        List<ActivityReportInfo> activityReportInfos = facadeActivityReportService.getActivityReportInfos(user, term);
-        facadeActivityReportService.uploadImages(activityReportInfos, firstImage, secondImage);
+        String term = facadeClubActivityReportService.getRequestTerm(commands);
+        List<ActivityReportInfo> activityReportInfos = facadeClubActivityReportService.getActivityReportInfos(user, term);
+        facadeClubActivityReportService.uploadImages(activityReportInfos, firstImage, secondImage);
     }
 
     @Override
@@ -85,10 +85,10 @@ public class ClubActivityReportApiController implements ClubActivityReportApi {
         List<UpdateActivityReportCommand> commands = requests.stream()
             .map(UpdateActivityReportRequest::toCommand)
             .toList();
-        facadeActivityReportService.update(user, term, commands);
-        List<ActivityReportInfo> activityReportInfos = facadeActivityReportService.getActivityReportInfos(
+        facadeClubActivityReportService.update(user, term, commands);
+        List<ActivityReportInfo> activityReportInfos = facadeClubActivityReportService.getActivityReportInfos(
             user, term);
-        facadeActivityReportService.updateImages(activityReportInfos, firstImage, secondImage);
+        facadeClubActivityReportService.updateImages(activityReportInfos, firstImage, secondImage);
     }
 
     @Override
@@ -97,15 +97,15 @@ public class ClubActivityReportApiController implements ClubActivityReportApi {
         String term
     ) {
         User user = principalDetails.getUser();
-        List<ActivityReportInfo> activityReportInfos = facadeActivityReportService.getActivityReportInfos(
+        List<ActivityReportInfo> activityReportInfos = facadeClubActivityReportService.getActivityReportInfos(
             user, term);
-        facadeActivityReportService.deleteImages(activityReportInfos);
-        facadeActivityReportService.delete(user, term);
+        facadeClubActivityReportService.deleteImages(activityReportInfos);
+        facadeClubActivityReportService.delete(user, term);
     }
 
     @Override
     public List<ActivityReportTermInfoResponse> getActivityTermInfos() {
-        List<ActivityReportTermInfoQuery> queries = facadeActivityReportService.getActivityReportTermInfos();
+        List<ActivityReportTermInfoQuery> queries = facadeClubActivityReportService.getActivityReportTermInfos();
         return queries.stream()
             .map(ActivityReportTermInfoResponse::from)
             .toList();

--- a/src/main/java/ddingdong/ddingdongBE/domain/activityreport/service/FacadeAdminActivityReportService.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/activityreport/service/FacadeAdminActivityReportService.java
@@ -1,0 +1,52 @@
+package ddingdong.ddingdongBE.domain.activityreport.service;
+
+import ddingdong.ddingdongBE.domain.activityreport.domain.ActivityReport;
+import ddingdong.ddingdongBE.domain.activityreport.service.dto.command.CreateActivityTermInfoCommand;
+import ddingdong.ddingdongBE.domain.activityreport.service.dto.query.ActivityReportInfo;
+import ddingdong.ddingdongBE.domain.activityreport.service.dto.query.ActivityReportListQuery;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class FacadeAdminActivityReportService {
+
+    private final ActivityReportTermInfoService activityReportTermInfoService;
+    private final ActivityReportService activityReportService;
+
+
+    public List<ActivityReportListQuery> getActivityReports() {
+        List<ActivityReport> activityReports = activityReportService.getActivityReports();
+        return parseToListQuery(activityReports);
+    }
+
+    @Transactional
+    public void createActivityTermInfo(CreateActivityTermInfoCommand command) {
+        activityReportTermInfoService.create(command.startDate(), command.totalTermCount());
+    }
+
+    private List<ActivityReportListQuery> parseToListQuery(final List<ActivityReport> activityReports) {
+        Map<String, Map<String, List<Long>>> groupedData = activityReports.stream().collect(
+            Collectors.groupingBy(activityReport -> activityReport.getClub().getName(),
+                Collectors.groupingBy(ActivityReport::getTerm,
+                    Collectors.mapping(ActivityReport::getId, Collectors.toList()))));
+
+        return groupedData.entrySet().stream().flatMap(entry -> {
+            String clubName = entry.getKey();
+            Map<String, List<Long>> termMap = entry.getValue();
+
+            return termMap.entrySet().stream().map(termEntry -> {
+                String term = termEntry.getKey();
+                List<ActivityReportInfo> activityReportInfos = termEntry.getValue().stream()
+                    .map(ActivityReportInfo::new)
+                    .toList();
+                return ActivityReportListQuery.of(clubName, term, activityReportInfos);
+            });
+        }).toList();
+    }
+}

--- a/src/main/java/ddingdong/ddingdongBE/domain/activityreport/service/FacadeClubActivityReportService.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/activityreport/service/FacadeClubActivityReportService.java
@@ -7,7 +7,6 @@ import ddingdong.ddingdongBE.common.exception.PersistenceException.ResourceNotFo
 import ddingdong.ddingdongBE.domain.activityreport.domain.ActivityReport;
 import ddingdong.ddingdongBE.domain.activityreport.domain.ActivityReportTermInfo;
 import ddingdong.ddingdongBE.domain.activityreport.service.dto.command.CreateActivityReportCommand;
-import ddingdong.ddingdongBE.domain.activityreport.service.dto.command.CreateActivityTermInfoCommand;
 import ddingdong.ddingdongBE.domain.activityreport.service.dto.command.UpdateActivityReportCommand;
 import ddingdong.ddingdongBE.domain.activityreport.service.dto.query.ActivityReportInfo;
 import ddingdong.ddingdongBE.domain.activityreport.service.dto.query.ActivityReportListQuery;
@@ -32,7 +31,7 @@ import org.springframework.web.multipart.MultipartFile;
 @Service
 @Transactional(readOnly = true)
 @RequiredArgsConstructor
-public class FacadeActivityReportService {
+public class FacadeClubActivityReportService {
 
     private final ActivityReportService activityReportService;
     private final ActivityReportTermInfoService activityReportTermInfoService;
@@ -51,11 +50,6 @@ public class FacadeActivityReportService {
             .toList();
     }
 
-    public List<ActivityReportListQuery> getActivityReports() {
-        List<ActivityReport> activityReports = activityReportService.getActivityReports();
-        return parseToListQuery(activityReports);
-    }
-
     public List<ActivityReportListQuery> getMyActivityReports(User user) {
         Club club = clubService.getByUserId(user.getId());
         List<ActivityReport> activityReports = activityReportService.getActivityReportsByClub(club);
@@ -71,11 +65,6 @@ public class FacadeActivityReportService {
 
     public String getCurrentTerm() {
         return activityReportTermInfoService.getCurrentTerm();
-    }
-
-    @Transactional
-    public void createActivityTermInfo(CreateActivityTermInfoCommand command) {
-        activityReportTermInfoService.create(command.startDate(), command.totalTermCount());
     }
 
     @Transactional

--- a/src/main/java/ddingdong/ddingdongBE/domain/activityreport/service/FacadeClubActivityReportService.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/activityreport/service/FacadeClubActivityReportService.java
@@ -3,7 +3,6 @@ package ddingdong.ddingdongBE.domain.activityreport.service;
 import static ddingdong.ddingdongBE.domain.fileinformation.entity.FileDomainCategory.ACTIVITY_REPORT;
 import static ddingdong.ddingdongBE.domain.fileinformation.entity.FileTypeCategory.IMAGE;
 
-import ddingdong.ddingdongBE.common.exception.PersistenceException.ResourceNotFound;
 import ddingdong.ddingdongBE.domain.activityreport.domain.ActivityReport;
 import ddingdong.ddingdongBE.domain.activityreport.domain.ActivityReportTermInfo;
 import ddingdong.ddingdongBE.domain.activityreport.service.dto.command.CreateActivityReportCommand;
@@ -17,7 +16,6 @@ import ddingdong.ddingdongBE.domain.club.service.ClubService;
 import ddingdong.ddingdongBE.domain.fileinformation.service.FileInformationService;
 import ddingdong.ddingdongBE.domain.user.entity.User;
 import ddingdong.ddingdongBE.file.service.FileService;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -70,9 +68,14 @@ public class FacadeClubActivityReportService {
     @Transactional
     public void create(
         User user,
-        List<CreateActivityReportCommand> commands
+        List<CreateActivityReportCommand> commands,
+        List<MultipartFile> images
     ) {
         Club club = clubService.getByUserId(user.getId());
+
+        String term = getRequestTerm(commands);
+        List<ActivityReport> activityReports = activityReportService.getActivityReport(club.getName(), term);
+        uploadImages(activityReports, images);
 
         commands.forEach(command -> {
             ActivityReport activityReport = command.toEntity(club);
@@ -84,9 +87,14 @@ public class FacadeClubActivityReportService {
     public void update(
         User user,
         String term,
-        List<UpdateActivityReportCommand> commands
+        List<UpdateActivityReportCommand> commands,
+        List<MultipartFile> images
     ) {
         Club club = clubService.getByUserId(user.getId());
+
+        List<ActivityReport> activityReports = activityReportService.getActivityReport(club.getName(), term);
+        updateImages(activityReports, images);
+
         List<ActivityReport> updateActivityReports = commands.stream()
             .map(UpdateActivityReportCommand::toEntity)
             .toList();
@@ -99,37 +107,16 @@ public class FacadeClubActivityReportService {
         List<ActivityReport> activityReports = activityReportService.getActivityReport(
             club.getName(),
             term);
+        deleteImages(activityReports);
         activityReportService.deleteAll(activityReports);
     }
 
-    public List<ActivityReportInfo> getActivityReportInfos(
-        User user,
-        String term
-    ) {
-        Club club = clubService.getByUserId(user.getId());
-        List<ActivityReport> activityReports = activityReportService.getActivityReport(
-            club.getName(),
-            term);
-
-        if (activityReports.isEmpty()) {
-            throw new ResourceNotFound("동아리 이름 : " + club.getName() + ", term :" + term
-                + "\nActivityReport를 찾을 수 없습니다.");
-        }
-
-        return activityReports.stream()
-            .map(ActivityReportInfo::from)
-            .toList();
-    }
-
-    @Transactional
-    public void uploadImages(List<ActivityReportInfo> activityReportInfos, MultipartFile firstImage,
-        MultipartFile secondImage) {
-        List<MultipartFile> images = Arrays.asList(firstImage, secondImage);
-        IntStream.range(0, activityReportInfos.size())
+    private void uploadImages(List<ActivityReport> activityReports, List<MultipartFile> images) {
+        IntStream.range(0, activityReports.size())
             .filter(index -> images.get(index) != null && !images.get(index).isEmpty())
             .forEach(index -> {
                 fileService.uploadFile(
-                    activityReportInfos.get(index).id(),
+                    activityReports.get(index).getId(),
                     Collections.singletonList(images.get(index)),
                     IMAGE,
                     ACTIVITY_REPORT
@@ -137,22 +124,18 @@ public class FacadeClubActivityReportService {
             });
     }
 
-    @Transactional
-    public void updateImages(List<ActivityReportInfo> activityReportInfos, MultipartFile firstImage,
-        MultipartFile secondImage) {
-        List<MultipartFile> images = Arrays.asList(firstImage, secondImage);
-
-        IntStream.range(0, activityReportInfos.size())
+    private void updateImages(List<ActivityReport> activityReports, List<MultipartFile> images) {
+        IntStream.range(0, activityReports.size())
             .filter(index -> images.get(index) != null && !images.get(index).isEmpty())
             .forEach(index -> {
                     fileService.deleteFile(
-                        activityReportInfos.get(index).id(),
+                        activityReports.get(index).getId(),
                         IMAGE,
                         ACTIVITY_REPORT
                     );
 
                     fileService.uploadFile(
-                        activityReportInfos.get(index).id(),
+                        activityReports.get(index).getId(),
                         Collections.singletonList(images.get(index)),
                         IMAGE,
                         ACTIVITY_REPORT
@@ -161,14 +144,13 @@ public class FacadeClubActivityReportService {
             );
     }
 
-    @Transactional
-    public void deleteImages(List<ActivityReportInfo> activityReportInfos) {
-        activityReportInfos.forEach(query -> {
-            fileService.deleteFile(query.id(), IMAGE, ACTIVITY_REPORT);
+    private void deleteImages(List<ActivityReport> activityReports) {
+        activityReports.forEach(report -> {
+            fileService.deleteFile(report.getId(), IMAGE, ACTIVITY_REPORT);
         });
     }
 
-    public String getRequestTerm(List<CreateActivityReportCommand> commands) {
+    private String getRequestTerm(List<CreateActivityReportCommand> commands) {
         return commands.stream()
             .findFirst()
             .map(CreateActivityReportCommand::term)


### PR DESCRIPTION
## 🚀 작업 내용
- 하나로 된 FacadeService를 admin, club을 분리하였습니다.
- 컨트롤러에 비즈니스 로직이 포함된 것 같아, 해당 로직을 FacadeService로 옮겼습니다

## 🤔 고민했던 내용
parseToList() 메소드가 중복되는데, 해당 메소드를 어떻게 처리해야할 지 고민됩니다.
제가 생각한 방법은 parsing 클래스 하나 만들고 공유하는 것인데, 최선은 아닌 것 같아서 아직 적용 안했습니다..

의견 공유 부탁드립니다!
