### PR TITLE
[DDING-5] Club 도메인 presingedUrl 적용

### DIFF
--- a/src/main/java/ddingdong/ddingdongBE/domain/banner/service/FacadeAdminBannerServiceImpl.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/banner/service/FacadeAdminBannerServiceImpl.java
@@ -26,9 +26,10 @@ public class FacadeAdminBannerServiceImpl implements FacadeAdminBannerService {
     @Override
     @Transactional
     public Long create(CreateBannerCommand command) {
-        fileMetaDataService.create(
-                FileMetaData.of(command.webImageKey(), BANNER_WEB_IMAGE),
-                FileMetaData.of(command.mobileImageKey(), BANNER_MOBILE_IMAGE)
+        fileMetaDataService.create(List.of(
+                        FileMetaData.of(command.webImageKey(), BANNER_WEB_IMAGE),
+                        FileMetaData.of(command.mobileImageKey(), BANNER_MOBILE_IMAGE)
+                )
         );
         return bannerService.save(command.toEntity());
     }

--- a/src/main/java/ddingdong/ddingdongBE/domain/club/api/CentralClubApi.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/club/api/CentralClubApi.java
@@ -56,9 +56,7 @@ public interface CentralClubApi {
     @SecurityRequirement(name = "AccessToken")
     @PatchMapping
     void updateClub(@AuthenticationPrincipal PrincipalDetails principalDetails,
-                    @Valid @ModelAttribute UpdateClubInfoRequest request,
-                    @RequestPart(name = "profileImage", required = false) List<MultipartFile> profileImage,
-                    @RequestPart(name = "introduceImages", required = false) List<MultipartFile> images);
+                    @Valid @RequestBody UpdateClubInfoRequest request);
 
     @Operation(summary = "동아리원 명단 등록 API")
     @ApiResponses(value = {

--- a/src/main/java/ddingdong/ddingdongBE/domain/club/controller/CentralClubController.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/club/controller/CentralClubController.java
@@ -1,9 +1,5 @@
 package ddingdong.ddingdongBE.domain.club.controller;
 
-import static ddingdong.ddingdongBE.domain.fileinformation.entity.FileDomainCategory.CLUB_INTRODUCE;
-import static ddingdong.ddingdongBE.domain.fileinformation.entity.FileDomainCategory.CLUB_PROFILE;
-import static ddingdong.ddingdongBE.domain.fileinformation.entity.FileTypeCategory.IMAGE;
-
 import ddingdong.ddingdongBE.auth.PrincipalDetails;
 import ddingdong.ddingdongBE.domain.club.api.CentralClubApi;
 import ddingdong.ddingdongBE.domain.club.controller.dto.request.UpdateClubInfoRequest;
@@ -14,7 +10,6 @@ import ddingdong.ddingdongBE.domain.club.service.dto.query.MyClubInfoQuery;
 import ddingdong.ddingdongBE.domain.clubmember.service.FacadeClubMemberService;
 import ddingdong.ddingdongBE.domain.clubmember.service.dto.command.UpdateClubMemberListCommand;
 import ddingdong.ddingdongBE.domain.user.entity.User;
-import ddingdong.ddingdongBE.file.service.FileService;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
@@ -33,7 +28,6 @@ public class CentralClubController implements CentralClubApi {
 
     private final FacadeCentralClubService facadeCentralClubService;
     private final FacadeClubMemberService facadeClubMemberService;
-    private final FileService fileService;
 
     @Override
     public ResponseEntity<byte[]> getMyClubMemberListFile(PrincipalDetails principalDetails) {
@@ -59,22 +53,9 @@ public class CentralClubController implements CentralClubApi {
     }
 
     @Override
-    public void updateClub(PrincipalDetails principalDetails,
-                           UpdateClubInfoRequest request,
-                           List<MultipartFile> profileImage,
-                           List<MultipartFile> images) {
+    public void updateClub(PrincipalDetails principalDetails, UpdateClubInfoRequest request) {
         User user = principalDetails.getUser();
-        Long updatedClubId = facadeCentralClubService.updateClubInfo(request.toCommand(user.getId()));
-
-        if (profileImage != null) {
-            fileService.deleteFile(updatedClubId, IMAGE, CLUB_PROFILE);
-            fileService.uploadFile(updatedClubId, profileImage, IMAGE, CLUB_PROFILE);
-        }
-
-        if (images != null) {
-            fileService.deleteFile(updatedClubId, IMAGE, CLUB_INTRODUCE);
-            fileService.uploadFile(updatedClubId, images, IMAGE, CLUB_INTRODUCE);
-        }
+        facadeCentralClubService.updateClubInfo(request.toCommand(user.getId()));
     }
 
     @Override

--- a/src/main/java/ddingdong/ddingdongBE/domain/club/controller/UserClubController.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/club/controller/UserClubController.java
@@ -26,7 +26,7 @@ public class UserClubController implements UserClubApi {
     }
 
     @Override
-    public UserClubResponse getDetailClub(@PathVariable("clubId") Long clubId) {
+    public UserClubResponse getDetailClub(Long clubId) {
         UserClubQuery query = facadeUserClubService.getClub(clubId);
         return UserClubResponse.from(query);
     }

--- a/src/main/java/ddingdong/ddingdongBE/domain/club/controller/dto/request/UpdateClubInfoRequest.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/club/controller/dto/request/UpdateClubInfoRequest.java
@@ -45,10 +45,10 @@ public record UpdateClubInfoRequest(
         String ideal,
         @Schema(description = "모집 Url", example = "Url")
         String formUrl,
-        @Schema(description = "동아리 프로필 이미지url", example = "url")
-        List<String> profileImageUrls,
-        @Schema(description = "동아리 소개 이미지 url", example = "url")
-        List<String> introduceImageUrls
+        @Schema(description = "동아리 프로필 이미지 key", example = "local/file/2024-01-01/abc/uuid")
+        String profileImageKey,
+        @Schema(description = "동아리 소개 이미지 key", example = "local/file/2024-01-01/abc/uuid")
+        String introductionImageKey
 
 ) {
 
@@ -68,8 +68,8 @@ public record UpdateClubInfoRequest(
                 activity,
                 ideal,
                 formUrl,
-                profileImageUrls,
-                introduceImageUrls
+                profileImageKey,
+                introductionImageKey
         );
     }
 }

--- a/src/main/java/ddingdong/ddingdongBE/domain/club/controller/dto/response/AdminClubListResponse.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/club/controller/dto/response/AdminClubListResponse.java
@@ -18,7 +18,6 @@ public record AdminClubListResponse(
         String category,
         @Schema(description = "동아리 점수", example = "0.00")
         BigDecimal score,
-        @Schema(description = "동아리 프로필 이미지 Url", example = "url")
         AdminClubListImageUrlResponse profileImageUrl
 ) {
 

--- a/src/main/java/ddingdong/ddingdongBE/domain/club/controller/dto/response/AdminClubListResponse.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/club/controller/dto/response/AdminClubListResponse.java
@@ -1,9 +1,9 @@
 package ddingdong.ddingdongBE.domain.club.controller.dto.response;
 
 import ddingdong.ddingdongBE.domain.club.service.dto.query.AdminClubListQuery;
+import ddingdong.ddingdongBE.file.service.dto.query.UploadedFileUrlQuery;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.math.BigDecimal;
-import java.util.List;
 
 @Schema(
         name = "AdminClubListResponse",
@@ -19,7 +19,7 @@ public record AdminClubListResponse(
         @Schema(description = "동아리 점수", example = "0.00")
         BigDecimal score,
         @Schema(description = "동아리 프로필 이미지 Url", example = "url")
-        List<String> profileImageUrls
+        AdminClubListImageUrlResponse profileImageUrl
 ) {
 
     public static AdminClubListResponse from(AdminClubListQuery query) {
@@ -28,8 +28,25 @@ public record AdminClubListResponse(
                 query.name(),
                 query.category(),
                 query.score(),
-                query.profileImageUrls()
+                AdminClubListImageUrlResponse.from(query.profileImageUrlQuery())
         );
+    }
+
+    @Schema(
+            name = "AdminClubListImageUrlResponse",
+            description = "어드민 - 동아리 목록 이미지 URL 조회 응답"
+    )
+    record AdminClubListImageUrlResponse(
+            @Schema(description = "원본 url", example = "url")
+            String originUrl,
+            @Schema(description = "cdn url", example = "url")
+            String cdnUrl
+    ) {
+
+        public static AdminClubListImageUrlResponse from(UploadedFileUrlQuery query) {
+            return new AdminClubListImageUrlResponse(query.originUrl(), query.cdnUrl());
+        }
+
     }
 
 }

--- a/src/main/java/ddingdong/ddingdongBE/domain/club/controller/dto/response/MyClubInfoResponse.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/club/controller/dto/response/MyClubInfoResponse.java
@@ -43,9 +43,7 @@ public record MyClubInfoResponse(
         String formUrl,
         @Schema(description = "동아리 프로필 이미지 Url", example = "url")
         MyClubInfoImageUrlResponse profileImageUrl,
-        @Schema(description = "동아리 소개 이미지 Url ", example = "url")
         MyClubInfoImageUrlResponse introduceImageUrl,
-        @Schema(description = "동아리원 목록")
         List<ClubMemberResponse> clubMembers
 ) {
 

--- a/src/main/java/ddingdong/ddingdongBE/domain/club/controller/dto/response/MyClubInfoResponse.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/club/controller/dto/response/MyClubInfoResponse.java
@@ -3,6 +3,7 @@ package ddingdong.ddingdongBE.domain.club.controller.dto.response;
 import com.fasterxml.jackson.annotation.JsonFormat;
 import ddingdong.ddingdongBE.domain.club.service.dto.query.MyClubInfoQuery;
 import ddingdong.ddingdongBE.domain.clubmember.entity.ClubMember;
+import ddingdong.ddingdongBE.file.service.dto.query.UploadedFileUrlQuery;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalDateTime;
 import java.util.List;
@@ -41,9 +42,9 @@ public record MyClubInfoResponse(
         @Schema(description = "모집Url", example = "url")
         String formUrl,
         @Schema(description = "동아리 프로필 이미지 Url", example = "url")
-        List<String> profileImageUrls,
+        MyClubInfoImageUrlResponse profileImageUrl,
         @Schema(description = "동아리 소개 이미지 Url ", example = "url")
-        List<String> introduceImageUrls,
+        MyClubInfoImageUrlResponse introduceImageUrl,
         @Schema(description = "동아리원 목록")
         List<ClubMemberResponse> clubMembers
 ) {
@@ -63,12 +64,29 @@ public record MyClubInfoResponse(
                 query.activity(),
                 query.ideal(),
                 query.formUrl(),
-                query.profileImageUrls(),
-                query.introduceImageUrls(),
+                MyClubInfoImageUrlResponse.from(query.profileImageUrlQuery()),
+                MyClubInfoImageUrlResponse.from(query.introductionImageUrlQuery()),
                 query.clubMembers().stream()
                         .map(ClubMemberResponse::from)
                         .toList()
         );
+    }
+
+    @Schema(
+            name = "MyClubInfoImageUrlResponse",
+            description = "동아리 - 내 동아리 정보 이미지 URL 조회 응답"
+    )
+    record MyClubInfoImageUrlResponse(
+            @Schema(description = "원본 url", example = "url")
+            String originUrl,
+            @Schema(description = "cdn url", example = "url")
+            String cdnUrl
+    ) {
+
+        public static MyClubInfoImageUrlResponse from(UploadedFileUrlQuery query) {
+            return new MyClubInfoImageUrlResponse(query.originUrl(), query.cdnUrl());
+        }
+
     }
 
     @Schema(

--- a/src/main/java/ddingdong/ddingdongBE/domain/club/controller/dto/response/UserClubResponse.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/club/controller/dto/response/UserClubResponse.java
@@ -2,9 +2,9 @@ package ddingdong.ddingdongBE.domain.club.controller.dto.response;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
 import ddingdong.ddingdongBE.domain.club.service.dto.query.UserClubQuery;
+import ddingdong.ddingdongBE.file.service.dto.query.UploadedFileUrlQuery;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalDateTime;
-import java.util.List;
 
 @Schema(
         name = "UserClubResponse",
@@ -40,9 +40,9 @@ public record UserClubResponse(
         @Schema(description = "모집Url", example = "url")
         String formUrl,
         @Schema(description = "동아리 프로필 이미지 Url", example = "url")
-        List<String> profileImageUrls,
+        UserClubImageUrlResponse profileImageUrl,
         @Schema(description = "동아리 소개 이미지 Url ", example = "url")
-        List<String> introduceImageUrls
+        UserClubImageUrlResponse introductionImageUrl
 ) {
 
     public static UserClubResponse from(UserClubQuery query) {
@@ -60,8 +60,25 @@ public record UserClubResponse(
                 query.activity(),
                 query.ideal(),
                 query.formUrl(),
-                query.profileImageUrls(),
-                query.introduceImageUrls()
+                UserClubImageUrlResponse.from(query.profileImageUrlQuery()),
+                UserClubImageUrlResponse.from(query.introductionImageUrlQuery())
         );
+    }
+
+    @Schema(
+            name = "UserClubImageUrlResponse",
+            description = "유저 - 동아리 정보 이미지 URL 조회 응답"
+    )
+    record UserClubImageUrlResponse(
+            @Schema(description = "원본 url", example = "url")
+            String originUrl,
+            @Schema(description = "cdn url", example = "url")
+            String cdnUrl
+    ) {
+
+        public static UserClubImageUrlResponse from(UploadedFileUrlQuery query) {
+            return new UserClubImageUrlResponse(query.originUrl(), query.cdnUrl());
+        }
+
     }
 }

--- a/src/main/java/ddingdong/ddingdongBE/domain/club/controller/dto/response/UserClubResponse.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/club/controller/dto/response/UserClubResponse.java
@@ -39,9 +39,7 @@ public record UserClubResponse(
         String ideal,
         @Schema(description = "모집Url", example = "url")
         String formUrl,
-        @Schema(description = "동아리 프로필 이미지 Url", example = "url")
         UserClubImageUrlResponse profileImageUrl,
-        @Schema(description = "동아리 소개 이미지 Url ", example = "url")
         UserClubImageUrlResponse introductionImageUrl
 ) {
 

--- a/src/main/java/ddingdong/ddingdongBE/domain/club/entity/Club.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/club/entity/Club.java
@@ -71,7 +71,6 @@ public class Club extends BaseEntity {
 
     private String formUrl;
 
-    //TODO: migration script 작성
     private String profileImageKey;
 
     private String introductionImageKey;

--- a/src/main/java/ddingdong/ddingdongBE/domain/club/entity/Club.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/club/entity/Club.java
@@ -71,6 +71,11 @@ public class Club extends BaseEntity {
 
     private String formUrl;
 
+    //TODO: migration script 작성
+    private String profileImageKey;
+
+    private String introductionImageKey;
+
     @Embedded
     private Score score;
 
@@ -81,7 +86,8 @@ public class Club extends BaseEntity {
     private Club(Long id, User user, List<ClubMember> clubMembers, String name, String category, String tag,
                  String leader, PhoneNumber phoneNumber, Location location, LocalDateTime startRecruitPeriod,
                  LocalDateTime endRecruitPeriod, String regularMeeting, String introduction, String activity,
-                 String ideal, String formUrl, Score score, LocalDateTime deletedAt) {
+                 String ideal, String formUrl, String profileImageKey, String introductionImageKey, Score score,
+                 LocalDateTime deletedAt) {
         this.id = id;
         this.user = user;
         this.clubMembers = clubMembers;
@@ -98,6 +104,8 @@ public class Club extends BaseEntity {
         this.activity = activity;
         this.ideal = ideal;
         this.formUrl = formUrl;
+        this.profileImageKey = profileImageKey;
+        this.introductionImageKey = introductionImageKey;
         this.score = score;
         this.deletedAt = deletedAt;
     }

--- a/src/main/java/ddingdong/ddingdongBE/domain/club/service/ClubService.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/club/service/ClubService.java
@@ -13,7 +13,7 @@ public interface ClubService {
 
     List<Club> findAll();
 
-    void update(Long clubId, Club updatedClub);
+    void update(Club club, Club updatedClub);
 
     void delete(Long clubId);
 

--- a/src/main/java/ddingdong/ddingdongBE/domain/club/service/FacadeAdminClubServiceImpl.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/club/service/FacadeAdminClubServiceImpl.java
@@ -1,14 +1,11 @@
 package ddingdong.ddingdongBE.domain.club.service;
 
-import static ddingdong.ddingdongBE.domain.fileinformation.entity.FileDomainCategory.CLUB_PROFILE;
-import static ddingdong.ddingdongBE.domain.fileinformation.entity.FileTypeCategory.IMAGE;
-
 import ddingdong.ddingdongBE.auth.service.AuthService;
 import ddingdong.ddingdongBE.domain.club.entity.Club;
 import ddingdong.ddingdongBE.domain.club.service.dto.command.CreateClubCommand;
 import ddingdong.ddingdongBE.domain.club.service.dto.query.AdminClubListQuery;
-import ddingdong.ddingdongBE.domain.fileinformation.service.FileInformationService;
 import ddingdong.ddingdongBE.domain.user.entity.User;
+import ddingdong.ddingdongBE.file.service.S3FileService;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -21,7 +18,7 @@ public class FacadeAdminClubServiceImpl implements FacadeAdminClubService {
 
     private final ClubService clubService;
     private final AuthService authService;
-    private final FileInformationService fileInformationService;
+    private final S3FileService s3FileService;
 
 
     @Override
@@ -36,8 +33,7 @@ public class FacadeAdminClubServiceImpl implements FacadeAdminClubService {
     @Override
     public List<AdminClubListQuery> findAll() {
         return clubService.findAll().stream()
-                .map(club -> AdminClubListQuery.of(club, fileInformationService.getImageUrls(
-                        IMAGE.getFileType() + CLUB_PROFILE.getFileDomain() + club.getId())))
+                .map(club -> AdminClubListQuery.of(club, s3FileService.getUploadedFileUrl(club.getProfileImageKey())))
                 .toList();
     }
 

--- a/src/main/java/ddingdong/ddingdongBE/domain/club/service/FacadeCentralClubServiceImpl.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/club/service/FacadeCentralClubServiceImpl.java
@@ -3,6 +3,7 @@ package ddingdong.ddingdongBE.domain.club.service;
 import static ddingdong.ddingdongBE.domain.fileinformation.entity.FileDomainCategory.CLUB_INTRODUCE;
 import static ddingdong.ddingdongBE.domain.fileinformation.entity.FileDomainCategory.CLUB_PROFILE;
 import static ddingdong.ddingdongBE.domain.fileinformation.entity.FileTypeCategory.IMAGE;
+import static ddingdong.ddingdongBE.domain.filemetadata.entity.FileCategory.*;
 
 import ddingdong.ddingdongBE.domain.club.entity.Club;
 import ddingdong.ddingdongBE.domain.club.service.dto.command.UpdateClubInfoCommand;
@@ -10,6 +11,9 @@ import ddingdong.ddingdongBE.domain.club.service.dto.query.MyClubInfoQuery;
 import ddingdong.ddingdongBE.domain.fileinformation.entity.FileInformation;
 import ddingdong.ddingdongBE.domain.fileinformation.repository.FileInformationRepository;
 import ddingdong.ddingdongBE.domain.fileinformation.service.FileInformationService;
+import ddingdong.ddingdongBE.domain.filemetadata.entity.FileCategory;
+import ddingdong.ddingdongBE.domain.filemetadata.entity.FileMetaData;
+import ddingdong.ddingdongBE.domain.filemetadata.service.FileMetaDataService;
 import ddingdong.ddingdongBE.file.FileStore;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -22,6 +26,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class FacadeCentralClubServiceImpl implements FacadeCentralClubService {
 
     private final ClubService clubService;
+    private final FileMetaDataService fileMetaDataService;
     private final FileInformationService fileInformationService;
 
     @Override
@@ -40,6 +45,10 @@ public class FacadeCentralClubServiceImpl implements FacadeCentralClubService {
     public Long updateClubInfo(UpdateClubInfoCommand command) {
         Club club = clubService.getByUserId(command.userId());
         clubService.update(club, command.toEntity());
+        fileMetaDataService.create(
+                FileMetaData.of(command.profileImageKey(), CLUB_PROFILE_IMAGE),
+                FileMetaData.of(command.introduceImageKey(), CLUB_INTRODUCTION_IMAGE)
+        );
         return club.getId();
     }
 

--- a/src/main/java/ddingdong/ddingdongBE/domain/club/service/FacadeCentralClubServiceImpl.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/club/service/FacadeCentralClubServiceImpl.java
@@ -23,8 +23,6 @@ public class FacadeCentralClubServiceImpl implements FacadeCentralClubService {
 
     private final ClubService clubService;
     private final FileInformationService fileInformationService;
-    private final FileStore fileStore;
-    private final FileInformationRepository fileInformationRepository;
 
     @Override
     public MyClubInfoQuery getMyClubInfo(Long userId) {
@@ -41,44 +39,8 @@ public class FacadeCentralClubServiceImpl implements FacadeCentralClubService {
     @Transactional
     public Long updateClubInfo(UpdateClubInfoCommand command) {
         Club club = clubService.getByUserId(command.userId());
-        updateIntroduceImageInformation(command.introduceImageUrls(), club);
-        updateProfileImageInformation(command.profileImageUrls(), club);
-        clubService.update(club.getId(), command.toEntity());
+        clubService.update(club, command.toEntity());
         return club.getId();
-    }
-
-    private void updateIntroduceImageInformation(List<String> introduceImageUrls, Club club) {
-        List<FileInformation> fileInformation = fileInformationService.getFileInformation(
-                IMAGE.getFileType() + CLUB_INTRODUCE.getFileDomain() + club.getId());
-        if (!introduceImageUrls.isEmpty()) {
-            List<FileInformation> deleteInformation = fileInformation.stream()
-                    .filter(information -> !introduceImageUrls
-                            .contains(fileStore.getImageUrlPrefix() + information.getFileTypeCategory()
-                                    .getFileType() + information.getFileDomainCategory().getFileDomain()
-                                    + information.getStoredName()))
-                    .toList();
-
-            fileInformationRepository.deleteAll(deleteInformation);
-        } else {
-            fileInformationRepository.deleteAll(fileInformation);
-        }
-    }
-
-    private void updateProfileImageInformation(List<String> profileImageUrls, Club club) {
-        List<FileInformation> fileInformation = fileInformationService.getFileInformation(
-                IMAGE.getFileType() + CLUB_PROFILE.getFileDomain() + club.getId());
-        if (!profileImageUrls.isEmpty()) {
-            List<FileInformation> deleteInformation = fileInformation.stream()
-                    .filter(information -> !profileImageUrls
-                            .contains(fileStore.getImageUrlPrefix() + information.getFileTypeCategory()
-                                    .getFileType() + information.getFileDomainCategory().getFileDomain()
-                                    + information.getStoredName()))
-                    .toList();
-
-            fileInformationRepository.deleteAll(deleteInformation);
-        } else {
-            fileInformationRepository.deleteAll(fileInformation);
-        }
     }
 
 }

--- a/src/main/java/ddingdong/ddingdongBE/domain/club/service/FacadeCentralClubServiceImpl.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/club/service/FacadeCentralClubServiceImpl.java
@@ -1,21 +1,15 @@
 package ddingdong.ddingdongBE.domain.club.service;
 
-import static ddingdong.ddingdongBE.domain.fileinformation.entity.FileDomainCategory.CLUB_INTRODUCE;
-import static ddingdong.ddingdongBE.domain.fileinformation.entity.FileDomainCategory.CLUB_PROFILE;
-import static ddingdong.ddingdongBE.domain.fileinformation.entity.FileTypeCategory.IMAGE;
-import static ddingdong.ddingdongBE.domain.filemetadata.entity.FileCategory.*;
+import static ddingdong.ddingdongBE.domain.filemetadata.entity.FileCategory.CLUB_INTRODUCTION_IMAGE;
+import static ddingdong.ddingdongBE.domain.filemetadata.entity.FileCategory.CLUB_PROFILE_IMAGE;
 
 import ddingdong.ddingdongBE.domain.club.entity.Club;
 import ddingdong.ddingdongBE.domain.club.service.dto.command.UpdateClubInfoCommand;
 import ddingdong.ddingdongBE.domain.club.service.dto.query.MyClubInfoQuery;
-import ddingdong.ddingdongBE.domain.fileinformation.entity.FileInformation;
-import ddingdong.ddingdongBE.domain.fileinformation.repository.FileInformationRepository;
-import ddingdong.ddingdongBE.domain.fileinformation.service.FileInformationService;
-import ddingdong.ddingdongBE.domain.filemetadata.entity.FileCategory;
 import ddingdong.ddingdongBE.domain.filemetadata.entity.FileMetaData;
 import ddingdong.ddingdongBE.domain.filemetadata.service.FileMetaDataService;
-import ddingdong.ddingdongBE.file.FileStore;
-import java.util.List;
+import ddingdong.ddingdongBE.file.service.S3FileService;
+import ddingdong.ddingdongBE.file.service.dto.query.UploadedFileUrlQuery;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -27,17 +21,15 @@ public class FacadeCentralClubServiceImpl implements FacadeCentralClubService {
 
     private final ClubService clubService;
     private final FileMetaDataService fileMetaDataService;
-    private final FileInformationService fileInformationService;
+    private final S3FileService s3FileService;
 
     @Override
     public MyClubInfoQuery getMyClubInfo(Long userId) {
         Club club = clubService.getByUserId(userId);
-
-        List<String> profileImageUrl = fileInformationService.getImageUrls(
-                IMAGE.getFileType() + CLUB_PROFILE.getFileDomain() + club.getId());
-        List<String> introduceImageUrls = fileInformationService.getImageUrls(
-                IMAGE.getFileType() + CLUB_INTRODUCE.getFileDomain() + club.getId());
-        return MyClubInfoQuery.of(club, profileImageUrl, introduceImageUrls);
+        UploadedFileUrlQuery profileImageUrlQuery = s3FileService.getUploadedFileUrl(club.getProfileImageKey());
+        UploadedFileUrlQuery introductionImageUrlQuery =
+                s3FileService.getUploadedFileUrl(club.getIntroductionImageKey());
+        return MyClubInfoQuery.of(club, profileImageUrlQuery, introductionImageUrlQuery);
     }
 
     @Override

--- a/src/main/java/ddingdong/ddingdongBE/domain/club/service/FacadeCentralClubServiceImpl.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/club/service/FacadeCentralClubServiceImpl.java
@@ -10,6 +10,8 @@ import ddingdong.ddingdongBE.domain.filemetadata.entity.FileMetaData;
 import ddingdong.ddingdongBE.domain.filemetadata.service.FileMetaDataService;
 import ddingdong.ddingdongBE.file.service.S3FileService;
 import ddingdong.ddingdongBE.file.service.dto.query.UploadedFileUrlQuery;
+import java.util.ArrayList;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -37,11 +39,21 @@ public class FacadeCentralClubServiceImpl implements FacadeCentralClubService {
     public Long updateClubInfo(UpdateClubInfoCommand command) {
         Club club = clubService.getByUserId(command.userId());
         clubService.update(club, command.toEntity());
-        fileMetaDataService.create(
-                FileMetaData.of(command.profileImageKey(), CLUB_PROFILE_IMAGE),
-                FileMetaData.of(command.introduceImageKey(), CLUB_INTRODUCTION_IMAGE)
-        );
+        createFileMetaData(command);
         return club.getId();
+    }
+
+    private void createFileMetaData(UpdateClubInfoCommand command) {
+        List<FileMetaData> metaDataList = new ArrayList<>();
+        if (command.profileImageKey() != null) {
+            metaDataList.add(FileMetaData.of(command.profileImageKey(), CLUB_PROFILE_IMAGE));
+        }
+        if (command.introductionImageKey() != null) {
+            metaDataList.add(FileMetaData.of(command.introductionImageKey(), CLUB_INTRODUCTION_IMAGE));
+        }
+        if (!metaDataList.isEmpty()) {
+            fileMetaDataService.create(metaDataList);
+        }
     }
 
 }

--- a/src/main/java/ddingdong/ddingdongBE/domain/club/service/FacadeUserClubServiceImpl.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/club/service/FacadeUserClubServiceImpl.java
@@ -12,6 +12,7 @@ import ddingdong.ddingdongBE.domain.club.entity.RecruitmentStatus;
 import ddingdong.ddingdongBE.domain.club.service.dto.query.UserClubListQuery;
 import ddingdong.ddingdongBE.domain.club.service.dto.query.UserClubQuery;
 import ddingdong.ddingdongBE.domain.fileinformation.service.FileInformationService;
+import ddingdong.ddingdongBE.file.service.S3FileService;
 import java.time.LocalDateTime;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -24,7 +25,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class FacadeUserClubServiceImpl implements FacadeUserClubService {
 
     private final ClubService clubService;
-    private final FileInformationService fileInformationService;
+    private final S3FileService s3FileService;
 
     @Override
     public List<UserClubListQuery> findAllWithRecruitTimeCheckPoint(LocalDateTime now) {
@@ -36,11 +37,11 @@ public class FacadeUserClubServiceImpl implements FacadeUserClubService {
     @Override
     public UserClubQuery getClub(Long clubId) {
         Club club = clubService.getById(clubId);
-        List<String> profileImageUrl = fileInformationService.getImageUrls(
-                IMAGE.getFileType() + CLUB_PROFILE.getFileDomain() + clubId);
-        List<String> introduceImageUrls = fileInformationService.getImageUrls(
-                IMAGE.getFileType() + CLUB_INTRODUCE.getFileDomain() + clubId);
-        return UserClubQuery.of(club, profileImageUrl, introduceImageUrls);
+        return UserClubQuery.of(
+                club,
+                s3FileService.getUploadedFileUrl(club.getProfileImageKey()),
+                s3FileService.getUploadedFileUrl(club.getIntroductionImageKey())
+        );
     }
 
     private RecruitmentStatus checkRecruit(LocalDateTime now, Club club) {

--- a/src/main/java/ddingdong/ddingdongBE/domain/club/service/GeneralClubService.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/club/service/GeneralClubService.java
@@ -41,8 +41,7 @@ public class GeneralClubService implements ClubService {
 
     @Override
     @Transactional
-    public void update(Long clubId, Club updatedClub) {
-        Club club = getById(clubId);
+    public void update(Club club, Club updatedClub) {
         club.updateClubInfo(updatedClub);
     }
 

--- a/src/main/java/ddingdong/ddingdongBE/domain/club/service/dto/command/UpdateClubInfoCommand.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/club/service/dto/command/UpdateClubInfoCommand.java
@@ -5,7 +5,6 @@ import ddingdong.ddingdongBE.domain.club.entity.Location;
 import ddingdong.ddingdongBE.domain.club.entity.PhoneNumber;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
-import java.util.List;
 
 public record UpdateClubInfoCommand(
         Long userId,
@@ -22,8 +21,8 @@ public record UpdateClubInfoCommand(
         String activity,
         String ideal,
         String formUrl,
-        List<String> profileImageUrls,
-        List<String> introduceImageUrls
+        String profileImageKey,
+        String introduceImageKey
 ) {
 
     public Club toEntity() {
@@ -41,6 +40,8 @@ public record UpdateClubInfoCommand(
                 .activity(activity)
                 .ideal(ideal)
                 .formUrl(formUrl)
+                .profileImageKey(profileImageKey)
+                .introductionImageKey(introduceImageKey)
                 .build();
     }
 

--- a/src/main/java/ddingdong/ddingdongBE/domain/club/service/dto/command/UpdateClubInfoCommand.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/club/service/dto/command/UpdateClubInfoCommand.java
@@ -22,7 +22,7 @@ public record UpdateClubInfoCommand(
         String ideal,
         String formUrl,
         String profileImageKey,
-        String introduceImageKey
+        String introductionImageKey
 ) {
 
     public Club toEntity() {
@@ -41,7 +41,7 @@ public record UpdateClubInfoCommand(
                 .ideal(ideal)
                 .formUrl(formUrl)
                 .profileImageKey(profileImageKey)
-                .introductionImageKey(introduceImageKey)
+                .introductionImageKey(introductionImageKey)
                 .build();
     }
 

--- a/src/main/java/ddingdong/ddingdongBE/domain/club/service/dto/query/AdminClubListQuery.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/club/service/dto/query/AdminClubListQuery.java
@@ -1,6 +1,7 @@
 package ddingdong.ddingdongBE.domain.club.service.dto.query;
 
 import ddingdong.ddingdongBE.domain.club.entity.Club;
+import ddingdong.ddingdongBE.file.service.dto.query.UploadedFileUrlQuery;
 import java.math.BigDecimal;
 import java.util.List;
 import lombok.Builder;
@@ -11,16 +12,17 @@ public record AdminClubListQuery(
         String name,
         String category,
         BigDecimal score,
-        List<String> profileImageUrls
+        UploadedFileUrlQuery profileImageUrlQuery
 ) {
 
-    public static AdminClubListQuery of(Club club, List<String> profileImageUrls) {
+    public static AdminClubListQuery of(Club club, UploadedFileUrlQuery profileImageUrlQuery) {
         return AdminClubListQuery.builder()
                 .id(club.getId())
                 .name(club.getName())
                 .category(club.getCategory())
                 .score(club.getScore().getValue())
-                .profileImageUrls(profileImageUrls).build();
+                .profileImageUrlQuery(profileImageUrlQuery)
+                .build();
     }
 
 }

--- a/src/main/java/ddingdong/ddingdongBE/domain/club/service/dto/query/MyClubInfoQuery.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/club/service/dto/query/MyClubInfoQuery.java
@@ -2,6 +2,7 @@ package ddingdong.ddingdongBE.domain.club.service.dto.query;
 
 import ddingdong.ddingdongBE.domain.club.entity.Club;
 import ddingdong.ddingdongBE.domain.clubmember.entity.ClubMember;
+import ddingdong.ddingdongBE.file.service.dto.query.UploadedFileUrlQuery;
 import java.time.LocalDateTime;
 import java.util.List;
 
@@ -19,12 +20,16 @@ public record MyClubInfoQuery(
         String activity,
         String ideal,
         String formUrl,
-        List<String> profileImageUrls,
-        List<String> introduceImageUrls,
+        UploadedFileUrlQuery profileImageUrlQuery,
+        UploadedFileUrlQuery introductionImageUrlQuery,
         List<ClubMember> clubMembers
 ) {
 
-    public static MyClubInfoQuery of(Club club, List<String> profileImageUrls, List<String> introduceImageUrls) {
+    public static MyClubInfoQuery of(
+            Club club,
+            UploadedFileUrlQuery profileImageUrlQuery,
+            UploadedFileUrlQuery introductionImageUrlQuery
+    ) {
         return new MyClubInfoQuery(
                 club.getName(),
                 club.getCategory(),
@@ -39,8 +44,8 @@ public record MyClubInfoQuery(
                 club.getActivity(),
                 club.getIdeal(),
                 club.getFormUrl(),
-                profileImageUrls,
-                introduceImageUrls,
+                profileImageUrlQuery,
+                introductionImageUrlQuery,
                 club.getClubMembers()
         );
     }

--- a/src/main/java/ddingdong/ddingdongBE/domain/club/service/dto/query/UserClubQuery.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/club/service/dto/query/UserClubQuery.java
@@ -1,9 +1,8 @@
 package ddingdong.ddingdongBE.domain.club.service.dto.query;
 
 import ddingdong.ddingdongBE.domain.club.entity.Club;
-import ddingdong.ddingdongBE.domain.clubmember.entity.ClubMember;
+import ddingdong.ddingdongBE.file.service.dto.query.UploadedFileUrlQuery;
 import java.time.LocalDateTime;
-import java.util.List;
 
 public record UserClubQuery(
         String name,
@@ -19,11 +18,14 @@ public record UserClubQuery(
         String activity,
         String ideal,
         String formUrl,
-        List<String> profileImageUrls,
-        List<String> introduceImageUrls
+        UploadedFileUrlQuery profileImageUrlQuery,
+        UploadedFileUrlQuery introductionImageUrlQuery
 ) {
 
-    public static UserClubQuery of(Club club, List<String> profileImageUrls, List<String> introduceImageUrls) {
+    public static UserClubQuery of(
+            Club club,
+            UploadedFileUrlQuery profileImageUrlQuery,
+            UploadedFileUrlQuery introductionImageUrlQuery) {
         return new UserClubQuery(
                 club.getName(),
                 club.getCategory(),
@@ -38,8 +40,8 @@ public record UserClubQuery(
                 club.getActivity(),
                 club.getIdeal(),
                 club.getFormUrl(),
-                profileImageUrls,
-                introduceImageUrls
+                profileImageUrlQuery,
+                introductionImageUrlQuery
         );
     }
 

--- a/src/main/java/ddingdong/ddingdongBE/domain/filemetadata/entity/FileMetaData.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/filemetadata/entity/FileMetaData.java
@@ -1,5 +1,6 @@
 package ddingdong.ddingdongBE.domain.filemetadata.entity;
 
+import com.github.f4b6a3.uuid.UuidCreator;
 import ddingdong.ddingdongBE.common.BaseEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -40,6 +41,6 @@ public class FileMetaData extends BaseEntity {
 
     private static UUID extractFilename(String key) {
         String[] splitKey = key.split("/");
-        return UUID.fromString(splitKey[splitKey.length - 1]);
+        return UuidCreator.fromString(splitKey[splitKey.length - 1]);
     }
 }

--- a/src/main/java/ddingdong/ddingdongBE/domain/filemetadata/service/FileMetaDataService.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/filemetadata/service/FileMetaDataService.java
@@ -1,11 +1,12 @@
 package ddingdong.ddingdongBE.domain.filemetadata.service;
 
 import ddingdong.ddingdongBE.domain.filemetadata.entity.FileMetaData;
+import java.util.List;
 import java.util.UUID;
 
 public interface FileMetaDataService {
 
-    void create(FileMetaData... fileMetaData);
+    void create(List<FileMetaData> fileMetaDataList);
 
     FileMetaData getByFileId(UUID fileId);
 

--- a/src/main/java/ddingdong/ddingdongBE/domain/filemetadata/service/GeneralFileMetaDataService.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/filemetadata/service/GeneralFileMetaDataService.java
@@ -3,7 +3,6 @@ package ddingdong.ddingdongBE.domain.filemetadata.service;
 import ddingdong.ddingdongBE.common.exception.PersistenceException.ResourceNotFound;
 import ddingdong.ddingdongBE.domain.filemetadata.entity.FileMetaData;
 import ddingdong.ddingdongBE.domain.filemetadata.repository.FileMetaDataRepository;
-import java.util.Arrays;
 import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
@@ -19,13 +18,13 @@ public class GeneralFileMetaDataService implements FileMetaDataService {
 
     @Override
     @Transactional
-    public void create(FileMetaData... fileMetaData) {
-        List<FileMetaData> newFileMetaData = Arrays.stream(fileMetaData)
+    public void create(List<FileMetaData> fileMetaDataList) {
+        List<FileMetaData> newFileMetaDataList = fileMetaDataList.stream()
                 .filter(fmd -> !fileMetaDataRepository.existsById(fmd.getFileId()))
                 .toList();
 
-        if (!newFileMetaData.isEmpty()) {
-            fileMetaDataRepository.saveAll(newFileMetaData);
+        if (!newFileMetaDataList.isEmpty()) {
+            fileMetaDataRepository.saveAll(newFileMetaDataList);
         }
     }
 

--- a/src/main/java/ddingdong/ddingdongBE/domain/filemetadata/service/GeneralFileMetaDataService.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/filemetadata/service/GeneralFileMetaDataService.java
@@ -20,7 +20,13 @@ public class GeneralFileMetaDataService implements FileMetaDataService {
     @Override
     @Transactional
     public void create(FileMetaData... fileMetaData) {
-        fileMetaDataRepository.saveAll(List.of(fileMetaData));
+        List<FileMetaData> newFileMetaData = Arrays.stream(fileMetaData)
+                .filter(fmd -> !fileMetaDataRepository.existsById(fmd.getFileId()))
+                .toList();
+
+        if (!newFileMetaData.isEmpty()) {
+            fileMetaDataRepository.saveAll(newFileMetaData);
+        }
     }
 
     @Override

--- a/src/main/resources/db/migration/V15__alter_table_club_add_column.sql
+++ b/src/main/resources/db/migration/V15__alter_table_club_add_column.sql
@@ -1,0 +1,8 @@
+ALTER TABLE club
+    ADD introduction_image_key VARCHAR(255) NULL;
+
+ALTER TABLE club
+    ADD profile_image_key VARCHAR(255) NULL;
+
+ALTER TABLE club
+    ADD CONSTRAINT UK_club_user UNIQUE (user_id);

--- a/src/test/java/ddingdong/ddingdongBE/domain/club/service/FacadeAdminClubServiceImplTest.java
+++ b/src/test/java/ddingdong/ddingdongBE/domain/club/service/FacadeAdminClubServiceImplTest.java
@@ -73,6 +73,7 @@ class FacadeAdminClubServiceImplTest extends TestContainerSupport {
                 .set("id", null)
                 .set("user", null)
                 .set("score", Score.from(BigDecimal.ZERO))
+                .set("profileImageKey", "test/file/2024-01-01/test/uuid")
                 .set("deletedAt", null)
                 .sampleList(3);
         clubRepository.saveAll(clubs);

--- a/src/test/java/ddingdong/ddingdongBE/domain/club/service/FacadeCentralClubServiceImplTest.java
+++ b/src/test/java/ddingdong/ddingdongBE/domain/club/service/FacadeCentralClubServiceImplTest.java
@@ -1,5 +1,7 @@
 package ddingdong.ddingdongBE.domain.club.service;
 
+import static org.assertj.core.api.Assertions.*;
+
 import com.navercorp.fixturemonkey.FixtureMonkey;
 import ddingdong.ddingdongBE.common.support.FixtureMonkeyFactory;
 import ddingdong.ddingdongBE.common.support.TestContainerSupport;
@@ -52,7 +54,7 @@ class FacadeCentralClubServiceImplTest extends TestContainerSupport {
         MyClubInfoQuery result = facadeCentralClubService.getMyClubInfo(savedUser.getId());
 
         //then
-        Assertions.assertThat(result).isNotNull();
+        assertThat(result).isNotNull();
     }
 
     @DisplayName("중앙동아리: 동아리 정보 수정")
@@ -85,8 +87,8 @@ class FacadeCentralClubServiceImplTest extends TestContainerSupport {
                 "testactivity",
                 "testideal",
                 "testformUrl",
-                List.of(),
-                List.of()
+                "testKey",
+                "testKey"
         );
 
         //when
@@ -94,7 +96,7 @@ class FacadeCentralClubServiceImplTest extends TestContainerSupport {
 
         //then
         Club result = clubRepository.findById(savedClub.getId()).orElseThrow();
-        Assertions.assertThat(result.getName()).isEqualTo("testname");
+        assertThat(result.getName()).isEqualTo("testname");
     }
 
 }

--- a/src/test/java/ddingdong/ddingdongBE/domain/club/service/FacadeCentralClubServiceImplTest.java
+++ b/src/test/java/ddingdong/ddingdongBE/domain/club/service/FacadeCentralClubServiceImplTest.java
@@ -1,7 +1,8 @@
 package ddingdong.ddingdongBE.domain.club.service;
 
-import static org.assertj.core.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
 
+import com.github.f4b6a3.uuid.UuidCreator;
 import com.navercorp.fixturemonkey.FixtureMonkey;
 import ddingdong.ddingdongBE.common.support.FixtureMonkeyFactory;
 import ddingdong.ddingdongBE.common.support.TestContainerSupport;
@@ -15,8 +16,6 @@ import ddingdong.ddingdongBE.domain.scorehistory.entity.Score;
 import ddingdong.ddingdongBE.domain.user.entity.User;
 import ddingdong.ddingdongBE.domain.user.repository.UserRepository;
 import java.math.BigDecimal;
-import java.util.List;
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -89,8 +88,8 @@ class FacadeCentralClubServiceImplTest extends TestContainerSupport {
                 "testactivity",
                 "testideal",
                 "testformUrl",
-                "testKey",
-                "testKey"
+                "test/file/2024-01-01/test/" + UuidCreator.getTimeBased(),
+                "test/file/2024-01-01/test/" + UuidCreator.getTimeBased()
         );
 
         //when

--- a/src/test/java/ddingdong/ddingdongBE/domain/club/service/FacadeCentralClubServiceImplTest.java
+++ b/src/test/java/ddingdong/ddingdongBE/domain/club/service/FacadeCentralClubServiceImplTest.java
@@ -45,6 +45,8 @@ class FacadeCentralClubServiceImplTest extends TestContainerSupport {
                 .set("score", Score.from(BigDecimal.ZERO))
                 .set("phoneNumber", PhoneNumber.from("010-1234-5678"))
                 .set("location", Location.from("S1111"))
+                .set("profileImageKey", "test/file/2024-01-01/test/uuid")
+                .set("introductionImageKey", "test/file/2024-01-01/test/uuid")
                 .set("clubMembers", null)
                 .set("deletedAt", null)
                 .sample();

--- a/src/test/java/ddingdong/ddingdongBE/domain/club/service/FacadeUserClubServiceImplTest.java
+++ b/src/test/java/ddingdong/ddingdongBE/domain/club/service/FacadeUserClubServiceImplTest.java
@@ -59,7 +59,7 @@ class FacadeUserClubServiceImplTest extends TestContainerSupport {
                 .allMatch((query -> query.recruitStatus().equals(RECRUITING.getText())))).isTrue();
     }
 
-    @DisplayName("유저: 동아리 목록 조회 - 모집 마")
+    @DisplayName("유저: 동아리 목록 조회 - 모집 마감")
     @Test
     void findAllWithEND_RECRUIT() {
         //given
@@ -97,6 +97,8 @@ class FacadeUserClubServiceImplTest extends TestContainerSupport {
                 .set("location", Location.from("S1111"))
                 .set("startRecruitPeriod", LocalDateTime.of(2024, 9, 1, 0, 0))
                 .set("startRecruitPeriod", LocalDateTime.of(2024, 12, 31, 0, 0))
+                .set("profileImageKey", "test/file/2024-01-01/test/uuid")
+                .set("introductionImageKey", "test/file/2024-01-01/test/uuid")
                 .set("clubMembers", null)
                 .set("deletedAt", null)
                 .sample());


### PR DESCRIPTION
## 🚀 작업 내용
### Club 도메인 presignedUrl 적용
- [x] Admin - 동아리 목록 조회 API
- [x] Central - 내 동아리 정보 조회 API
- [x] Central - 내 동아리 정보 수정 API
- [x] User - 동아리 정보 조회 API
## 🤔 고민했던 내용
## 💬 리뷰 중점사항


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **새로운 기능**
	- 클럽 업데이트 기능이 간소화되어 파일 업로드 처리가 제거되었습니다.
	- 클럽 정보 요청 시 이미지 키를 사용하여 새로운 구조가 도입되었습니다.

- **버그 수정**
	- 클럽 세부 정보 조회 메서드의 파라미터가 간소화되었습니다.

- **문서화**
	- 데이터베이스 스키마에 새로운 컬럼이 추가되었습니다.

- **테스트**
	- 클럽 엔티티에 대한 테스트가 업데이트되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->