### PR TITLE
[DDING-000] 동아리 api uri 수정

### DIFF
--- a/src/main/java/ddingdong/ddingdongBE/common/config/SecurityConfig.java
+++ b/src/main/java/ddingdong/ddingdongBE/common/config/SecurityConfig.java
@@ -38,7 +38,7 @@ public class SecurityConfig {
                     API_PREFIX + "/events/**")
                 .permitAll()
                 .requestMatchers(API_PREFIX + "/admin/**").hasRole("ADMIN")
-                .requestMatchers(API_PREFIX + "/club/**").hasRole("CLUB")
+                .requestMatchers(API_PREFIX + "/central/**").hasRole("CLUB")
                 .requestMatchers(actuatorPath).hasRole("ADMIN")
                 .requestMatchers(GET,
                     API_PREFIX + "/clubs/**",

--- a/src/main/java/ddingdong/ddingdongBE/domain/activityreport/api/ClubActivityReportApi.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/activityreport/api/ClubActivityReportApi.java
@@ -26,7 +26,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseStatus;
 
 @Tag(name = "Activity Report - Club", description = "Activity Report Club API")
-@RequestMapping("/server/club")
+@RequestMapping("/server/central")
 public interface ClubActivityReportApi {
 
     @Operation(summary = "현재 활동보고서 회차 조회")

--- a/src/main/java/ddingdong/ddingdongBE/domain/club/api/CentralClubApi.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/club/api/CentralClubApi.java
@@ -2,8 +2,8 @@ package ddingdong.ddingdongBE.domain.club.api;
 
 import ddingdong.ddingdongBE.auth.PrincipalDetails;
 import ddingdong.ddingdongBE.common.exception.ErrorResponse;
-import ddingdong.ddingdongBE.domain.club.controller.dto.request.UpdateClubMemberRequest;
 import ddingdong.ddingdongBE.domain.club.controller.dto.request.UpdateClubInfoRequest;
+import ddingdong.ddingdongBE.domain.club.controller.dto.request.UpdateClubMemberRequest;
 import ddingdong.ddingdongBE.domain.club.controller.dto.response.MyClubInfoResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -13,14 +13,12 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import java.util.List;
 import jakarta.validation.Valid;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -31,7 +29,7 @@ import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.multipart.MultipartFile;
 
 @Tag(name = "Club - CentralClub", description = "Club CentralClub API")
-@RequestMapping("/server/club/my")
+@RequestMapping("/server/central/my")
 public interface CentralClubApi {
 
     @Operation(summary = "동아리원 명단 다운로드 API")

--- a/src/main/java/ddingdong/ddingdongBE/domain/scorehistory/api/ClubScoreHistoryApi.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/scorehistory/api/ClubScoreHistoryApi.java
@@ -19,7 +19,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.ResponseStatus;
 
 @Tag(name = "ScoreHistory - Club", description = "ScoreHistory Club API")
-@RequestMapping("/server/club/my/score")
+@RequestMapping("/server/central/my/score")
 public interface ClubScoreHistoryApi {
 
     @Operation(summary = "동아리 내 점수 내역 목록 조회 API")


### PR DESCRIPTION
## 🚀 작업 내용
- 동아리 api uri 수정
	- club -> central

## 🤔 고민했던 내용
## 💬 리뷰 중점사항

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **변경 사항**
	- API 엔드포인트 경로가 `/server/club/**`에서 `/server/central/**`로 변경되어 접근 제어가 수정되었습니다.
	- `ClubActivityReportApi`, `CentralClubApi`, `ClubScoreHistoryApi`의 기본 URL 매핑이 각각 `/server/club`에서 `/server/central`로 업데이트되었습니다. 
	- API 기능은 변경되지 않았으며, 기존의 보고서 및 클럽 정보 관련 기능은 그대로 유지됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->