### PR TITLE
[DDING-000] urlQuery null 체킹 추가

### DIFF
--- a/src/main/java/ddingdong/ddingdongBE/domain/activityreport/controller/dto/response/ActivityReportResponse.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/activityreport/controller/dto/response/ActivityReportResponse.java
@@ -75,6 +75,9 @@ public record ActivityReportResponse(
     ) {
 
         public static ActivityReportImageUrlResponse from(UploadedFileUrlQuery query) {
+            if (query == null) {
+                return null;
+            }
             return new ActivityReportImageUrlResponse(query.originUrl(), query.cdnUrl());
         }
 

--- a/src/main/java/ddingdong/ddingdongBE/domain/banner/controller/dto/response/AdminBannerListResponse.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/banner/controller/dto/response/AdminBannerListResponse.java
@@ -35,6 +35,9 @@ public record AdminBannerListResponse(
     ) {
 
         public static AdminBannerListImageUrlResponse from(UploadedFileUrlQuery query) {
+            if (query == null) {
+                return null;
+            }
             return new AdminBannerListImageUrlResponse(query.originUrl(), query.cdnUrl());
         }
 

--- a/src/main/java/ddingdong/ddingdongBE/domain/banner/controller/dto/response/UserBannerListResponse.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/banner/controller/dto/response/UserBannerListResponse.java
@@ -35,6 +35,9 @@ public record UserBannerListResponse(
     ) {
 
         public static UserBannerListImageUrlResponse from(UploadedFileUrlQuery query) {
+            if (query == null) {
+                return null;
+            }
             return new UserBannerListImageUrlResponse(query.originUrl(), query.cdnUrl());
         }
 

--- a/src/main/java/ddingdong/ddingdongBE/domain/club/controller/dto/response/MyClubInfoResponse.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/club/controller/dto/response/MyClubInfoResponse.java
@@ -82,6 +82,9 @@ public record MyClubInfoResponse(
     ) {
 
         public static MyClubInfoImageUrlResponse from(UploadedFileUrlQuery query) {
+            if (query == null) {
+                return null;
+            }
             return new MyClubInfoImageUrlResponse(query.originUrl(), query.cdnUrl());
         }
 

--- a/src/main/java/ddingdong/ddingdongBE/domain/club/controller/dto/response/UserClubResponse.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/club/controller/dto/response/UserClubResponse.java
@@ -75,6 +75,9 @@ public record UserClubResponse(
     ) {
 
         public static UserClubImageUrlResponse from(UploadedFileUrlQuery query) {
+            if (query == null) {
+                return null;
+            }
             return new UserClubImageUrlResponse(query.originUrl(), query.cdnUrl());
         }
 

--- a/src/main/java/ddingdong/ddingdongBE/domain/documents/controller/dto/response/DocumentResponse.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/documents/controller/dto/response/DocumentResponse.java
@@ -47,6 +47,9 @@ public record DocumentResponse(
     ) {
 
         public static DocumentFileUrlsResponse from(UploadedFileUrlQuery query) {
+            if (query == null) {
+                return null;
+            }
             return new DocumentFileUrlsResponse(query.originUrl(), query.cdnUrl());
         }
     }


### PR DESCRIPTION
## 🚀 작업 내용
- xxxUrlQuery를 사용하는 ResponseDto의 팩토리메서드에 null 체킹을 추가하여 npe를 예방하는 코드 작성

## 🤔 고민했던 내용

## 💬 리뷰 중점사항

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **버그 수정**
	- 여러 응답 클래스의 `from` 메서드에 null 체크 추가: `query`가 null일 경우 null 반환, 이를 통해 `NullPointerException` 방지.
	- 수정된 클래스: `ActivityReportResponse`, `AdminBannerListResponse`, `UserBannerListResponse`, `MyClubInfoResponse`, `UserClubResponse`, `DocumentResponse`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->