### PR TITLE
[DDOING-000] 동아리원 명단 조회 API 분리

### DIFF
--- a/src/main/java/ddingdong/ddingdongBE/domain/club/api/CentralClubApi.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/club/api/CentralClubApi.java
@@ -4,8 +4,10 @@ import ddingdong.ddingdongBE.auth.PrincipalDetails;
 import ddingdong.ddingdongBE.common.exception.ErrorResponse;
 import ddingdong.ddingdongBE.domain.club.controller.dto.request.UpdateClubInfoRequest;
 import ddingdong.ddingdongBE.domain.club.controller.dto.request.UpdateClubMemberRequest;
+import ddingdong.ddingdongBE.domain.club.controller.dto.response.CentralClubMemberListResponse;
 import ddingdong.ddingdongBE.domain.club.controller.dto.response.MyClubInfoResponse;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -14,6 +16,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import java.util.List;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -47,6 +50,14 @@ public interface CentralClubApi {
     @SecurityRequirement(name = "AccessToken")
     @GetMapping
     MyClubInfoResponse getMyClub(@AuthenticationPrincipal PrincipalDetails principalDetails);
+
+    @Operation(summary = "동아리원 명단 조회 API")
+    @ResponseStatus(HttpStatus.OK)
+    @ApiResponse(responseCode = "200", description = "동아리원 명단 조회 성공",
+            content = @Content(array = @ArraySchema(schema = @Schema(implementation = CentralClubMemberListResponse.class))))
+    @SecurityRequirement(name = "AccessToken")
+    @GetMapping("/club-members")
+    List<CentralClubMemberListResponse> getMyClubMembers(@AuthenticationPrincipal PrincipalDetails principalDetails);
 
     @Operation(summary = "내 동아리 정보 수정 API")
     @ResponseStatus(HttpStatus.NO_CONTENT)

--- a/src/main/java/ddingdong/ddingdongBE/domain/club/controller/CentralClubController.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/club/controller/CentralClubController.java
@@ -4,10 +4,11 @@ import ddingdong.ddingdongBE.auth.PrincipalDetails;
 import ddingdong.ddingdongBE.domain.club.api.CentralClubApi;
 import ddingdong.ddingdongBE.domain.club.controller.dto.request.UpdateClubInfoRequest;
 import ddingdong.ddingdongBE.domain.club.controller.dto.request.UpdateClubMemberRequest;
+import ddingdong.ddingdongBE.domain.club.controller.dto.response.CentralClubMemberListResponse;
 import ddingdong.ddingdongBE.domain.club.controller.dto.response.MyClubInfoResponse;
 import ddingdong.ddingdongBE.domain.club.service.FacadeCentralClubService;
 import ddingdong.ddingdongBE.domain.club.service.dto.query.MyClubInfoQuery;
-import ddingdong.ddingdongBE.domain.clubmember.service.FacadeClubMemberService;
+import ddingdong.ddingdongBE.domain.clubmember.service.FacadeCentralClubMemberService;
 import ddingdong.ddingdongBE.domain.clubmember.service.dto.command.UpdateClubMemberListCommand;
 import ddingdong.ddingdongBE.domain.user.entity.User;
 import java.net.URLEncoder;
@@ -27,12 +28,12 @@ import org.springframework.web.multipart.MultipartFile;
 public class CentralClubController implements CentralClubApi {
 
     private final FacadeCentralClubService facadeCentralClubService;
-    private final FacadeClubMemberService facadeClubMemberService;
+    private final FacadeCentralClubMemberService facadeCentralClubMemberService;
 
     @Override
     public ResponseEntity<byte[]> getMyClubMemberListFile(PrincipalDetails principalDetails) {
         User user = principalDetails.getUser();
-        byte[] clubMemberListFileData = facadeClubMemberService.getClubMemberListFile(user.getId());
+        byte[] clubMemberListFileData = facadeCentralClubMemberService.getClubMemberListFile(user.getId());
         String filename = "동아리원명단.xlsx";
         String encodedFilename = URLEncoder.encode(filename, StandardCharsets.UTF_8).replaceAll("\\+", "%20");
 
@@ -53,6 +54,14 @@ public class CentralClubController implements CentralClubApi {
     }
 
     @Override
+    public List<CentralClubMemberListResponse> getMyClubMembers(PrincipalDetails principalDetails) {
+        User user = principalDetails.getUser();
+        return facadeCentralClubMemberService.getAllMyClubMember(user.getId()).stream()
+                .map(CentralClubMemberListResponse::from)
+                .toList();
+    }
+
+    @Override
     public void updateClub(PrincipalDetails principalDetails, UpdateClubInfoRequest request) {
         User user = principalDetails.getUser();
         facadeCentralClubService.updateClubInfo(request.toCommand(user.getId()));
@@ -65,11 +74,11 @@ public class CentralClubController implements CentralClubApi {
                 .userId(user.getId())
                 .clubMemberListFile(clubMemberListFile)
                 .build();
-        facadeClubMemberService.updateMemberList(command);
+        facadeCentralClubMemberService.updateMemberList(command);
     }
 
     @Override
     public void updateClubMembers(Long clubMemberId, UpdateClubMemberRequest request) {
-        facadeClubMemberService.update(request.toCommand(clubMemberId));
+        facadeCentralClubMemberService.update(request.toCommand(clubMemberId));
     }
 }

--- a/src/main/java/ddingdong/ddingdongBE/domain/club/controller/dto/response/CentralClubMemberListResponse.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/club/controller/dto/response/CentralClubMemberListResponse.java
@@ -1,0 +1,39 @@
+package ddingdong.ddingdongBE.domain.club.controller.dto.response;
+
+import ddingdong.ddingdongBE.domain.clubmember.service.dto.query.CentralClubMemberListQuery;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(
+        name = "ClubMemberResponse",
+        description = "중앙동아리 - 동아리원 조회 응답"
+)
+public record CentralClubMemberListResponse(
+        @Schema(description = "식별자", example = "1")
+        Long id,
+        @Schema(description = "이름", example = "홍길동")
+        String name,
+        @Schema(description = "학번", example = "60001111")
+        String studentNumber,
+        @Schema(description = "전화번호", example = "010-1234-5678")
+        String phoneNumber,
+        @Schema(description = "동아리원 역할",
+                example = "LEADER",
+                allowableValues = {"LEADER", "EXECUTION", "MEMBER"}
+        )
+        String position,
+        @Schema(description = "학과", example = "학과")
+        String department
+) {
+
+    public static CentralClubMemberListResponse from(CentralClubMemberListQuery query) {
+        return new CentralClubMemberListResponse(
+                query.id(),
+                query.name(),
+                query.studentNumber(),
+                query.phoneNumber(),
+                query.position(),
+                query.department()
+        );
+    }
+
+}

--- a/src/main/java/ddingdong/ddingdongBE/domain/club/controller/dto/response/MyClubInfoResponse.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/club/controller/dto/response/MyClubInfoResponse.java
@@ -2,11 +2,9 @@ package ddingdong.ddingdongBE.domain.club.controller.dto.response;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
 import ddingdong.ddingdongBE.domain.club.service.dto.query.MyClubInfoQuery;
-import ddingdong.ddingdongBE.domain.clubmember.entity.ClubMember;
 import ddingdong.ddingdongBE.file.service.dto.query.UploadedFileUrlQuery;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalDateTime;
-import java.util.List;
 
 @Schema(
         name = "MyClubInfoResponse",
@@ -43,8 +41,7 @@ public record MyClubInfoResponse(
         String formUrl,
         @Schema(description = "동아리 프로필 이미지 Url", example = "url")
         MyClubInfoImageUrlResponse profileImageUrl,
-        MyClubInfoImageUrlResponse introduceImageUrl,
-        List<ClubMemberResponse> clubMembers
+        MyClubInfoImageUrlResponse introductionImageUrl
 ) {
 
     public static MyClubInfoResponse from(MyClubInfoQuery query) {
@@ -63,10 +60,7 @@ public record MyClubInfoResponse(
                 query.ideal(),
                 query.formUrl(),
                 MyClubInfoImageUrlResponse.from(query.profileImageUrlQuery()),
-                MyClubInfoImageUrlResponse.from(query.introductionImageUrlQuery()),
-                query.clubMembers().stream()
-                        .map(ClubMemberResponse::from)
-                        .toList()
+                MyClubInfoImageUrlResponse.from(query.introductionImageUrlQuery())
         );
     }
 
@@ -88,40 +82,6 @@ public record MyClubInfoResponse(
             return new MyClubInfoImageUrlResponse(query.originUrl(), query.cdnUrl());
         }
 
-    }
-
-    @Schema(
-            name = "ClubMemberResponse",
-            description = "중앙동아리 - 동아리원 조회 응답"
-    )
-    public record ClubMemberResponse(
-            @Schema(description = "식별자", example = "1")
-            Long id,
-            @Schema(description = "이름", example = "홍길동")
-            String name,
-            @Schema(description = "학번", example = "60001111")
-            String studentNumber,
-            @Schema(description = "전화번호", example = "010-1234-5678")
-            String phoneNumber,
-            @Schema(description = "동아리원 역할",
-                    example = "LEADER",
-                    allowableValues = {"LEADER", "EXECUTION", "MEMBER"}
-            )
-            String position,
-            @Schema(description = "학과", example = "학과")
-            String department
-    ) {
-
-        public static ClubMemberResponse from(ClubMember clubMember) {
-            return new ClubMemberResponse(
-                    clubMember.getId(),
-                    clubMember.getName(),
-                    clubMember.getStudentNumber(),
-                    clubMember.getPhoneNumber(),
-                    clubMember.getPosition().getName(),
-                    clubMember.getDepartment()
-            );
-        }
     }
 
 }

--- a/src/main/java/ddingdong/ddingdongBE/domain/clubmember/service/FacadeCentralClubMemberService.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/clubmember/service/FacadeCentralClubMemberService.java
@@ -2,10 +2,14 @@ package ddingdong.ddingdongBE.domain.clubmember.service;
 
 import ddingdong.ddingdongBE.domain.clubmember.service.dto.command.UpdateClubMemberCommand;
 import ddingdong.ddingdongBE.domain.clubmember.service.dto.command.UpdateClubMemberListCommand;
+import ddingdong.ddingdongBE.domain.clubmember.service.dto.query.CentralClubMemberListQuery;
+import java.util.List;
 
-public interface FacadeClubMemberService {
+public interface FacadeCentralClubMemberService {
 
     byte[] getClubMemberListFile(Long userId);
+
+    List<CentralClubMemberListQuery> getAllMyClubMember(Long userId);
 
     void updateMemberList(UpdateClubMemberListCommand command);
 

--- a/src/main/java/ddingdong/ddingdongBE/domain/clubmember/service/FacadeCentralClubMemberServiceImpl.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/clubmember/service/FacadeCentralClubMemberServiceImpl.java
@@ -5,6 +5,7 @@ import ddingdong.ddingdongBE.domain.club.service.ClubService;
 import ddingdong.ddingdongBE.domain.clubmember.entity.ClubMember;
 import ddingdong.ddingdongBE.domain.clubmember.service.dto.command.UpdateClubMemberCommand;
 import ddingdong.ddingdongBE.domain.clubmember.service.dto.command.UpdateClubMemberListCommand;
+import ddingdong.ddingdongBE.domain.clubmember.service.dto.query.CentralClubMemberListQuery;
 import ddingdong.ddingdongBE.file.service.ExcelFileService;
 import java.util.HashSet;
 import java.util.List;
@@ -17,7 +18,7 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 @Transactional(readOnly = true)
 @RequiredArgsConstructor
-public class FacadeClubMemberServiceImpl implements FacadeClubMemberService {
+public class FacadeCentralClubMemberServiceImpl implements FacadeCentralClubMemberService {
 
     private final ClubService clubService;
     private final ClubMemberService clubMemberService;
@@ -27,6 +28,14 @@ public class FacadeClubMemberServiceImpl implements FacadeClubMemberService {
     public byte[] getClubMemberListFile(Long userId) {
         Club club = clubService.getByUserId(userId);
         return excelFileService.generateClubMemberListFile(club.getClubMembers());
+    }
+
+    @Override
+    public List<CentralClubMemberListQuery> getAllMyClubMember(Long userId) {
+        Club club = clubService.getByUserId(userId);
+        return club.getClubMembers().stream()
+                .map(CentralClubMemberListQuery::from)
+                .toList();
     }
 
     @Override

--- a/src/main/java/ddingdong/ddingdongBE/domain/clubmember/service/dto/query/CentralClubMemberListQuery.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/clubmember/service/dto/query/CentralClubMemberListQuery.java
@@ -1,0 +1,25 @@
+package ddingdong.ddingdongBE.domain.clubmember.service.dto.query;
+
+import ddingdong.ddingdongBE.domain.clubmember.entity.ClubMember;
+
+public record CentralClubMemberListQuery(
+        Long id,
+        String name,
+        String studentNumber,
+        String phoneNumber,
+        String position,
+        String department
+) {
+
+    public static CentralClubMemberListQuery from(ClubMember clubMember){
+        return new CentralClubMemberListQuery(
+                clubMember.getId(),
+                clubMember.getName(),
+                clubMember.getStudentNumber(),
+                clubMember.getPhoneNumber(),
+                clubMember.getPosition().getName(),
+                clubMember.getDepartment()
+        );
+    }
+
+}

--- a/src/test/java/ddingdong/ddingdongBE/domain/clubmember/service/FacadeCentralClubMemberServiceTest.java
+++ b/src/test/java/ddingdong/ddingdongBE/domain/clubmember/service/FacadeCentralClubMemberServiceTest.java
@@ -30,14 +30,13 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.mock.web.MockMultipartFile;
-import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
 @SpringBootTest
-class FacadeClubMemberServiceTest extends TestContainerSupport {
+class FacadeCentralClubMemberServiceTest extends TestContainerSupport {
 
     @Autowired
-    private FacadeClubMemberService facadeClubMemberService;
+    private FacadeCentralClubMemberService facadeCentralClubMemberService;
     @Autowired
     private UserRepository userRepository;
     @Autowired
@@ -113,7 +112,7 @@ class FacadeClubMemberServiceTest extends TestContainerSupport {
                 .build();
 
         //when
-        facadeClubMemberService.updateMemberList(command);
+        facadeCentralClubMemberService.updateMemberList(command);
 
         //then
         List<ClubMember> updatedClubMemberList = clubMemberRepository.findAll();
@@ -145,7 +144,7 @@ class FacadeClubMemberServiceTest extends TestContainerSupport {
                 .department("test").build();
 
         //when
-        facadeClubMemberService.update(command);
+        facadeCentralClubMemberService.update(command);
 
         //then
         ClubMember updatedClubMember = clubMemberService.getById(savedClubMember.getId());


### PR DESCRIPTION
## 🚀 작업 내용
### 동아리원원 명단 조회 API 분리
- `/central/my` 엔드포인트의 응답인 동아리원 명단 정보를 `/central/my/club-members` 엔드포인트로 분리


## 🤔 고민했던 내용

## 💬 리뷰 중점사항

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- 새로운 API 엔드포인트 추가: 클럽 회원 목록을 가져오는 `getMyClubMembers` 메서드.
	- 클럽 회원 정보를 담는 새로운 응답 구조체 `CentralClubMemberListResponse` 추가.
	- 클럽 회원 목록을 가져오는 새로운 서비스 메서드 `getAllMyClubMember` 추가.

- **Bug Fixes**
	- 클럽 회원 관련 서비스의 이름 변경 및 통합으로 인한 코드 정리.

- **Documentation**
	- API 문서화 개선을 위한 OpenAPI 주석 추가.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->