### PR TITLE
[DDING-000] 공지사항 페이지 수 반환 로직 버그 수정

### DIFF
--- a/src/main/java/ddingdong/ddingdongBE/domain/notice/service/NoticeServiceImpl.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/notice/service/NoticeServiceImpl.java
@@ -13,6 +13,8 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional(readOnly = true)
 public class NoticeServiceImpl implements NoticeService {
 
+    public static final int NOTICE_COUNT_FOR_PAGE = 10;
+
     private final NoticeRepository noticeRepository;
 
     @Override
@@ -43,7 +45,8 @@ public class NoticeServiceImpl implements NoticeService {
 
     @Override
     public int getNoticePageCount() {
-        return (int) noticeRepository.countAll();
+        int totalCount = noticeRepository.countAll();
+        return (totalCount + NOTICE_COUNT_FOR_PAGE - 1) / NOTICE_COUNT_FOR_PAGE;
     }
 
 }


### PR DESCRIPTION
## 🚀 작업 내용
* 잘못 작성되어 있던 페이지 수 반환 로직을 재 작성했습니다. 
* 한 페이지 당 기준 공지사항 수는 10개입니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
	- 공지사항 페이지 수 계산 로직 개선: 페이지당 공지사항 수를 10으로 설정하여 보다 정확한 페이지 수를 제공합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->