### PR TITLE
[DDING-000] 테스트 오류 제거

### DIFF
--- a/src/main/java/ddingdong/ddingdongBE/domain/filemetadata/service/FileMetaDataServiceImpl.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/filemetadata/service/FileMetaDataServiceImpl.java
@@ -36,9 +36,6 @@ public class FileMetaDataServiceImpl implements FileMetaDataService {
     @Override
     @Transactional
     public void updateAll(List<String> ids, DomainType domainType, Long entityId) {
-        if(ids == null || ids.isEmpty()) {
-            return;
-        }
         List<FileMetaData> fileMetaDataList =
                 fileMetaDataRepository.findAllByDomainTypeAndEntityIdWithFileStatus(domainType, entityId, COUPLED);
         Set<UUID> existingIds = fileMetaDataList.stream()


### PR DESCRIPTION
## 🚀 작업 내용
- FileMetaDataService - updateAll 메서드 null 체킹 제거

## 🤔 고민했던 내용

## 💬 리뷰 중점사항


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **버그 수정**
	- `updateAll` 메서드에서 null 또는 빈 `ids`에 대한 초기 체크가 제거되어, 이제 `ids`가 제공되지 않더라도 메서드가 항상 실행됩니다. 
- **기능 개선**
	- 파일 메타데이터 검색 및 처리 로직이 변경되어, `ids`가 없을 경우에도 파일 메타데이터 항목을 항상 시도하여 검색합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->