### PR TITLE
[DDING-41] FileMetaData 로직 분리

### DIFF
--- a/src/main/java/ddingdong/ddingdongBE/domain/club/service/FacadeCentralClubServiceImpl.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/club/service/FacadeCentralClubServiceImpl.java
@@ -7,8 +7,6 @@ import ddingdong.ddingdongBE.domain.filemetadata.entity.DomainType;
 import ddingdong.ddingdongBE.domain.filemetadata.service.FileMetaDataService;
 import ddingdong.ddingdongBE.file.service.S3FileService;
 import ddingdong.ddingdongBE.file.service.dto.query.UploadedFileUrlQuery;
-import java.util.Objects;
-import java.util.stream.Stream;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -26,7 +24,8 @@ public class FacadeCentralClubServiceImpl implements FacadeCentralClubService {
     public MyClubInfoQuery getMyClubInfo(Long userId) {
         Club club = clubService.getByUserId(userId);
         return MyClubInfoQuery.of(
-                club, getFileKey(DomainType.CLUB_PROFILE, club.getId()),
+                club,
+                getFileKey(DomainType.CLUB_PROFILE, club.getId()),
                 getFileKey(DomainType.CLUB_INTRODUCTION, club.getId())
         );
     }
@@ -36,8 +35,8 @@ public class FacadeCentralClubServiceImpl implements FacadeCentralClubService {
     public Long updateClubInfo(UpdateClubInfoCommand command) {
         Club club = clubService.getByUserId(command.userId());
         clubService.update(club, command.toEntity());
-        updateFileMetaData(command.profileImageId(), DomainType.CLUB_PROFILE, club.getId());
-        updateFileMetaData(command.introductionImageId(), DomainType.CLUB_INTRODUCTION, club.getId());
+        fileMetaDataService.update(command.profileImageId(), DomainType.CLUB_PROFILE, club.getId());
+        fileMetaDataService.update(command.introductionImageId(), DomainType.CLUB_INTRODUCTION, club.getId());
         return club.getId();
     }
 
@@ -47,16 +46,6 @@ public class FacadeCentralClubServiceImpl implements FacadeCentralClubService {
                 .map(fileMetaData -> s3FileService.getUploadedFileUrl(fileMetaData.getFileKey()))
                 .findFirst()
                 .orElse(null);
-    }
-
-    private void updateFileMetaData(String fileId, DomainType clubProfile, Long entityId) {
-        fileMetaDataService.updateAll(
-                Stream.of(fileId)
-                        .filter(Objects::nonNull)
-                        .toList(),
-                clubProfile,
-                entityId
-        );
     }
 
 }

--- a/src/main/java/ddingdong/ddingdongBE/domain/filemetadata/entity/FileMetaData.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/filemetadata/entity/FileMetaData.java
@@ -8,16 +8,21 @@ import jakarta.persistence.Enumerated;
 import jakarta.persistence.Id;
 import jakarta.persistence.Index;
 import jakarta.persistence.Table;
+import java.time.LocalDateTime;
 import java.util.UUID;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.SQLRestriction;
 
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@Table(indexes = {@Index(columnList = "domainType,entityId,fileStatus")})
+@Table(name = "file_meta_data",indexes = {@Index(columnList = "domainType,entityId,fileStatus")})
+@SQLDelete(sql = "update file_meta_data set deleted_at = CURRENT_TIMESTAMP where id=?")
+@SQLRestriction("deleted_at IS NULL")
 public class FileMetaData extends BaseEntity {
 
     @Id
@@ -41,6 +46,9 @@ public class FileMetaData extends BaseEntity {
 
     @Enumerated(EnumType.STRING)
     private FileCategory fileCategory;
+
+    @Column(name = "deleted_at", columnDefinition = "TIMESTAMP")
+    private LocalDateTime deletedAt;
 
     @Builder
     private FileMetaData(UUID id, String fileKey, String fileName, DomainType domainType, Long entityId,

--- a/src/main/java/ddingdong/ddingdongBE/domain/filemetadata/service/FileMetaDataService.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/filemetadata/service/FileMetaDataService.java
@@ -11,7 +11,15 @@ public interface FileMetaDataService {
 
     List<FileMetaData> getCoupledAllByDomainTypeAndEntityId(DomainType domainType, Long entityId);
 
-    void updateAll(List<String> ids, DomainType domainType, Long entityId);
+    void updateToCoupled(List<String> ids, DomainType domainType, Long entityId);
+
+    void updateToCoupled(String id, DomainType domainType, Long entityId);
+
+    void updateToDelete(DomainType domainType, Long entityId);
+
+    void update(String id, DomainType domainType, Long entityId);
+
+    void update(List<String> ids, DomainType domainType, Long entityId);
 
 
 }

--- a/src/main/java/ddingdong/ddingdongBE/domain/filemetadata/service/FileMetaDataServiceImpl.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/filemetadata/service/FileMetaDataServiceImpl.java
@@ -33,12 +33,9 @@ public class FileMetaDataServiceImpl implements FileMetaDataService {
 
     @Override
     public void updateToCoupled(List<String> ids, DomainType domainType, Long entityId) {
-        List<UUID> fileMetaDataIds = toUUIDs(ids);
-        List<FileMetaData> fileMetaDatas = fileMetaDataRepository.findByIdIn(fileMetaDataIds);
-        if (fileMetaDatas.isEmpty()) {
-            return;
-        }
-        fileMetaDatas.forEach(fileMetaData -> fileMetaData.updateStatus(COUPLED));
+        ids.forEach(id -> {
+            updateToCoupled(id, domainType, entityId);
+        });
     }
 
     @Override
@@ -48,6 +45,7 @@ public class FileMetaDataServiceImpl implements FileMetaDataService {
         if (fileMetaData == null) {
             return;
         }
+        fileMetaData.updateCoupledEntityInfo(domainType, entityId);
         fileMetaData.updateStatus(COUPLED);
     }
 
@@ -76,11 +74,5 @@ public class FileMetaDataServiceImpl implements FileMetaDataService {
             fileMetaData.updateStatus(DELETED);
             fileMetaDataRepository.delete(fileMetaData);
         });
-    }
-
-    private List<UUID> toUUIDs(List<String> ids) {
-        return ids.stream()
-                .map(UUID::fromString)
-                .toList();
     }
 }

--- a/src/main/java/ddingdong/ddingdongBE/domain/filemetadata/service/FileMetaDataServiceImpl.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/filemetadata/service/FileMetaDataServiceImpl.java
@@ -7,9 +7,7 @@ import ddingdong.ddingdongBE.domain.filemetadata.entity.DomainType;
 import ddingdong.ddingdongBE.domain.filemetadata.entity.FileMetaData;
 import ddingdong.ddingdongBE.domain.filemetadata.repository.FileMetaDataRepository;
 import java.util.List;
-import java.util.Set;
 import java.util.UUID;
-import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -34,31 +32,55 @@ public class FileMetaDataServiceImpl implements FileMetaDataService {
     }
 
     @Override
-    @Transactional
-    public void updateAll(List<String> ids, DomainType domainType, Long entityId) {
-        List<FileMetaData> fileMetaDataList =
-                fileMetaDataRepository.findAllByDomainTypeAndEntityIdWithFileStatus(domainType, entityId, COUPLED);
-        Set<UUID> existingIds = fileMetaDataList.stream()
-                .map(FileMetaData::getId)
-                .collect(Collectors.toSet());
-        Set<UUID> newIds = ids.stream()
-                .map(UUID::fromString)
-                .collect(Collectors.toSet());
-
-        // delete files
-        fileMetaDataList.stream()
-                .filter(fileMetaData -> !newIds.contains(fileMetaData.getId()))
-                .forEach(fileMetaData -> fileMetaData.updateStatus(DELETED));
-
-        // couple files
-        fileMetaDataRepository.findByIdIn(
-                        newIds.stream()
-                                .filter(id -> !existingIds.contains(id))
-                                .toList())
-                .forEach(fileMetaData -> {
-                    fileMetaData.updateCoupledEntityInfo(domainType, entityId);
-                    fileMetaData.updateStatus(COUPLED);
-                });
+    public void updateToCoupled(List<String> ids, DomainType domainType, Long entityId) {
+        List<UUID> fileMetaDataIds = toUUIDs(ids);
+        List<FileMetaData> fileMetaDatas = fileMetaDataRepository.findByIdIn(fileMetaDataIds);
+        if (fileMetaDatas.isEmpty()) {
+            return;
+        }
+        fileMetaDatas.forEach(fileMetaData -> fileMetaData.updateStatus(COUPLED));
     }
 
+    @Override
+    public void updateToCoupled(String id, DomainType domainType, Long entityId) {
+        UUID fileMetaDataId = UUID.fromString(id);
+        FileMetaData fileMetaData = fileMetaDataRepository.findById(fileMetaDataId).orElse(null);
+        if (fileMetaData == null) {
+            return;
+        }
+        fileMetaData.updateStatus(COUPLED);
+    }
+
+    @Override
+    public void update(String id, DomainType domainType, Long entityId) {
+        updateToDelete(domainType, entityId);
+        if (id == null) {
+            return;
+        }
+        updateToCoupled(id, domainType, entityId);
+    }
+
+    @Override
+    public void update(List<String> ids, DomainType domainType, Long entityId) {
+        updateToDelete(domainType, entityId);
+        if (ids == null || ids.isEmpty()) {
+            return;
+        }
+        updateToCoupled(ids, domainType, entityId);
+    }
+
+    @Override
+    public void updateToDelete(DomainType domainType, Long entityId) {
+        List<FileMetaData> fileMetaDatas = getCoupledAllByDomainTypeAndEntityId(domainType, entityId);
+        fileMetaDatas.forEach(fileMetaData -> {
+            fileMetaData.updateStatus(DELETED);
+            fileMetaDataRepository.delete(fileMetaData);
+        });
+    }
+
+    private List<UUID> toUUIDs(List<String> ids) {
+        return ids.stream()
+                .map(UUID::fromString)
+                .toList();
+    }
 }

--- a/src/test/java/ddingdong/ddingdongBE/domain/fixzone/service/FacadeCentralFixZoneServiceImplTest.java
+++ b/src/test/java/ddingdong/ddingdongBE/domain/fixzone/service/FacadeCentralFixZoneServiceImplTest.java
@@ -262,8 +262,9 @@ class FacadeCentralFixZoneServiceImplTest extends TestContainerSupport {
         Optional<FixZone> result = fixZoneRepository.findById(savedFixZone.getId());
         List<FileMetaData> fileMetaDataList = fileMetaDataRepository.findByIdIn(List.of(fileId1, fileId2));
         assertThat(result.isPresent()).isFalse();
-        assertThat(fileMetaDataList).hasSize(2)
-                .extracting("fileStatus")
-                .containsOnly(FileStatus.DELETED);
+        assertThat(fileMetaDataList).isEmpty();
+//        assertThat(fileMetaDataList).hasSize(2)
+//                .extracting("fileStatus")
+//                .containsOnly(FileStatus.DELETED);
     }
 }


### PR DESCRIPTION
## 🚀 작업 내용
FileMetaData의 메소드를 분리하였습니다.

## 🤔 고민했던 내용
FileMetaData에 soft delete를 적용하였습니다.
테스트 코드에서 DB사용자 권한 문제로 인해, 네이티브 쿼리로 delete문을 못사용하여 테스트 코드가 수정되었습니다.
추후에 해결하기 위해 이전 코드를 주석처리하였습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- 파일 메타데이터 업데이트 프로세스가 간소화되었습니다.
	- 소프트 삭제 기능이 추가되어 파일 삭제 시 기록이 유지됩니다.

- **Bug Fixes**
	- 삭제 후 파일 메타데이터 상태 확인 로직이 개선되었습니다.

- **Tests**
	- 파일 메타데이터 관련 테스트가 업데이트되어 새로운 메서드 호출 및 예상 결과가 반영되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->