### PR TITLE
[DDING-000] 페이지네이션 오류 수정 및 FileMetaData 로직 수정

### DIFF
--- a/src/main/java/ddingdong/ddingdongBE/domain/documents/repository/DocumentRepository.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/documents/repository/DocumentRepository.java
@@ -13,7 +13,7 @@ public interface DocumentRepository extends JpaRepository<Document, Long> {
             FROM document AS d
             ORDER BY d.id DESC
             LIMIT :limit
-            OFFSET :offsetValue
+            OFFSET :offset
             """,
             nativeQuery = true
     )

--- a/src/main/java/ddingdong/ddingdongBE/domain/filemetadata/entity/FileMetaData.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/filemetadata/entity/FileMetaData.java
@@ -81,4 +81,11 @@ public class FileMetaData extends BaseEntity {
         this.entityId = entityId;
     }
 
+    public boolean isCoupled() {
+        return this.fileStatus == FileStatus.COUPLED;
+    }
+
+    public boolean isPending() {
+        return this.fileStatus == FileStatus.PENDING;
+    }
 }

--- a/src/main/java/ddingdong/ddingdongBE/domain/filemetadata/service/FileMetaDataServiceImpl.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/filemetadata/service/FileMetaDataServiceImpl.java
@@ -96,9 +96,9 @@ public class FileMetaDataServiceImpl implements FileMetaDataService {
         List<FileMetaData> fileMetaDatas = getCoupledAllByDomainTypeAndEntityId(domainType, entityId);
         fileMetaDatas.forEach(fileMetaData -> {
             fileMetaData.updateStatus(DELETED);
-            entityManager.flush();
-            fileMetaDataRepository.delete(fileMetaData);
         });
+        entityManager.flush();
+        fileMetaDataRepository.deleteAll(fileMetaDatas);
     }
 
     private boolean isCoupled(String id) {
@@ -115,9 +115,9 @@ public class FileMetaDataServiceImpl implements FileMetaDataService {
                 .filter(fileMetaData -> !ids.contains(String.valueOf(fileMetaData.getId())))
                 .forEach(fileMetaData -> {
                     fileMetaData.updateStatus(DELETED);
-                    entityManager.flush();
-                    fileMetaDataRepository.delete(fileMetaData);
                 });
+        entityManager.flush();
+        fileMetaDataRepository.deleteAll(fileMetaDatas);
     }
 
     private FileMetaData findById(UUID id) {

--- a/src/main/java/ddingdong/ddingdongBE/domain/filemetadata/service/FileMetaDataServiceImpl.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/filemetadata/service/FileMetaDataServiceImpl.java
@@ -2,7 +2,6 @@ package ddingdong.ddingdongBE.domain.filemetadata.service;
 
 import static ddingdong.ddingdongBE.domain.filemetadata.entity.FileStatus.COUPLED;
 import static ddingdong.ddingdongBE.domain.filemetadata.entity.FileStatus.DELETED;
-import static ddingdong.ddingdongBE.domain.filemetadata.entity.FileStatus.PENDING;
 
 import ddingdong.ddingdongBE.common.exception.PersistenceException.ResourceNotFound;
 import ddingdong.ddingdongBE.domain.filemetadata.entity.DomainType;
@@ -46,11 +45,10 @@ public class FileMetaDataServiceImpl implements FileMetaDataService {
         List<UUID> fileMetaDataId = toUUIDs(ids);
         List<FileMetaData> fileMetaDatas = fileMetaDataRepository.findByIdIn(fileMetaDataId);
         if (ids.size() != fileMetaDatas.size()) {
-            log.info(ids.size() + " , " + fileMetaDatas.size());
             throw new ResourceNotFound("해당 FileMetaData(id: " + fileMetaDataId + ")를 찾을 수 없습니다.");
         }
         fileMetaDatas.stream()
-            .filter(fileMetaData -> fileMetaData.getFileStatus() == PENDING)
+            .filter(FileMetaData::isPending)
             .forEach(fileMetaData -> {
             fileMetaData.updateCoupledEntityInfo(domainType, entityId);
             fileMetaData.updateStatus(COUPLED);
@@ -106,7 +104,7 @@ public class FileMetaDataServiceImpl implements FileMetaDataService {
             return false;
         }
         FileMetaData fileMetaData = findById(UUID.fromString(id));
-        return fileMetaData.getFileStatus() == COUPLED;
+        return fileMetaData.isCoupled();
     }
 
     private void deleteExcludingIds(List<String> ids, DomainType domainType, Long entityId) {

--- a/src/main/java/ddingdong/ddingdongBE/domain/filemetadata/service/FileMetaDataServiceImpl.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/filemetadata/service/FileMetaDataServiceImpl.java
@@ -2,6 +2,7 @@ package ddingdong.ddingdongBE.domain.filemetadata.service;
 
 import static ddingdong.ddingdongBE.domain.filemetadata.entity.FileStatus.COUPLED;
 import static ddingdong.ddingdongBE.domain.filemetadata.entity.FileStatus.DELETED;
+import static ddingdong.ddingdongBE.domain.filemetadata.entity.FileStatus.PENDING;
 
 import ddingdong.ddingdongBE.common.exception.PersistenceException.ResourceNotFound;
 import ddingdong.ddingdongBE.domain.filemetadata.entity.DomainType;
@@ -39,15 +40,18 @@ public class FileMetaDataServiceImpl implements FileMetaDataService {
     @Transactional
     @Override
     public void updateStatusToCoupled(List<String> ids, DomainType domainType, Long entityId) {
-        if (ids.isEmpty()) {
+        if (ids == null || ids.isEmpty()) {
             return;
         }
         List<UUID> fileMetaDataId = toUUIDs(ids);
         List<FileMetaData> fileMetaDatas = fileMetaDataRepository.findByIdIn(fileMetaDataId);
         if (ids.size() != fileMetaDatas.size()) {
+            log.info(ids.size() + " , " + fileMetaDatas.size());
             throw new ResourceNotFound("해당 FileMetaData(id: " + fileMetaDataId + ")를 찾을 수 없습니다.");
         }
-        fileMetaDatas.forEach(fileMetaData -> {
+        fileMetaDatas.stream()
+            .filter(fileMetaData -> fileMetaData.getFileStatus() == PENDING)
+            .forEach(fileMetaData -> {
             fileMetaData.updateCoupledEntityInfo(domainType, entityId);
             fileMetaData.updateStatus(COUPLED);
         });
@@ -60,10 +64,7 @@ public class FileMetaDataServiceImpl implements FileMetaDataService {
             return;
         }
         UUID fileMetaDataId = UUID.fromString(id);
-        FileMetaData fileMetaData = fileMetaDataRepository.findById(fileMetaDataId).orElse(null);
-        if (fileMetaData == null) {
-            throw new ResourceNotFound("해당 FileMetaData(id: " + fileMetaDataId + ")를 찾을 수 없습니다.");
-        }
+        FileMetaData fileMetaData = findById(fileMetaDataId);
         fileMetaData.updateCoupledEntityInfo(domainType, entityId);
         fileMetaData.updateStatus(COUPLED);
     }
@@ -71,20 +72,21 @@ public class FileMetaDataServiceImpl implements FileMetaDataService {
     @Transactional
     @Override
     public void update(String id, DomainType domainType, Long entityId) {
-        updateStatusToDelete(domainType, entityId);
-        if (id == null) {
+        if (isCoupled(id)) {
             return;
         }
+        updateStatusToDelete(domainType, entityId);
         updateStatusToCoupled(id, domainType, entityId);
     }
 
     @Transactional
     @Override
     public void update(List<String> ids, DomainType domainType, Long entityId) {
-        updateStatusToDelete(domainType, entityId);
         if (ids == null || ids.isEmpty()) {
+            updateStatusToDelete(domainType, entityId);
             return;
         }
+        deleteExcludingIds(ids, domainType, entityId);
         updateStatusToCoupled(ids, domainType, entityId);
     }
 
@@ -97,6 +99,30 @@ public class FileMetaDataServiceImpl implements FileMetaDataService {
             entityManager.flush();
             fileMetaDataRepository.delete(fileMetaData);
         });
+    }
+
+    private boolean isCoupled(String id) {
+        if (id == null) {
+            return false;
+        }
+        FileMetaData fileMetaData = findById(UUID.fromString(id));
+        return fileMetaData.getFileStatus() == COUPLED;
+    }
+
+    private void deleteExcludingIds(List<String> ids, DomainType domainType, Long entityId) {
+        List<FileMetaData> fileMetaDatas = getCoupledAllByDomainTypeAndEntityId(domainType, entityId);
+        fileMetaDatas.stream()
+                .filter(fileMetaData -> !ids.contains(String.valueOf(fileMetaData.getId())))
+                .forEach(fileMetaData -> {
+                    fileMetaData.updateStatus(DELETED);
+                    entityManager.flush();
+                    fileMetaDataRepository.delete(fileMetaData);
+                });
+    }
+
+    private FileMetaData findById(UUID id) {
+        return fileMetaDataRepository.findById(id)
+            .orElseThrow(() -> new ResourceNotFound("해당 FileMetaData(id: " + id + ")를 찾을 수 없습니다."));
     }
 
     private List<UUID> toUUIDs(List<String> ids) {

--- a/src/test/java/ddingdong/ddingdongBE/domain/filemetadata/service/FileMetaDataServiceImplTest.java
+++ b/src/test/java/ddingdong/ddingdongBE/domain/filemetadata/service/FileMetaDataServiceImplTest.java
@@ -19,7 +19,9 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
 
+@Transactional
 @SpringBootTest
 class FileMetaDataServiceImplTest extends TestContainerSupport {
 
@@ -54,14 +56,14 @@ class FileMetaDataServiceImplTest extends TestContainerSupport {
         DomainType domainType = DomainType.CLUB_PROFILE;
         Long entityId = 1L;
         fileMetaDataRepository.saveAll(fixture.giveMeBuilder(FileMetaData.class)
-                .set("domainType", domainType)
-                .set("entityId", entityId)
-                .set("fileStatus", FileStatus.COUPLED)
-                .sampleList(3));
+            .set("domainType", domainType)
+            .set("entityId", entityId)
+            .set("fileStatus", FileStatus.COUPLED)
+            .sampleList(3));
 
         //when
         List<FileMetaData> result =
-                fileMetaDataService.getCoupledAllByDomainTypeAndEntityId(domainType, entityId);
+            fileMetaDataService.getCoupledAllByDomainTypeAndEntityId(domainType, entityId);
 
         //then
         assertThat(result).hasSize(3);
@@ -76,34 +78,34 @@ class FileMetaDataServiceImplTest extends TestContainerSupport {
         UUID id1 = UuidCreator.getTimeOrderedEpoch();
         UUID id2 = UuidCreator.getTimeOrderedEpoch();
         fileMetaDataRepository.saveAll(List.of(
-                fixture.giveMeBuilder(FileMetaData.class)
-                        .set("id", id1)
-                        .set("domainType", null)
-                        .set("entityId", null)
-                        .set("fileStatus", FileStatus.PENDING)
-                        .sample(),
-                fixture.giveMeBuilder(FileMetaData.class)
-                        .set("id", id2)
-                        .set("domainType", null)
-                        .set("entityId", null)
-                        .set("fileStatus", FileStatus.PENDING)
-                        .sample()
+            fixture.giveMeBuilder(FileMetaData.class)
+                .set("id", id1)
+                .set("domainType", null)
+                .set("entityId", null)
+                .set("fileStatus", FileStatus.PENDING)
+                .sample(),
+            fixture.giveMeBuilder(FileMetaData.class)
+                .set("id", id2)
+                .set("domainType", null)
+                .set("entityId", null)
+                .set("fileStatus", FileStatus.PENDING)
+                .sample()
         ));
-            em.flush();
-            em.clear();
+        em.flush();
+        em.clear();
         //when
         fileMetaDataService.updateStatusToCoupled(List.of(id1.toString(), id2.toString()), domainType, entityId);
         em.flush();
         em.clear();
         //then
         List<FileMetaData> result = fileMetaDataRepository.findAllByDomainTypeAndEntityIdWithFileStatus(
-                domainType, entityId, FileStatus.COUPLED);
+            domainType, entityId, FileStatus.COUPLED);
         assertThat(result).hasSize(2)
-                .extracting("fileStatus")
-                .contains(FileStatus.COUPLED);
+            .extracting("fileStatus")
+            .contains(FileStatus.COUPLED);
     }
 
-    @DisplayName("FileMetaData 수정 - COUPLED & DELETED")
+    @DisplayName("FileMetaData 수정 - COUPLED & DELETED id를 일부 수정할 경우")
     @Test
     void updateAllToActivatedAndAttached() {
         //given
@@ -111,37 +113,70 @@ class FileMetaDataServiceImplTest extends TestContainerSupport {
         Long entityId = 1L;
         UUID id1 = UuidCreator.getTimeOrderedEpoch();
         UUID id2 = UuidCreator.getTimeOrderedEpoch();
+        UUID id3 = UuidCreator.getTimeOrderedEpoch();
         fileMetaDataRepository.saveAll(List.of(
-                fixture.giveMeBuilder(FileMetaData.class)
-                        .set("id", id1)
-                        .set("domainType", null)
-                        .set("entityId", null)
-                        .set("fileStatus", FileStatus.PENDING)
-                        .sample(),
-                fixture.giveMeBuilder(FileMetaData.class)
-                        .set("id", id2)
-                        .set("domainType", domainType)
-                        .set("entityId", entityId)
-                        .set("fileStatus", FileStatus.COUPLED)
-                        .sample()
+            fixture.giveMeBuilder(FileMetaData.class)
+                .set("id", id1)
+                .set("domainType", null)
+                .set("entityId", null)
+                .set("fileStatus", FileStatus.PENDING)
+                .sample(),
+            fixture.giveMeBuilder(FileMetaData.class)
+                .set("id", id2)
+                .set("domainType", domainType)
+                .set("entityId", entityId)
+                .set("fileStatus", FileStatus.COUPLED)
+                .sample()
         ));
-
+        FileMetaData fileMetaData = fixture.giveMeBuilder(FileMetaData.class)
+            .set("id", id3)
+            .set("domainType", domainType)
+            .set("entityId", entityId)
+            .set("fileStatus", FileStatus.PENDING)
+            .sample();
+        fileMetaDataRepository.save(fileMetaData);
         //when
-        fileMetaDataService.update(List.of(id1.toString()), domainType, entityId);
+        fileMetaDataService.update(List.of(id1.toString(), fileMetaData.getId().toString()), domainType, entityId);
 
         //then
         List<FileMetaData> result = fileMetaDataRepository.findAllByDomainTypeAndEntityIdWithFileStatus(
-                domainType, entityId, FileStatus.COUPLED);
-//        FileMetaData attachedFileMetaData = (FileMetaData) em.createNativeQuery("select * from ddingdong.file_meta_data where id = :id",
-//                        FileMetaData.class)
-//                .setParameter("id", id2)
-//                .getSingleResult();
+            domainType, entityId, FileStatus.COUPLED);
+
         FileMetaData attachedFileMetaData = fileMetaDataRepository.findById(id2).orElse(null);
-        assertThat(result).hasSize(1)
-                .extracting("id", "fileStatus")
-                .contains(tuple(id1, FileStatus.COUPLED));
+        assertThat(result).hasSize(2)
+            .extracting("id", "fileStatus")
+            .contains(tuple(id1, FileStatus.COUPLED), tuple(id3, FileStatus.COUPLED));
         assertThat(attachedFileMetaData).isEqualTo(null);
     }
+
+    @DisplayName("FileMetaData 수정 - COUPLED & DELETED 기존 아이디를 그대로 입력할 경우")
+    @Test
+    void updateToActivatedAndAttached() {
+        //given
+        DomainType domainType = DomainType.CLUB_PROFILE;
+        Long entityId = 1L;
+        UUID id1 = UuidCreator.getTimeOrderedEpoch();
+        fileMetaDataRepository.save(
+            fixture.giveMeBuilder(FileMetaData.class)
+                .set("id", id1)
+                .set("domainType", domainType)
+                .set("entityId", entityId)
+                .set("fileStatus", FileStatus.COUPLED)
+                .sample()
+        );
+
+        //when
+        fileMetaDataService.update(id1.toString(), domainType, entityId);
+
+        //then
+        List<FileMetaData> result = fileMetaDataRepository.findAllByDomainTypeAndEntityIdWithFileStatus(
+            domainType, entityId, FileStatus.COUPLED);
+
+        assertThat(result).hasSize(1)
+            .extracting("id", "fileStatus")
+            .contains(tuple(id1, FileStatus.COUPLED));
+    }
+
 
     @DisplayName("FileMetaData 수정 - DELETED")
     @Test
@@ -152,18 +187,18 @@ class FileMetaDataServiceImplTest extends TestContainerSupport {
         UUID id1 = UuidCreator.getTimeOrderedEpoch();
         UUID id2 = UuidCreator.getTimeOrderedEpoch();
         fileMetaDataRepository.saveAll(List.of(
-                fixture.giveMeBuilder(FileMetaData.class)
-                        .set("id", id1)
-                        .set("domainType", domainType)
-                        .set("entityId", entityId)
-                        .set("fileStatus", FileStatus.COUPLED)
-                        .sample(),
-                fixture.giveMeBuilder(FileMetaData.class)
-                        .set("id", id2)
-                        .set("domainType", domainType)
-                        .set("entityId", entityId)
-                        .set("fileStatus", FileStatus.COUPLED)
-                        .sample()
+            fixture.giveMeBuilder(FileMetaData.class)
+                .set("id", id1)
+                .set("domainType", domainType)
+                .set("entityId", entityId)
+                .set("fileStatus", FileStatus.COUPLED)
+                .sample(),
+            fixture.giveMeBuilder(FileMetaData.class)
+                .set("id", id2)
+                .set("domainType", domainType)
+                .set("entityId", entityId)
+                .set("fileStatus", FileStatus.COUPLED)
+                .sample()
         ));
 
         //when

--- a/src/test/java/ddingdong/ddingdongBE/domain/filemetadata/service/FileMetaDataServiceImplTest.java
+++ b/src/test/java/ddingdong/ddingdongBE/domain/filemetadata/service/FileMetaDataServiceImplTest.java
@@ -205,19 +205,7 @@ class FileMetaDataServiceImplTest extends TestContainerSupport {
         fileMetaDataService.updateStatusToDelete(domainType, entityId);
         em.flush();
         //then
-//        List<FileMetaData> result = (List<FileMetaData>) em.createNativeQuery("select * from ddingdong.file_meta_data where id IN (:ids)",
-//                FileMetaData.class)
-//                .setParameter("ids", Arrays.asList(id1, id2))
-//                .getResultList();
         List<FileMetaData> result = fileMetaDataRepository.findByIdIn(List.of(id1, id2));
         assertThat(result).isEmpty();
-//        assertThat(result).hasSize(2)
-//                .allSatisfy(fileMetaData -> {
-//                    assertThat(fileMetaData.getDomainType()).isEqualTo(domainType);
-//                    assertThat(fileMetaData.getEntityId()).isEqualTo(entityId);
-//                    assertThat(fileMetaData.getFileStatus()).isEqualTo(FileStatus.DELETED);
-//                });
     }
-
-
 }

--- a/src/test/java/ddingdong/ddingdongBE/domain/fixzone/service/FacadeCentralFixZoneServiceImplTest.java
+++ b/src/test/java/ddingdong/ddingdongBE/domain/fixzone/service/FacadeCentralFixZoneServiceImplTest.java
@@ -30,7 +30,9 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
 
+@Transactional
 @SpringBootTest
 class FacadeCentralFixZoneServiceImplTest extends TestContainerSupport {
 


### PR DESCRIPTION
## 🚀 작업 내용
- 페이지네이션 쿼리 관련 오류 수정하였습니다.
- 일부 수정할 경우 수행하도록 로직 변경하였습니다.

1. 단일 ID일 경우
- 이미지를 새로 update 하려 했다면 presigned url을 호출하여 pending 상태에서 update를 수행할 것입니다.
- 만약 상태가 pending이 아닌 coupled라면 기존 id를 보낸 것으로 인식하여 update하지 않았습니다.

2. 여러 ID일 경우
- 마찬가지로, pending 상태의 id만 update를 하도록 로직을 추가하였는데, 이것은 updateStatusToCoupled()로직 중 스트림의 filter에서 pending인 것만 업데이트 하도록 로직을 구현하였습니다.

- 일부만 수정할 경우
- 여러 id인 경우 중 일부만 수정하였다면, 스트림으로 필터링하여 id로 받아온 것을 제외하고 엔터티에 속한 모든 filemetadata를 삭제했습니다.
- 그 이후에 문제 없이 coupled로 업데이트 하였습니다.

3. 하나의 엔터티를 삭제할 때 마다 flush()를 호출하는 것이 성능적인 이슈가 있을 것 같아, 배치방식으로 처리하였습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **버그 수정**
	- `DocumentRepository`의 SQL 쿼리에서 `OFFSET` 매개변수 이름을 변경하여 페이지네이션 정확성을 개선했습니다.
	- `FileMetaDataServiceImpl`의 여러 메서드에서 null 체크를 추가하여 오류 처리 및 흐름 제어를 강화했습니다.

- **새로운 기능**
	- `FileMetaDataServiceImpl`에 새로운 메서드 추가: `isCoupled`, `deleteExcludingIds`, `findById`로 기능을 확장했습니다.
	- `FileMetaData` 클래스에 `isCoupled` 및 `isPending` 메서드를 추가하여 파일 메타데이터 상태 확인 기능을 강화했습니다.
	- `FileMetaDataServiceImplTest`에 새로운 테스트 메서드 `updateToActivatedAndAttached` 추가하여 기존 ID 업데이트 검증을 강화했습니다.

- **문서화**
	- 테스트 클래스에 `@Transactional` 주석을 추가하여 데이터베이스 변경 사항이 테스트 후 롤백되도록 설정했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->