### PR TITLE
[DDING-000] FileMetaData의 삭제 상태관리 방법 수정

### DIFF
--- a/src/main/java/ddingdong/ddingdongBE/domain/filemetadata/entity/FileMetaData.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/filemetadata/entity/FileMetaData.java
@@ -8,21 +8,18 @@ import jakarta.persistence.Enumerated;
 import jakarta.persistence.Id;
 import jakarta.persistence.Index;
 import jakarta.persistence.Table;
-import java.time.LocalDateTime;
 import java.util.UUID;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.hibernate.annotations.SQLDelete;
 import org.hibernate.annotations.SQLRestriction;
 
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Table(name = "file_meta_data",indexes = {@Index(columnList = "domainType,entityId,fileStatus")})
-@SQLDelete(sql = "update file_meta_data set deleted_at = CURRENT_TIMESTAMP where id=?")
-@SQLRestriction("deleted_at IS NULL")
+@SQLRestriction("file_status != 'DELETED'")
 public class FileMetaData extends BaseEntity {
 
     @Id
@@ -46,9 +43,6 @@ public class FileMetaData extends BaseEntity {
 
     @Enumerated(EnumType.STRING)
     private FileCategory fileCategory;
-
-    @Column(name = "deleted_at", columnDefinition = "TIMESTAMP")
-    private LocalDateTime deletedAt;
 
     @Builder
     private FileMetaData(UUID id, String fileKey, String fileName, DomainType domainType, Long entityId,

--- a/src/main/java/ddingdong/ddingdongBE/domain/filemetadata/repository/FileMetaDataRepository.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/filemetadata/repository/FileMetaDataRepository.java
@@ -11,14 +11,35 @@ import org.springframework.data.repository.query.Param;
 
 public interface FileMetaDataRepository extends JpaRepository<FileMetaData, UUID> {
 
-    @Query("select fmd from FileMetaData fmd where fmd.domainType = :domainType and fmd.entityId = :entityId and fmd.fileStatus = :fileStatus")
+    @Query("""
+        select fmd from FileMetaData fmd
+        where fmd.domainType = :domainType
+        and fmd.entityId = :entityId
+        and fmd.fileStatus = :fileStatus
+        and fmd.fileStatus != 'DELETED'
+        """)
     List<FileMetaData> findAllByDomainTypeAndEntityIdWithFileStatus(
-            @Param("domainType") DomainType domainType,
-            @Param("entityId") Long entityId,
-            @Param("fileStatus") FileStatus fileStatus
+        @Param("domainType") DomainType domainType,
+        @Param("entityId") Long entityId,
+        @Param("fileStatus") FileStatus fileStatus
     );
 
-    List<FileMetaData> findAllByDomainTypeAndEntityId(DomainType domainType, Long entityId);
+    @Query(value = """
+        select * from file_meta_data
+        where domain_type = :#{#domainType.name()}
+        and entity_id = :entityId
+        and file_status != 'DELETED'
+        """, nativeQuery = true)
+    List<FileMetaData> findAllByDomainTypeAndEntityId(
+        @Param("domainType") DomainType domainType,
+        @Param("entityId") Long entityId
+    );
 
-    List<FileMetaData> findByIdIn(List<UUID> ids);
+    @Query(value = """
+        select *
+        from file_meta_data
+        where id in (:ids)
+        and file_status != 'DELETED'
+        """, nativeQuery = true)
+    List<FileMetaData> findByIdIn(@Param("ids") List<UUID> ids);
 }

--- a/src/main/java/ddingdong/ddingdongBE/domain/filemetadata/service/FileMetaDataServiceImpl.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/filemetadata/service/FileMetaDataServiceImpl.java
@@ -96,8 +96,6 @@ public class FileMetaDataServiceImpl implements FileMetaDataService {
         fileMetaDatas.forEach(fileMetaData -> {
             fileMetaData.updateStatus(DELETED);
         });
-        entityManager.flush();
-        fileMetaDataRepository.deleteAll(fileMetaDatas);
     }
 
     private List<String> getNewIds(List<String> ids) {
@@ -122,8 +120,6 @@ public class FileMetaDataServiceImpl implements FileMetaDataService {
             .filter(fileMetaData -> !ids.contains(String.valueOf(fileMetaData.getId())))
             .toList();
         deleteTarget.forEach(target -> target.updateStatus(DELETED));
-        entityManager.flush();
-        fileMetaDataRepository.deleteAll(deleteTarget);
     }
 
     private FileMetaData findById(UUID id) {

--- a/src/main/resources/db/migration/V27__drop_file_meta_data_column.sql
+++ b/src/main/resources/db/migration/V27__drop_file_meta_data_column.sql
@@ -1,0 +1,2 @@
+ALTER TABLE file_meta_data
+    DROP COLUMN deleted_at;

--- a/src/test/java/ddingdong/ddingdongBE/domain/filemetadata/repository/FileMetaDataRepositoryTest.java
+++ b/src/test/java/ddingdong/ddingdongBE/domain/filemetadata/repository/FileMetaDataRepositoryTest.java
@@ -1,0 +1,75 @@
+package ddingdong.ddingdongBE.domain.filemetadata.repository;
+
+import ddingdong.ddingdongBE.common.support.DataJpaTestSupport;
+import ddingdong.ddingdongBE.domain.filemetadata.entity.DomainType;
+import ddingdong.ddingdongBE.domain.filemetadata.entity.FileMetaData;
+import ddingdong.ddingdongBE.domain.filemetadata.entity.FileStatus;
+import jakarta.persistence.EntityManager;
+import java.util.List;
+import java.util.UUID;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+class FileMetaDataRepositoryTest extends DataJpaTestSupport {
+
+    @Autowired
+    private FileMetaDataRepository fileMetaDataRepository;
+
+    @Autowired
+    private EntityManager entityManager;
+
+    @Test
+    void findAllByDomainTypeAndEntityId() {
+        DomainType domainType = DomainType.CLUB_PROFILE;
+        Long id = 1L;
+        FileMetaData fileMetaData = FileMetaData.builder()
+            .id(UUID.randomUUID())
+            .fileKey("123")
+            .fileName("1234.png")
+            .domainType(domainType)
+            .entityId(id)
+            .fileStatus(FileStatus.COUPLED)
+            .build();
+        fileMetaDataRepository.save(fileMetaData);
+
+        List<FileMetaData> fileMetaDataList = fileMetaDataRepository.findAllByDomainTypeAndEntityId(domainType, id);
+
+        Assertions.assertThat(fileMetaDataList.size()).isEqualTo(1);
+        Assertions.assertThat(fileMetaDataList.get(0).getFileKey()).isEqualTo("123");
+    }
+
+    @DisplayName("여러 개 UUID를 사용하여 fileMetaData를 조회한다.")
+    @Test
+    void findByIn() {
+      // given
+        DomainType domainType = DomainType.CLUB_PROFILE;
+        Long entityId = 1L;
+        Long entityId2 = 2L;
+        UUID id = UUID.randomUUID();
+        UUID id2 = UUID.randomUUID();
+        FileMetaData fileMetaData = FileMetaData.builder()
+            .id(id)
+            .fileKey("123")
+            .fileName("1234.png")
+            .domainType(domainType)
+            .entityId(entityId)
+            .fileStatus(FileStatus.COUPLED)
+            .build();
+        FileMetaData fileMetaData2 = FileMetaData.builder()
+            .id(id2)
+            .fileKey("12344")
+            .fileName("123455.png")
+            .domainType(domainType)
+            .entityId(entityId2)
+            .fileStatus(FileStatus.DELETED)
+            .build();
+        fileMetaDataRepository.saveAll(List.of(fileMetaData, fileMetaData2));
+      // when
+        List<FileMetaData> fileMetaDataList = fileMetaDataRepository.findByIdIn(List.of(id, id2));
+        // then
+        Assertions.assertThat(fileMetaDataList.size()).isEqualTo(1);
+        Assertions.assertThat(fileMetaDataList.get(0).getFileKey()).isEqualTo("123");
+    }
+}

--- a/src/test/java/ddingdong/ddingdongBE/domain/filemetadata/service/FileMetaDataServiceImplTest.java
+++ b/src/test/java/ddingdong/ddingdongBE/domain/filemetadata/service/FileMetaDataServiceImplTest.java
@@ -141,11 +141,9 @@ class FileMetaDataServiceImplTest extends TestContainerSupport {
         List<FileMetaData> result = fileMetaDataRepository.findAllByDomainTypeAndEntityIdWithFileStatus(
             domainType, entityId, FileStatus.COUPLED);
 
-        FileMetaData attachedFileMetaData = fileMetaDataRepository.findById(id2).orElse(null);
         assertThat(result).hasSize(2)
             .extracting("id", "fileStatus")
             .contains(tuple(id1, FileStatus.COUPLED), tuple(id3, FileStatus.COUPLED));
-        assertThat(attachedFileMetaData).isEqualTo(null);
     }
 
     @DisplayName("FileMetaData 수정 - COUPLED & DELETED 기존 아이디를 그대로 입력할 경우")
@@ -199,7 +197,6 @@ class FileMetaDataServiceImplTest extends TestContainerSupport {
                 .set("fileStatus", FileStatus.COUPLED)
                 .sample()
         ));
-
         //when
         fileMetaDataService.updateStatusToDelete(domainType, entityId);
         em.flush();


### PR DESCRIPTION
## 🚀 작업 내용
기존 FileMetaData의 상태변환과 softDelete를 모두 하던 것을 상태 변환만 하도록 수정하였습니다.
즉, softDelete 관련 설정을 삭제하였습니다.

## 🤔 고민했던 내용
'@SQLRestriction'에 대한 동작 방식을 정확히 파악하고 있지 못해 테스트 실패 문제를 해결하는 데 오래걸렸습니다.
-> 다음과 같은 문제가 있었습니다.
'@SQLRestriction'사용 시 같은 트랜잭션 내에 save()로 저장된 엔터티를 findById()로 찾을 때 정해진 쿼리가 실행이 안되고 있습니다.
아래는 관련 링크입니다.

https://github.com/spring-projects/spring-data-jpa/issues/3467


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- 파일 메타데이터의 삭제 상태를 관리하는 새로운 로직이 도입되었습니다.
	- 파일 메타데이터를 검색할 때 삭제된 항목을 제외하는 조건이 추가되었습니다.

- **Bug Fixes**
	- 삭제 상태 업데이트 및 오래된 ID 삭제 방법의 오류 처리 방식이 개선되었습니다.

- **Tests**
	- `FileMetaDataRepository`에 대한 단위 테스트가 추가되었습니다.
	- `FileMetaDataServiceImplTest`의 테스트가 간소화되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->