### PR TITLE
[DDING-64] presignedUrl - 이미지 순서 적용 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -89,6 +89,14 @@ tasks.named('test') {
 
 sonar {
     properties {
+        property "sonar.projectKey", "COW-dev_ddingdong-be"
+        property "sonar.organization", "cow-dev"
+        property "sonar.host.url", "https://sonarcloud.io"
+        property "sonar.sourceEncoding", "UTF-8"
+        property "sonar.java.source", "${java.sourceCompatibility}"
+        property "sonar.coverage.jacoco.xmlReportPaths", "${layout.buildDirectory}/reports/jacoco/test/jacocoTestReport.xml"
+        property "sonar.junit.reportPaths", "${layout.buildDirectory}/test-results/test"
+
         property "sonar.exclusions", "**/common/**"
         property "sonar.coverage.exclusions", """
             **/common/**,

--- a/build.gradle
+++ b/build.gradle
@@ -89,21 +89,14 @@ tasks.named('test') {
 
 sonar {
     properties {
-        property "sonar.projectKey", "COW-dev_ddingdong-be"
-        property "sonar.organization", "cow-dev"
-        property "sonar.host.url", "https://sonarcloud.io"
-        property "sonar.sourceEncoding", "UTF-8"
-        property "sonar.java.source", "${java.sourceCompatibility}"
-        property "sonar.coverage.jacoco.xmlReportPaths", "${layout.buildDirectory}/reports/jacoco/test/jacocoTestReport.xml"
-        property "sonar.junit.reportPaths", "${layout.buildDirectory}/test-results/test"
-
-        property "sonar.exclusions", """
-            **/ddingdong/ddingdongBE/common/**,
+        property "sonar.exclusions", "**/common/**"
+        property "sonar.coverage.exclusions", """
+            **/common/**,
+            **/controller/**,
+            **/dto/**,
+            **/service/General*.java
         """
-        property "sonar.coverage.exclusions",
-                "**/common/**, **/controller/**, **/dto/**, **/service/General**Service"
     }
-
 }
 
 jacocoTestReport {
@@ -111,14 +104,10 @@ jacocoTestReport {
     afterEvaluate {
         classDirectories.setFrom(files(classDirectories.files.collect {
             fileTree(dir: it, exclude: [
-                    "**/ddingdong/ddingdongBE/common/**",
-                    "**/ddingdong/ddingdongBE/**/**Request**",
-                    "**/ddingdong/ddingdongBE/**/**Response**",
-                    "**/ddingdong/ddingdongBE/**/**Command**",
-                    "**/ddingdong/ddingdongBE/**/**Query**",
-                    "**/ddingdong/ddingdongBE/**/**Dto**",
-                    "**/ddingdong/ddingdongBE/**/**Controller**",
-                    "**/ddingdong/ddingdongBE/**/General*Service.class"
+                    "**/common/**",
+                    "**/controller/**",
+                    "**/dto/**",
+                    "**/service/General*.class"
             ])
         }))
     }

--- a/src/main/java/ddingdong/ddingdongBE/domain/filemetadata/entity/FileMetaData.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/filemetadata/entity/FileMetaData.java
@@ -17,7 +17,7 @@ import lombok.NoArgsConstructor;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@Table(name = "file_meta_data",indexes = {@Index(columnList = "domainType,entityId,fileStatus")})
+@Table(name = "file_meta_data", indexes = {@Index(columnList = "domainType,entityId,fileStatus")})
 public class FileMetaData extends BaseEntity {
 
     @Id
@@ -39,15 +39,19 @@ public class FileMetaData extends BaseEntity {
     @Column(nullable = false)
     private FileStatus fileStatus;
 
+    @Column(name = "file_meta_data_order", nullable = false, columnDefinition = "integer default 0")
+    private int order;
+
     @Builder
     private FileMetaData(UUID id, String fileKey, String fileName, DomainType domainType, Long entityId,
-                         FileStatus fileStatus) {
+                         FileStatus fileStatus, int order) {
         this.id = id;
         this.fileKey = fileKey;
         this.fileName = fileName;
         this.domainType = domainType;
         this.entityId = entityId;
         this.fileStatus = fileStatus;
+        this.order = order;
     }
 
     public static FileMetaData createPending(UUID id, String fileKey, String fileName) {
@@ -78,5 +82,9 @@ public class FileMetaData extends BaseEntity {
 
     public boolean isOwn(Long entityId) {
         return this.entityId.equals(entityId);
+    }
+
+    public void updateOrder(int order) {
+        this.order = order;
     }
 }

--- a/src/main/java/ddingdong/ddingdongBE/domain/filemetadata/service/FileMetaDataService.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/filemetadata/service/FileMetaDataService.java
@@ -2,6 +2,7 @@ package ddingdong.ddingdongBE.domain.filemetadata.service;
 
 import ddingdong.ddingdongBE.domain.filemetadata.entity.DomainType;
 import ddingdong.ddingdongBE.domain.filemetadata.entity.FileMetaData;
+import ddingdong.ddingdongBE.domain.filemetadata.service.dto.FileMetaDataIdOrderDto;
 import java.util.List;
 import java.util.UUID;
 
@@ -14,7 +15,7 @@ public interface FileMetaDataService {
     List<FileMetaData> getCoupledAllByEntityId(Long entityId);
 
     List<FileMetaData> getCoupledAllByDomainTypeAndEntityIdOrderedAsc(DomainType domainType,
-        Long entityId);
+                                                                      Long entityId);
 
     List<FileMetaData> getCoupledAllByEntityIds(List<Long> entityIds);
 
@@ -22,9 +23,13 @@ public interface FileMetaDataService {
 
     void updateStatusToCoupled(String id, DomainType domainType, Long entityId);
 
+    void updateStatusToCoupledWithOrder(List<FileMetaDataIdOrderDto> ids, DomainType domainType, Long entityId);
+
     void updateStatusToDelete(DomainType domainType, Long entityId);
 
     void update(String id, DomainType domainType, Long entityId);
 
     void update(List<String> ids, DomainType domainType, Long entityId);
+
+    void updateWithOrder(List<FileMetaDataIdOrderDto> fileMetaDataIdOrderDtos, DomainType domainType, Long entityId);
 }

--- a/src/main/java/ddingdong/ddingdongBE/domain/filemetadata/service/FileMetaDataService.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/filemetadata/service/FileMetaDataService.java
@@ -23,7 +23,7 @@ public interface FileMetaDataService {
 
     void updateStatusToCoupled(String id, DomainType domainType, Long entityId);
 
-    void updateStatusToCoupledWithOrder(List<FileMetaDataIdOrderDto> ids, DomainType domainType, Long entityId);
+    void updateStatusToCoupledWithOrder(List<FileMetaDataIdOrderDto> fileMetaDataIdOrderDtos, DomainType domainType, Long entityId);
 
     void updateStatusToDelete(DomainType domainType, Long entityId);
 

--- a/src/main/java/ddingdong/ddingdongBE/domain/filemetadata/service/FileMetaDataServiceImpl.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/filemetadata/service/FileMetaDataServiceImpl.java
@@ -95,7 +95,7 @@ public class FileMetaDataServiceImpl implements FileMetaDataService {
             return;
         }
         List<UUID> fileMetaDataIds = toUUIDs(fileMetaDataIdOrderDtos.stream()
-                .map(FileMetaDataIdOrderDto::fileMetaDatId)
+                .map(FileMetaDataIdOrderDto::fileMetaDataId)
                 .toList());
         List<FileMetaData> fileMetaDataList = fileMetaDataRepository.findByIdIn(fileMetaDataIds);
         if (fileMetaDataIdOrderDtos.size() != fileMetaDataList.size()) {
@@ -103,7 +103,7 @@ public class FileMetaDataServiceImpl implements FileMetaDataService {
         }
         Map<UUID, Integer> orderMap = fileMetaDataIdOrderDtos.stream()
                 .collect(Collectors.toMap(
-                        dto -> UUID.fromString(dto.fileMetaDatId()),
+                        dto -> UUID.fromString(dto.fileMetaDataId()),
                         FileMetaDataIdOrderDto::fileMetaDataOrder
                 ));
 
@@ -147,7 +147,7 @@ public class FileMetaDataServiceImpl implements FileMetaDataService {
             return;
         }
         List<String> ids = fileMetaDataIdOrderDtos.stream()
-                .map(FileMetaDataIdOrderDto::fileMetaDatId)
+                .map(FileMetaDataIdOrderDto::fileMetaDataId)
                 .toList();
         deleteOldIds(ids, domainType, entityId); //ids에 포함된 id를 가진 fileMetaData외에 전부 제거
         updateStatusToCoupledWithOrder(fileMetaDataIdOrderDtos, domainType, entityId);

--- a/src/main/java/ddingdong/ddingdongBE/domain/filemetadata/service/dto/FileMetaDataIdOrderDto.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/filemetadata/service/dto/FileMetaDataIdOrderDto.java
@@ -1,0 +1,13 @@
+package ddingdong.ddingdongBE.domain.filemetadata.service.dto;
+
+public record FileMetaDataIdOrderDto(
+        String fileMetaDatId,
+        int fileMetaDataOrder
+
+) {
+
+    public static FileMetaDataIdOrderDto of(String fileMetaDatId, int fileMetaDataOrder) {
+        return new FileMetaDataIdOrderDto(fileMetaDatId, fileMetaDataOrder);
+    }
+
+}

--- a/src/main/java/ddingdong/ddingdongBE/domain/filemetadata/service/dto/FileMetaDataIdOrderDto.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/filemetadata/service/dto/FileMetaDataIdOrderDto.java
@@ -1,7 +1,7 @@
 package ddingdong.ddingdongBE.domain.filemetadata.service.dto;
 
 public record FileMetaDataIdOrderDto(
-        String fileMetaDatId,
+        String fileMetaDataId,
         int fileMetaDataOrder
 
 ) {

--- a/src/main/java/ddingdong/ddingdongBE/domain/fixzone/controller/api/ClubFixZoneApi.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/fixzone/controller/api/ClubFixZoneApi.java
@@ -10,6 +10,7 @@ import ddingdong.ddingdongBE.domain.fixzone.controller.dto.response.CentralMyFix
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import java.util.List;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -43,7 +44,7 @@ public interface ClubFixZoneApi {
     @ResponseStatus(HttpStatus.CREATED)
     @SecurityRequirement(name = "AccessToken")
     void createFixZone(@AuthenticationPrincipal PrincipalDetails principalDetails,
-                       @RequestBody CreateFixZoneRequest request);
+                       @RequestBody @Valid CreateFixZoneRequest request);
 
     @Operation(summary = "Fix Zone 수정 API")
     @PatchMapping(value = "/{fixZoneId}")
@@ -51,7 +52,7 @@ public interface ClubFixZoneApi {
     @SecurityRequirement(name = "AccessToken")
     void updateFixZone(
             @PathVariable("fixZoneId") Long fixZoneId,
-            @RequestBody UpdateFixZoneRequest request
+            @RequestBody @Valid UpdateFixZoneRequest request
     );
 
     @Operation(summary = "Fix Zone 삭제 API")

--- a/src/main/java/ddingdong/ddingdongBE/domain/fixzone/controller/dto/request/CreateFixZoneRequest.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/fixzone/controller/dto/request/CreateFixZoneRequest.java
@@ -22,9 +22,11 @@ public record CreateFixZoneRequest(
                 userId,
                 title,
                 content,
-                images.stream()
-                        .map(image -> new ImageInfo(image.id, image.order()))
-                        .toList()
+                (images != null) ?
+                        images.stream()
+                                .map(image -> new ImageInfo(image.id, image.order()))
+                                .toList() :
+                        List.of()
         );
     }
 

--- a/src/main/java/ddingdong/ddingdongBE/domain/fixzone/controller/dto/request/CreateFixZoneRequest.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/fixzone/controller/dto/request/CreateFixZoneRequest.java
@@ -1,6 +1,7 @@
 package ddingdong.ddingdongBE.domain.fixzone.controller.dto.request;
 
 import ddingdong.ddingdongBE.domain.fixzone.service.dto.command.CreateFixZoneCommand;
+import ddingdong.ddingdongBE.domain.fixzone.service.dto.command.CreateFixZoneCommand.ImageInfo;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 import java.util.List;
@@ -12,8 +13,8 @@ public record CreateFixZoneRequest(
         @NotNull
         @Schema(description = "내용")
         String content,
-        @Schema(description = "픽스존 이미지 식별자 목록", example = "[\"0192c828-ffce-7ee8-94a8-d9d4c8cdec00\", \"0192c828-ffce-7ee8-94a8-d9d4c8cdec00\"]")
-        List<String> fixZoneImageIds
+        @Schema(description = "픽스존 이미지 정보 목록")
+        List<ImageInfoRequest> images
 ) {
 
     public CreateFixZoneCommand toCommand(Long userId) {
@@ -21,8 +22,19 @@ public record CreateFixZoneRequest(
                 userId,
                 title,
                 content,
-                fixZoneImageIds
+                images.stream()
+                        .map(image -> new ImageInfo(image.id, image.order()))
+                        .toList()
         );
+    }
+
+    public record ImageInfoRequest(
+            @Schema(description = "이미지 식별자", example = "0192c828-ffce-7ee8-94a8-d9d4c8cdec00")
+            String id,
+            @Schema(description = "이미지 순서", example = "1")
+            int order
+    ) {
+
     }
 
 }

--- a/src/main/java/ddingdong/ddingdongBE/domain/fixzone/controller/dto/request/CreateFixZoneRequest.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/fixzone/controller/dto/request/CreateFixZoneRequest.java
@@ -3,6 +3,7 @@ package ddingdong.ddingdongBE.domain.fixzone.controller.dto.request;
 import ddingdong.ddingdongBE.domain.fixzone.service.dto.command.CreateFixZoneCommand;
 import ddingdong.ddingdongBE.domain.fixzone.service.dto.command.CreateFixZoneCommand.ImageInfo;
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
 import java.util.List;
 
@@ -34,6 +35,7 @@ public record CreateFixZoneRequest(
             @Schema(description = "이미지 식별자", example = "0192c828-ffce-7ee8-94a8-d9d4c8cdec00")
             String id,
             @Schema(description = "이미지 순서", example = "1")
+            @Min(value = 1, message = "이미지 순서는 1 이상이어야 합니다")
             int order
     ) {
 

--- a/src/main/java/ddingdong/ddingdongBE/domain/fixzone/controller/dto/request/CreateFixZoneRequest.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/fixzone/controller/dto/request/CreateFixZoneRequest.java
@@ -31,7 +31,7 @@ public record CreateFixZoneRequest(
         );
     }
 
-    public record ImageInfoRequest(
+    private record ImageInfoRequest(
             @Schema(description = "이미지 식별자", example = "0192c828-ffce-7ee8-94a8-d9d4c8cdec00")
             String id,
             @Schema(description = "이미지 순서", example = "1")

--- a/src/main/java/ddingdong/ddingdongBE/domain/fixzone/controller/dto/request/UpdateFixZoneRequest.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/fixzone/controller/dto/request/UpdateFixZoneRequest.java
@@ -31,7 +31,7 @@ public record UpdateFixZoneRequest(
         );
     }
 
-    public record ImageInfoRequest(
+    private record ImageInfoRequest(
             @Schema(description = "이미지 식별자", example = "0192c828-ffce-7ee8-94a8-d9d4c8cdec00")
             String id,
             @Schema(description = "이미지 순서", example = "1")

--- a/src/main/java/ddingdong/ddingdongBE/domain/fixzone/controller/dto/request/UpdateFixZoneRequest.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/fixzone/controller/dto/request/UpdateFixZoneRequest.java
@@ -1,6 +1,7 @@
 package ddingdong.ddingdongBE.domain.fixzone.controller.dto.request;
 
 import ddingdong.ddingdongBE.domain.fixzone.service.dto.command.UpdateFixZoneCommand;
+import ddingdong.ddingdongBE.domain.fixzone.service.dto.command.UpdateFixZoneCommand.ImageInfo;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 import java.util.List;
@@ -12,8 +13,8 @@ public record UpdateFixZoneRequest(
         @NotNull
         @Schema(description = "내용")
         String content,
-        @Schema(description = "픽스존 이미지 식별자 목록", example = "[\"0192c828-ffce-7ee8-94a8-d9d4c8cdec00\", \"0192c828-ffce-7ee8-94a8-d9d4c8cdec00\"]")
-        List<String> fixZoneImageIds
+        @Schema(description = "픽스존 이미지 정보 목록")
+        List<ImageInfoRequest> images
 ) {
 
     public UpdateFixZoneCommand toCommand(Long fixZoneId) {
@@ -21,8 +22,19 @@ public record UpdateFixZoneRequest(
                 fixZoneId,
                 title,
                 content,
-                fixZoneImageIds
+                images.stream()
+                        .map(image -> new ImageInfo(image.id(), image.order()))
+                        .toList()
         );
+    }
+
+    public record ImageInfoRequest(
+            @Schema(description = "이미지 식별자", example = "0192c828-ffce-7ee8-94a8-d9d4c8cdec00")
+            String id,
+            @Schema(description = "이미지 순서", example = "1")
+            int order
+    ) {
+
     }
 
 }

--- a/src/main/java/ddingdong/ddingdongBE/domain/fixzone/controller/dto/request/UpdateFixZoneRequest.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/fixzone/controller/dto/request/UpdateFixZoneRequest.java
@@ -3,6 +3,7 @@ package ddingdong.ddingdongBE.domain.fixzone.controller.dto.request;
 import ddingdong.ddingdongBE.domain.fixzone.service.dto.command.UpdateFixZoneCommand;
 import ddingdong.ddingdongBE.domain.fixzone.service.dto.command.UpdateFixZoneCommand.ImageInfo;
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
 import java.util.List;
 
@@ -34,6 +35,7 @@ public record UpdateFixZoneRequest(
             @Schema(description = "이미지 식별자", example = "0192c828-ffce-7ee8-94a8-d9d4c8cdec00")
             String id,
             @Schema(description = "이미지 순서", example = "1")
+            @Min(value = 1, message = "이미지 순서는 1 이상이어야 합니다")
             int order
     ) {
 

--- a/src/main/java/ddingdong/ddingdongBE/domain/fixzone/controller/dto/request/UpdateFixZoneRequest.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/fixzone/controller/dto/request/UpdateFixZoneRequest.java
@@ -22,9 +22,11 @@ public record UpdateFixZoneRequest(
                 fixZoneId,
                 title,
                 content,
-                images.stream()
-                        .map(image -> new ImageInfo(image.id(), image.order()))
-                        .toList()
+                (images != null) ?
+                        images.stream()
+                                .map(image -> new ImageInfo(image.id, image.order()))
+                                .toList() :
+                        List.of()
         );
     }
 

--- a/src/main/java/ddingdong/ddingdongBE/domain/fixzone/controller/dto/response/AdminFixZoneResponse.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/fixzone/controller/dto/response/AdminFixZoneResponse.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonFormat;
 import ddingdong.ddingdongBE.domain.fixzone.service.dto.query.AdminFixZoneQuery;
 import ddingdong.ddingdongBE.domain.fixzone.service.dto.query.AdminFixZoneQuery.FixZoneCommentQuery;
 import ddingdong.ddingdongBE.file.service.dto.query.UploadedFileUrlQuery;
+import ddingdong.ddingdongBE.file.service.dto.query.UploadedFileUrlWithOrderQuery;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalDateTime;
 import java.util.List;
@@ -54,17 +55,19 @@ public record AdminFixZoneResponse(
             description = "어드민 - 픽스존 이미지 URL 조회 응답"
     )
     record FixZoneImageUrlResponse(
+            @Schema(description = "이미지 순서", example = "1")
+            int order,
             @Schema(description = "원본 url", example = "url")
             String originUrl,
             @Schema(description = "cdn url", example = "url")
             String cdnUrl
     ) {
 
-        public static FixZoneImageUrlResponse from(UploadedFileUrlQuery query) {
+        public static FixZoneImageUrlResponse from(UploadedFileUrlWithOrderQuery query) {
             if (query == null) {
                 return null;
             }
-            return new FixZoneImageUrlResponse(query.originUrl(), query.cdnUrl());
+            return new FixZoneImageUrlResponse(query.order(), query.originUrl(), query.cdnUrl());
         }
 
     }

--- a/src/main/java/ddingdong/ddingdongBE/domain/fixzone/controller/dto/response/CentralFixZoneResponse.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/fixzone/controller/dto/response/CentralFixZoneResponse.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonFormat;
 import ddingdong.ddingdongBE.domain.fixzone.service.dto.query.CentralFixZoneQuery;
 import ddingdong.ddingdongBE.domain.fixzone.service.dto.query.CentralFixZoneQuery.FixZoneCommentQuery;
 import ddingdong.ddingdongBE.file.service.dto.query.UploadedFileUrlQuery;
+import ddingdong.ddingdongBE.file.service.dto.query.UploadedFileUrlWithOrderQuery;
 import io.swagger.v3.oas.annotations.media.ArraySchema;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalDateTime;
@@ -57,17 +58,19 @@ public record CentralFixZoneResponse(
     record FixZoneImageUrlResponse(
             @Schema(description = "파일 식별자", example = "0192c828-ffce-7ee8-94a8-d9d4c8cdec00l")
             String id,
+            @Schema(description = "이미지 순서", example = "1")
+            int order,
             @Schema(description = "원본 url", example = "url")
             String originUrl,
             @Schema(description = "cdn url", example = "url")
             String cdnUrl
     ) {
 
-        public static FixZoneImageUrlResponse from(UploadedFileUrlQuery query) {
+        public static FixZoneImageUrlResponse from(UploadedFileUrlWithOrderQuery query) {
             if (query == null) {
                 return null;
             }
-            return new FixZoneImageUrlResponse(query.id(), query.originUrl(), query.cdnUrl());
+            return new FixZoneImageUrlResponse(query.id(), query.order(), query.originUrl(), query.cdnUrl());
         }
 
     }

--- a/src/main/java/ddingdong/ddingdongBE/domain/fixzone/service/FacadeAdminFixZoneServiceImpl.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/fixzone/service/FacadeAdminFixZoneServiceImpl.java
@@ -8,6 +8,7 @@ import ddingdong.ddingdongBE.domain.fixzone.service.dto.query.AdminFixZoneListQu
 import ddingdong.ddingdongBE.domain.fixzone.service.dto.query.AdminFixZoneQuery;
 import ddingdong.ddingdongBE.file.service.S3FileService;
 import ddingdong.ddingdongBE.file.service.dto.query.UploadedFileUrlQuery;
+import ddingdong.ddingdongBE.file.service.dto.query.UploadedFileUrlWithOrderQuery;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -32,10 +33,11 @@ public class FacadeAdminFixZoneServiceImpl implements FacadeAdminFixZoneService 
     @Override
     public AdminFixZoneQuery getFixZone(Long fixZoneId) {
         FixZone fixZone = fixZoneService.getById(fixZoneId);
-        List<UploadedFileUrlQuery> imageUrlQueries = fileMetaDataService
+        List<UploadedFileUrlWithOrderQuery> imageUrlQueries = fileMetaDataService
                 .getCoupledAllByDomainTypeAndEntityId(DomainType.FIX_ZONE_IMAGE, fixZoneId)
                 .stream()
-                .map(fileMetaData -> s3FileService.getUploadedFileUrl(fileMetaData.getFileKey()))
+                .map(fileMetaData -> UploadedFileUrlWithOrderQuery.of(
+                        s3FileService.getUploadedFileUrl(fileMetaData.getFileKey()), fileMetaData.getOrder()))
                 .toList();
         Club club = fixZone.getClub();
         UploadedFileUrlQuery clubProfileImageQuery = fileMetaDataService

--- a/src/main/java/ddingdong/ddingdongBE/domain/fixzone/service/FacadeCentralFixZoneServiceImpl.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/fixzone/service/FacadeCentralFixZoneServiceImpl.java
@@ -36,7 +36,7 @@ public class FacadeCentralFixZoneServiceImpl implements FacadeCentralFixZoneServ
         Long createdFixZoneId = fixZoneService.save(createdFixZone);
 
         List<FileMetaDataIdOrderDto> imageFileMetaDataIdOrderDtos = command.imageInfos().stream()
-                .map(imageInfo -> FileMetaDataIdOrderDto.of(imageInfo.imagId(), imageInfo.order()))
+                .map(imageInfo -> FileMetaDataIdOrderDto.of(imageInfo.imageId(), imageInfo.order()))
                 .toList();
 
         fileMetaDataService.updateStatusToCoupledWithOrder(
@@ -82,7 +82,7 @@ public class FacadeCentralFixZoneServiceImpl implements FacadeCentralFixZoneServ
         FixZone fixZone = fixZoneService.getById(command.fixZoneId());
         fixZone.update(command.toEntity());
         List<FileMetaDataIdOrderDto> imageFileMetaDataIdOrderDtos = command.imageInfos().stream()
-                .map(imageInfo -> FileMetaDataIdOrderDto.of(imageInfo.imagId(), imageInfo.order()))
+                .map(imageInfo -> FileMetaDataIdOrderDto.of(imageInfo.imageId(), imageInfo.order()))
                 .toList();
         fileMetaDataService.updateWithOrder(imageFileMetaDataIdOrderDtos, DomainType.FIX_ZONE_IMAGE, fixZone.getId());
         return fixZone.getId();

--- a/src/main/java/ddingdong/ddingdongBE/domain/fixzone/service/dto/command/CreateFixZoneCommand.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/fixzone/service/dto/command/CreateFixZoneCommand.java
@@ -8,7 +8,7 @@ public record CreateFixZoneCommand(
         Long userId,
         String title,
         String content,
-        List<String> fixZoneImageIds
+        List<ImageInfo> imageInfos
 ) {
 
     public FixZone toEntity(Club club) {
@@ -18,6 +18,13 @@ public record CreateFixZoneCommand(
                 .content(content)
                 .isCompleted(false)
                 .build();
+    }
+
+    public record ImageInfo(
+            String imagId,
+            int order
+    ) {
+
     }
 
 }

--- a/src/main/java/ddingdong/ddingdongBE/domain/fixzone/service/dto/command/CreateFixZoneCommand.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/fixzone/service/dto/command/CreateFixZoneCommand.java
@@ -21,7 +21,7 @@ public record CreateFixZoneCommand(
     }
 
     public record ImageInfo(
-            String imagId,
+            String imageId,
             int order
     ) {
 

--- a/src/main/java/ddingdong/ddingdongBE/domain/fixzone/service/dto/command/UpdateFixZoneCommand.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/fixzone/service/dto/command/UpdateFixZoneCommand.java
@@ -7,7 +7,7 @@ public record UpdateFixZoneCommand(
         Long fixZoneId,
         String title,
         String content,
-        List<String> fixZoneImageIds
+        List<ImageInfo> imageInfos
 ) {
 
     public FixZone toEntity() {
@@ -15,6 +15,13 @@ public record UpdateFixZoneCommand(
                 .title(title)
                 .content(content)
                 .build();
+    }
+
+    public record ImageInfo(
+            String imagId,
+            int order
+    ) {
+
     }
 
 }

--- a/src/main/java/ddingdong/ddingdongBE/domain/fixzone/service/dto/command/UpdateFixZoneCommand.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/fixzone/service/dto/command/UpdateFixZoneCommand.java
@@ -18,7 +18,7 @@ public record UpdateFixZoneCommand(
     }
 
     public record ImageInfo(
-            String imagId,
+            String imageId,
             int order
     ) {
 

--- a/src/main/java/ddingdong/ddingdongBE/domain/fixzone/service/dto/query/AdminFixZoneQuery.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/fixzone/service/dto/query/AdminFixZoneQuery.java
@@ -3,6 +3,7 @@ package ddingdong.ddingdongBE.domain.fixzone.service.dto.query;
 import ddingdong.ddingdongBE.domain.fixzone.entity.FixZone;
 import ddingdong.ddingdongBE.domain.fixzone.entity.FixZoneComment;
 import ddingdong.ddingdongBE.file.service.dto.query.UploadedFileUrlQuery;
+import ddingdong.ddingdongBE.file.service.dto.query.UploadedFileUrlWithOrderQuery;
 import java.time.LocalDateTime;
 import java.util.List;
 
@@ -14,13 +15,13 @@ public record AdminFixZoneQuery(
         String content,
         boolean isCompleted,
         LocalDateTime requestedAt,
-        List<UploadedFileUrlQuery> imageUrlQueries,
+        List<UploadedFileUrlWithOrderQuery> imageUrlQueries,
         List<FixZoneCommentQuery> fixZoneCommentQueries
 ) {
 
     public static AdminFixZoneQuery of(
             FixZone fixZone,
-            List<UploadedFileUrlQuery> fixZoneImageUrlQueries,
+            List<UploadedFileUrlWithOrderQuery> fixZoneImageUrlQueries,
             UploadedFileUrlQuery commenterProfileImageUrlQuery) {
         return new AdminFixZoneQuery(
                 fixZone.getId(),

--- a/src/main/java/ddingdong/ddingdongBE/domain/fixzone/service/dto/query/CentralFixZoneQuery.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/fixzone/service/dto/query/CentralFixZoneQuery.java
@@ -3,6 +3,7 @@ package ddingdong.ddingdongBE.domain.fixzone.service.dto.query;
 import ddingdong.ddingdongBE.domain.fixzone.entity.FixZone;
 import ddingdong.ddingdongBE.domain.fixzone.entity.FixZoneComment;
 import ddingdong.ddingdongBE.file.service.dto.query.UploadedFileUrlQuery;
+import ddingdong.ddingdongBE.file.service.dto.query.UploadedFileUrlWithOrderQuery;
 import java.time.LocalDateTime;
 import java.util.List;
 
@@ -14,13 +15,13 @@ public record CentralFixZoneQuery(
         String content,
         boolean isCompleted,
         LocalDateTime requestedAt,
-        List<UploadedFileUrlQuery> imageUrlQueries,
+        List<UploadedFileUrlWithOrderQuery> imageUrlQueries,
         List<FixZoneCommentQuery> fixZoneCommentQueries
 ) {
 
     public static CentralFixZoneQuery of(
             FixZone fixZone,
-            List<UploadedFileUrlQuery> fixZoneImageUrlQueries,
+            List<UploadedFileUrlWithOrderQuery> fixZoneImageUrlQueries,
             UploadedFileUrlQuery commenterProfileImageUrlQuery) {
         return new CentralFixZoneQuery(
                 fixZone.getId(),

--- a/src/main/java/ddingdong/ddingdongBE/domain/notice/api/AdminNoticeApi.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/notice/api/AdminNoticeApi.java
@@ -7,6 +7,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -27,7 +28,7 @@ public interface AdminNoticeApi {
     @SecurityRequirement(name = "AccessToken")
     @PostMapping
     void createNotice(
-        @RequestBody CreateNoticeRequest request,
+        @RequestBody @Valid CreateNoticeRequest request,
         @AuthenticationPrincipal PrincipalDetails principalDetails
     );
 
@@ -38,7 +39,7 @@ public interface AdminNoticeApi {
     @PatchMapping("/{noticeId}")
     void updateNotice(
         @PathVariable("noticeId") Long noticeId,
-        @RequestBody UpdateNoticeRequest request
+        @RequestBody @Valid UpdateNoticeRequest request
     );
 
     @Operation(summary = "공지사항 삭제 API")

--- a/src/main/java/ddingdong/ddingdongBE/domain/notice/api/AdminNoticeApi.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/notice/api/AdminNoticeApi.java
@@ -37,7 +37,7 @@ public interface AdminNoticeApi {
     @SecurityRequirement(name = "AccessToken")
     @PatchMapping("/{noticeId}")
     void updateNotice(
-        @PathVariable Long noticeId,
+        @PathVariable("noticeId") Long noticeId,
         @RequestBody UpdateNoticeRequest request
     );
 
@@ -46,6 +46,6 @@ public interface AdminNoticeApi {
     @ResponseStatus(HttpStatus.NO_CONTENT)
     @SecurityRequirement(name = "AccessToken")
     @DeleteMapping("/{noticeId}")
-    void deleteNotice(@PathVariable Long noticeId);
+    void deleteNotice(@PathVariable("noticeId") Long noticeId);
 
 }

--- a/src/main/java/ddingdong/ddingdongBE/domain/notice/api/NoticeApi.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/notice/api/NoticeApi.java
@@ -30,6 +30,6 @@ public interface NoticeApi {
         content = @Content(schema = @Schema(implementation = NoticeResponse.class)))
     @ResponseStatus(HttpStatus.OK)
     @GetMapping("/{noticeId}")
-    NoticeResponse getNotice(@PathVariable Long noticeId);
+    NoticeResponse getNotice(@PathVariable("noticeId") Long noticeId);
 
 }

--- a/src/main/java/ddingdong/ddingdongBE/domain/notice/controller/AdminNoticeController.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/notice/controller/AdminNoticeController.java
@@ -28,7 +28,7 @@ public class AdminNoticeController implements AdminNoticeApi {
     }
 
     @Override
-    public void deleteNotice(@PathVariable Long noticeId) {
+    public void deleteNotice(Long noticeId) {
         facadeAdminNoticeService.delete(noticeId);
     }
 

--- a/src/main/java/ddingdong/ddingdongBE/domain/notice/controller/NoticeController.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/notice/controller/NoticeController.java
@@ -20,13 +20,13 @@ public class NoticeController implements NoticeApi {
     @Override
     public NoticeListResponse getNoticeList(GetNoticePagingRequest request) {
         NoticeListPagingQuery noticeListPagingQuery = facadeNoticeServiceImpl.getNoticeList(
-            request.toCommand());
+                request.toCommand());
 
         return NoticeListResponse.from(noticeListPagingQuery);
     }
 
     @Override
-    public NoticeResponse getNotice(@PathVariable Long noticeId) {
+    public NoticeResponse getNotice(Long noticeId) {
         NoticeQuery query = facadeNoticeServiceImpl.getNotice(noticeId);
         return NoticeResponse.from(query);
     }

--- a/src/main/java/ddingdong/ddingdongBE/domain/notice/controller/dto/request/CreateNoticeRequest.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/notice/controller/dto/request/CreateNoticeRequest.java
@@ -5,6 +5,7 @@ import ddingdong.ddingdongBE.domain.notice.service.dto.command.CreateNoticeComma
 import ddingdong.ddingdongBE.domain.notice.service.dto.command.CreateNoticeCommand.ImageInfo;
 import ddingdong.ddingdongBE.domain.user.entity.User;
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
 import java.util.List;
 
@@ -46,6 +47,7 @@ public record CreateNoticeRequest(
             @Schema(description = "이미지 식별자", example = "0192c828-ffce-7ee8-94a8-d9d4c8cdec00")
             String id,
             @Schema(description = "이미지 순서", example = "1")
+            @Min(value = 1, message = "이미지 순서는 1 이상이어야 합니다")
             int order
     ) {
 
@@ -55,6 +57,7 @@ public record CreateNoticeRequest(
             @Schema(description = "파일 식별자", example = "0192c828-ffce-7ee8-94a8-d9d4c8cdec00")
             String id,
             @Schema(description = "파일 순서", example = "1")
+            @Min(value = 1, message = "파일 순서는 1 이상이어야 합니다")
             int order
     ) {
 

--- a/src/main/java/ddingdong/ddingdongBE/domain/notice/controller/dto/request/CreateNoticeRequest.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/notice/controller/dto/request/CreateNoticeRequest.java
@@ -43,7 +43,7 @@ public record CreateNoticeRequest(
                 .build();
     }
 
-    public record ImageInfoRequest(
+    private record ImageInfoRequest(
             @Schema(description = "이미지 식별자", example = "0192c828-ffce-7ee8-94a8-d9d4c8cdec00")
             String id,
             @Schema(description = "이미지 순서", example = "1")
@@ -53,7 +53,7 @@ public record CreateNoticeRequest(
 
     }
 
-    public record FileInfoRequest(
+    private record FileInfoRequest(
             @Schema(description = "파일 식별자", example = "0192c828-ffce-7ee8-94a8-d9d4c8cdec00")
             String id,
             @Schema(description = "파일 순서", example = "1")

--- a/src/main/java/ddingdong/ddingdongBE/domain/notice/controller/dto/request/CreateNoticeRequest.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/notice/controller/dto/request/CreateNoticeRequest.java
@@ -29,12 +29,16 @@ public record CreateNoticeRequest(
                 .user(user)
                 .title(title)
                 .content(content)
-                .imageInfos(images.stream()
-                        .map(image -> new ImageInfo(image.id, image.order()))
-                        .toList())
-                .fileInfos(files.stream()
-                        .map(file -> new FileInfo(file.id, file.order()))
-                        .toList())
+                .imageInfos((images != null) ?
+                        images.stream()
+                                .map(image -> new ImageInfo(image.id, image.order()))
+                                .toList() :
+                        List.of())
+                .fileInfos((files != null) ?
+                        files.stream()
+                                .map(file -> new FileInfo(file.id, file.order()))
+                                .toList() :
+                        List.of())
                 .build();
     }
 

--- a/src/main/java/ddingdong/ddingdongBE/domain/notice/controller/dto/request/CreateNoticeRequest.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/notice/controller/dto/request/CreateNoticeRequest.java
@@ -1,35 +1,59 @@
 package ddingdong.ddingdongBE.domain.notice.controller.dto.request;
 
 import ddingdong.ddingdongBE.domain.notice.service.dto.command.CreateNoticeCommand;
+import ddingdong.ddingdongBE.domain.notice.service.dto.command.CreateNoticeCommand.FileInfo;
+import ddingdong.ddingdongBE.domain.notice.service.dto.command.CreateNoticeCommand.ImageInfo;
 import ddingdong.ddingdongBE.domain.user.entity.User;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 import java.util.List;
 
 public record CreateNoticeRequest(
-    @NotNull(message = "공지사항 제목은 필수 입력 사항입니다.")
-    @Schema(description = "공지사항 제목", example = "공지사항 제목")
-    String title,
+        @NotNull(message = "공지사항 제목은 필수 입력 사항입니다.")
+        @Schema(description = "공지사항 제목", example = "공지사항 제목")
+        String title,
 
-    @NotNull(message = "공지사항 내용은 필수 입력 사항입니다.")
-    @Schema(description = "공지사항 내용", example = "공지사항 내용")
-    String content,
+        @NotNull(message = "공지사항 내용은 필수 입력 사항입니다.")
+        @Schema(description = "공지사항 내용", example = "공지사항 내용")
+        String content,
 
-    @Schema(description = "공지사항 이미지 식별자 목록", example = "[\"0192c828-ffce-7ee8-94a8-d9d4c8cdec00\", \"0192c828-ffce-7ee8-94a8-d9d4c8cdec00\"]")
-    List<String> imageIds,
+        @Schema(description = "공지사항 이미지 정보 목록")
+        List<ImageInfoRequest> images,
 
-    @Schema(description = "공지사항 파일 식별자 목록", example = "[\"0192c828-ffce-7ee8-94a8-d9d4c8cdec00\", \"0192c828-ffce-7ee8-94a8-d9d4c8cdec00\"]")
-    List<String> fileIds
+        @Schema(description = "공지사항 파일 정보 목록")
+        List<FileInfoRequest> files
 ) {
 
     public CreateNoticeCommand toCommand(User user) {
         return CreateNoticeCommand.builder()
-            .user(user)
-            .title(title)
-            .content(content)
-            .imageIds(imageIds)
-            .fileIds(fileIds)
-            .build();
+                .user(user)
+                .title(title)
+                .content(content)
+                .imageInfos(images.stream()
+                        .map(image -> new ImageInfo(image.id, image.order()))
+                        .toList())
+                .fileInfos(files.stream()
+                        .map(file -> new FileInfo(file.id, file.order()))
+                        .toList())
+                .build();
+    }
+
+    public record ImageInfoRequest(
+            @Schema(description = "이미지 식별자", example = "0192c828-ffce-7ee8-94a8-d9d4c8cdec00")
+            String id,
+            @Schema(description = "이미지 순서", example = "1")
+            int order
+    ) {
+
+    }
+
+    public record FileInfoRequest(
+            @Schema(description = "파일 식별자", example = "0192c828-ffce-7ee8-94a8-d9d4c8cdec00")
+            String id,
+            @Schema(description = "파일 순서", example = "1")
+            int order
+    ) {
+
     }
 
 }

--- a/src/main/java/ddingdong/ddingdongBE/domain/notice/controller/dto/request/UpdateNoticeRequest.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/notice/controller/dto/request/UpdateNoticeRequest.java
@@ -29,11 +29,7 @@ public record UpdateNoticeRequest(
                 .noticeId(noticeId)
                 .title(title)
                 .content(content)
-                .imageInfos((images != null) ?
-                        images.stream()
-                                .map(image -> new ImageInfo(image.id, image.order()))
-                                .toList() :
-                        List.of())
+                .imageInfos(getImageInfos())
                 .fileInfos((files != null) ?
                         files.stream()
                                 .map(file -> new FileInfo(file.id, file.order()))
@@ -42,7 +38,15 @@ public record UpdateNoticeRequest(
                 .build();
     }
 
-    public record ImageInfoRequest(
+    private List<ImageInfo> getImageInfos() {
+        return (images != null) ?
+                images.stream()
+                        .map(image -> new ImageInfo(image.id, image.order()))
+                        .toList() :
+                List.of();
+    }
+
+    private record ImageInfoRequest(
             @Schema(description = "이미지 식별자", example = "0192c828-ffce-7ee8-94a8-d9d4c8cdec00")
             String id,
             @Schema(description = "이미지 순서", example = "1")
@@ -52,7 +56,7 @@ public record UpdateNoticeRequest(
 
     }
 
-    public record FileInfoRequest(
+    private record FileInfoRequest(
             @Schema(description = "파일 식별자", example = "0192c828-ffce-7ee8-94a8-d9d4c8cdec00")
             String id,
             @Schema(description = "파일 순서", example = "1")

--- a/src/main/java/ddingdong/ddingdongBE/domain/notice/controller/dto/request/UpdateNoticeRequest.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/notice/controller/dto/request/UpdateNoticeRequest.java
@@ -1,34 +1,58 @@
 package ddingdong.ddingdongBE.domain.notice.controller.dto.request;
 
 import ddingdong.ddingdongBE.domain.notice.service.dto.command.UpdateNoticeCommand;
+import ddingdong.ddingdongBE.domain.notice.service.dto.command.UpdateNoticeCommand.FileInfo;
+import ddingdong.ddingdongBE.domain.notice.service.dto.command.UpdateNoticeCommand.ImageInfo;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 import java.util.List;
 
 public record UpdateNoticeRequest(
-    @NotNull(message = "공지사항 제목은 필수 입력 사항입니다.")
-    @Schema(description = "공지사항 제목", example = "공지사항 제목")
-    String title,
+        @NotNull(message = "공지사항 제목은 필수 입력 사항입니다.")
+        @Schema(description = "공지사항 제목", example = "공지사항 제목")
+        String title,
 
-    @NotNull(message = "공지사항 내용은 필수 입력 사항입니다.")
-    @Schema(description = "공지사항 내용", example = "공지사항 내용")
-    String content,
+        @NotNull(message = "공지사항 내용은 필수 입력 사항입니다.")
+        @Schema(description = "공지사항 내용", example = "공지사항 내용")
+        String content,
 
-    @Schema(description = "공지사항 이미지 식별자 목록", example = "[\"0192c828-ffce-7ee8-94a8-d9d4c8cdec00\", \"0192c828-ffce-7ee8-94a8-d9d4c8cdec00\"]")
-    List<String> imageIds,
+        @Schema(description = "공지사항 이미지 정보 목록")
+        List<ImageInfoRequest> images,
 
-    @Schema(description = "공지사항 파일 식별자 목록", example = "[\"0192c828-ffce-7ee8-94a8-d9d4c8cdec00\", \"0192c828-ffce-7ee8-94a8-d9d4c8cdec00\"]")
-    List<String> fileIds
+        @Schema(description = "공지사항 파일 정보 목록")
+        List<FileInfoRequest> files
 ) {
 
     public UpdateNoticeCommand toCommand(Long noticeId) {
         return UpdateNoticeCommand.builder()
-            .noticeId(noticeId)
-            .title(title)
-            .content(content)
-            .imageIds(imageIds)
-            .fileIds(fileIds)
-            .build();
+                .noticeId(noticeId)
+                .title(title)
+                .content(content)
+                .imageInfos(images.stream()
+                        .map(image -> new ImageInfo(image.id, image.order()))
+                        .toList())
+                .fileInfos(files.stream()
+                        .map(file -> new FileInfo(file.id, file.order()))
+                        .toList())
+                .build();
+    }
+
+    public record ImageInfoRequest(
+            @Schema(description = "이미지 식별자", example = "0192c828-ffce-7ee8-94a8-d9d4c8cdec00")
+            String id,
+            @Schema(description = "이미지 순서", example = "1")
+            int order
+    ) {
+
+    }
+
+    public record FileInfoRequest(
+            @Schema(description = "파일 식별자", example = "0192c828-ffce-7ee8-94a8-d9d4c8cdec00")
+            String id,
+            @Schema(description = "파일 순서", example = "1")
+            int order
+    ) {
+
     }
 
 }

--- a/src/main/java/ddingdong/ddingdongBE/domain/notice/controller/dto/request/UpdateNoticeRequest.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/notice/controller/dto/request/UpdateNoticeRequest.java
@@ -4,6 +4,7 @@ import ddingdong.ddingdongBE.domain.notice.service.dto.command.UpdateNoticeComma
 import ddingdong.ddingdongBE.domain.notice.service.dto.command.UpdateNoticeCommand.FileInfo;
 import ddingdong.ddingdongBE.domain.notice.service.dto.command.UpdateNoticeCommand.ImageInfo;
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
 import java.util.List;
 
@@ -45,6 +46,7 @@ public record UpdateNoticeRequest(
             @Schema(description = "이미지 식별자", example = "0192c828-ffce-7ee8-94a8-d9d4c8cdec00")
             String id,
             @Schema(description = "이미지 순서", example = "1")
+            @Min(value = 1, message = "이미지 순서는 1 이상이어야 합니다")
             int order
     ) {
 
@@ -54,6 +56,7 @@ public record UpdateNoticeRequest(
             @Schema(description = "파일 식별자", example = "0192c828-ffce-7ee8-94a8-d9d4c8cdec00")
             String id,
             @Schema(description = "파일 순서", example = "1")
+            @Min(value = 1, message = "파일 순서는 1 이상이어야 합니다")
             int order
     ) {
 

--- a/src/main/java/ddingdong/ddingdongBE/domain/notice/controller/dto/request/UpdateNoticeRequest.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/notice/controller/dto/request/UpdateNoticeRequest.java
@@ -28,12 +28,16 @@ public record UpdateNoticeRequest(
                 .noticeId(noticeId)
                 .title(title)
                 .content(content)
-                .imageInfos(images.stream()
-                        .map(image -> new ImageInfo(image.id, image.order()))
-                        .toList())
-                .fileInfos(files.stream()
-                        .map(file -> new FileInfo(file.id, file.order()))
-                        .toList())
+                .imageInfos((images != null) ?
+                        images.stream()
+                                .map(image -> new ImageInfo(image.id, image.order()))
+                                .toList() :
+                        List.of())
+                .fileInfos((files != null) ?
+                        files.stream()
+                                .map(file -> new FileInfo(file.id, file.order()))
+                                .toList() :
+                        List.of())
                 .build();
     }
 

--- a/src/main/java/ddingdong/ddingdongBE/domain/notice/controller/dto/response/NoticeResponse.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/notice/controller/dto/response/NoticeResponse.java
@@ -1,8 +1,8 @@
 package ddingdong.ddingdongBE.domain.notice.controller.dto.response;
 
 import ddingdong.ddingdongBE.domain.notice.service.dto.query.NoticeQuery;
-import ddingdong.ddingdongBE.file.service.dto.query.UploadedFileUrlAndNameQuery;
-import ddingdong.ddingdongBE.file.service.dto.query.UploadedFileUrlQuery;
+import ddingdong.ddingdongBE.file.service.dto.query.UploadedFileUrlAndNameWithOrderQuery;
+import ddingdong.ddingdongBE.file.service.dto.query.UploadedFileUrlWithOrderQuery;
 import io.swagger.v3.oas.annotations.media.ArraySchema;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalDateTime;
@@ -11,30 +11,84 @@ import lombok.Builder;
 
 @Builder
 public record NoticeResponse(
-    @Schema(description = "공지사항 제목", example = "공지사항 제목입니다")
-    String title,
+        @Schema(description = "공지사항 제목", example = "공지사항 제목입니다")
+        String title,
 
-    @Schema(description = "공지사항 내용", example = "카우 공지사항 내용입니다")
-    String content,
+        @Schema(description = "공지사항 내용", example = "카우 공지사항 내용입니다")
+        String content,
 
-    @Schema(description = "공지사항 생성 날짜 및 시간", example = "2024-01-01 12:12")
-    LocalDateTime createdAt,
+        @Schema(description = "공지사항 생성 날짜 및 시간", example = "2024-01-01 12:12")
+        LocalDateTime createdAt,
 
-    @ArraySchema(schema = @Schema(description = "이미지 Urls", example = "https://%s.s3.%s.amazonaws.com/%s/%s/%s"))
-    List<UploadedFileUrlQuery> images,
+        @ArraySchema(schema = @Schema(description = "이미지 정보"))
+        List<NoticeImageUrlResponse> images,
 
-    @ArraySchema(schema = @Schema(description = "파일 상세 정보"))
-    List<UploadedFileUrlAndNameQuery> files
+        @ArraySchema(schema = @Schema(description = "파일 정보"))
+        List<NoticeFileUrlResponse> files
 ) {
 
     public static NoticeResponse from(NoticeQuery query) {
         return NoticeResponse.builder()
-            .title(query.title())
-            .content(query.content())
-            .createdAt(query.createdAt())
-            .images(query.images())
-            .files(query.files())
-            .build();
+                .title(query.title())
+                .content(query.content())
+                .createdAt(query.createdAt())
+                .images(query.images().stream()
+                        .map(NoticeImageUrlResponse::from)
+                        .toList())
+                .files(query.files().stream()
+                        .map(NoticeFileUrlResponse::from)
+                        .toList())
+                .build();
+    }
+
+    @Schema(
+            name = "NoticeImageUrlResponse",
+            description = "공지사항 이미지 정보 조회 응답"
+    )
+    public record NoticeImageUrlResponse(
+            @Schema(description = "파일 식별자", example = "0192c828-ffce-7ee8-94a8-d9d4c8cdec00")
+            String id,
+            @Schema(description = "이미지 순서", example = "1")
+            int order,
+            @Schema(description = "원본 url", example = "url")
+            String originUrl,
+            @Schema(description = "cdn url", example = "url")
+            String cdnUrl
+    ) {
+
+        public static NoticeImageUrlResponse from(UploadedFileUrlWithOrderQuery query) {
+            return new NoticeImageUrlResponse(query.id(), query.order(), query.originUrl(), query.cdnUrl());
+        }
+
+    }
+
+    @Schema(
+            name = "NoticeFileUrlResponse",
+            description = "공지사항 파일 정보 조회 응답"
+    )
+    public record NoticeFileUrlResponse(
+            @Schema(description = "파일 식별자", example = "0192c828-ffce-7ee8-94a8-d9d4c8cdec00")
+            String id,
+            @Schema(description = "파일 순서", example = "1")
+            int order,
+            @Schema(description = "파일 이름", example = "파일명")
+            String fileName,
+            @Schema(description = "원본 url", example = "url")
+            String originUrl,
+            @Schema(description = "cdn url", example = "url")
+            String cdnUrl
+    ) {
+
+        public static NoticeFileUrlResponse from(UploadedFileUrlAndNameWithOrderQuery query) {
+            return new NoticeFileUrlResponse(
+                    query.id(),
+                    query.order(),
+                    query.fileName(),
+                    query.originUrl(),
+                    query.cdnUrl()
+            );
+        }
+
     }
 
 }

--- a/src/main/java/ddingdong/ddingdongBE/domain/notice/service/FacadeAdminNoticeServiceImpl.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/notice/service/FacadeAdminNoticeServiceImpl.java
@@ -5,8 +5,6 @@ import ddingdong.ddingdongBE.domain.filemetadata.service.FileMetaDataService;
 import ddingdong.ddingdongBE.domain.filemetadata.service.dto.FileMetaDataIdOrderDto;
 import ddingdong.ddingdongBE.domain.notice.entity.Notice;
 import ddingdong.ddingdongBE.domain.notice.service.dto.command.CreateNoticeCommand;
-import ddingdong.ddingdongBE.domain.notice.service.dto.command.CreateNoticeCommand.FileInfo;
-import ddingdong.ddingdongBE.domain.notice.service.dto.command.CreateNoticeCommand.ImageInfo;
 import ddingdong.ddingdongBE.domain.notice.service.dto.command.UpdateNoticeCommand;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -50,7 +48,7 @@ public class FacadeAdminNoticeServiceImpl implements FacadeAdminNoticeService {
         notice.update(command.toEntity());
 
         List<FileMetaDataIdOrderDto> imageFileMetaDataIdOrderDtos = command.imageInfos().stream()
-                .map(imageInfo -> FileMetaDataIdOrderDto.of(imageInfo.imagId(), imageInfo.order()))
+                .map(imageInfo -> FileMetaDataIdOrderDto.of(imageInfo.imageId(), imageInfo.order()))
                 .toList();
 
         List<FileMetaDataIdOrderDto> fileFileMetaDataIdOrderDtos = command.fileInfos().stream()

--- a/src/main/java/ddingdong/ddingdongBE/domain/notice/service/FacadeAdminNoticeServiceImpl.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/notice/service/FacadeAdminNoticeServiceImpl.java
@@ -25,7 +25,7 @@ public class FacadeAdminNoticeServiceImpl implements FacadeAdminNoticeService {
         Long createdNoticeId = noticeService.save(notice);
 
         List<FileMetaDataIdOrderDto> imageFileMetaDataIdOrderDtos = command.imageInfos().stream()
-                .map(imageInfo -> FileMetaDataIdOrderDto.of(imageInfo.imagId(), imageInfo.order()))
+                .map(imageInfo -> FileMetaDataIdOrderDto.of(imageInfo.imageId(), imageInfo.order()))
                 .toList();
 
         List<FileMetaDataIdOrderDto> fileFileMetaDataIdOrderDtos = command.fileInfos().stream()

--- a/src/main/java/ddingdong/ddingdongBE/domain/notice/service/FacadeAdminNoticeServiceImpl.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/notice/service/FacadeAdminNoticeServiceImpl.java
@@ -2,9 +2,13 @@ package ddingdong.ddingdongBE.domain.notice.service;
 
 import ddingdong.ddingdongBE.domain.filemetadata.entity.DomainType;
 import ddingdong.ddingdongBE.domain.filemetadata.service.FileMetaDataService;
+import ddingdong.ddingdongBE.domain.filemetadata.service.dto.FileMetaDataIdOrderDto;
 import ddingdong.ddingdongBE.domain.notice.entity.Notice;
 import ddingdong.ddingdongBE.domain.notice.service.dto.command.CreateNoticeCommand;
+import ddingdong.ddingdongBE.domain.notice.service.dto.command.CreateNoticeCommand.FileInfo;
+import ddingdong.ddingdongBE.domain.notice.service.dto.command.CreateNoticeCommand.ImageInfo;
 import ddingdong.ddingdongBE.domain.notice.service.dto.command.UpdateNoticeCommand;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -22,10 +26,22 @@ public class FacadeAdminNoticeServiceImpl implements FacadeAdminNoticeService {
         Notice notice = command.toEntity();
         Long createdNoticeId = noticeService.save(notice);
 
-        fileMetaDataService.updateStatusToCoupled(command.imageIds(), DomainType.NOTICE_IMAGE,
-            createdNoticeId);
-        fileMetaDataService.updateStatusToCoupled(command.fileIds(), DomainType.NOTICE_FILE,
-            createdNoticeId);
+        List<FileMetaDataIdOrderDto> imageFileMetaDataIdOrderDtos = command.imageInfos().stream()
+                .map(imageInfo -> FileMetaDataIdOrderDto.of(imageInfo.imagId(), imageInfo.order()))
+                .toList();
+
+        List<FileMetaDataIdOrderDto> fileFileMetaDataIdOrderDtos = command.fileInfos().stream()
+                .map(fileInfo -> FileMetaDataIdOrderDto.of(fileInfo.fileId(), fileInfo.order()))
+                .toList();
+
+        fileMetaDataService.updateStatusToCoupledWithOrder(
+                imageFileMetaDataIdOrderDtos,
+                DomainType.NOTICE_IMAGE,
+                createdNoticeId);
+        fileMetaDataService.updateStatusToCoupledWithOrder(
+                fileFileMetaDataIdOrderDtos,
+                DomainType.NOTICE_FILE,
+                createdNoticeId);
     }
 
     @Transactional
@@ -33,10 +49,18 @@ public class FacadeAdminNoticeServiceImpl implements FacadeAdminNoticeService {
         Notice notice = noticeService.getById(command.noticeId());
         notice.update(command.toEntity());
 
-        fileMetaDataService.update(command.imageIds(), DomainType.NOTICE_IMAGE,
-            command.noticeId());
-        fileMetaDataService.update(command.fileIds(), DomainType.NOTICE_FILE,
-            command.noticeId());
+        List<FileMetaDataIdOrderDto> imageFileMetaDataIdOrderDtos = command.imageInfos().stream()
+                .map(imageInfo -> FileMetaDataIdOrderDto.of(imageInfo.imagId(), imageInfo.order()))
+                .toList();
+
+        List<FileMetaDataIdOrderDto> fileFileMetaDataIdOrderDtos = command.fileInfos().stream()
+                .map(fileInfo -> FileMetaDataIdOrderDto.of(fileInfo.fileId(), fileInfo.order()))
+                .toList();
+
+        fileMetaDataService.updateWithOrder(imageFileMetaDataIdOrderDtos, DomainType.NOTICE_IMAGE,
+                command.noticeId());
+        fileMetaDataService.updateWithOrder(fileFileMetaDataIdOrderDtos, DomainType.NOTICE_FILE,
+                command.noticeId());
     }
 
     @Transactional

--- a/src/main/java/ddingdong/ddingdongBE/domain/notice/service/dto/command/CreateNoticeCommand.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/notice/service/dto/command/CreateNoticeCommand.java
@@ -7,19 +7,33 @@ import lombok.Builder;
 
 @Builder
 public record CreateNoticeCommand(
-    User user,
-    String title,
-    String content,
-    List<String> imageIds,
-    List<String> fileIds
+        User user,
+        String title,
+        String content,
+        List<ImageInfo> imageInfos,
+        List<FileInfo> fileInfos
 ) {
 
     public Notice toEntity() {
         return Notice.builder()
-            .user(user)
-            .title(title)
-            .content(content)
-            .build();
+                .user(user)
+                .title(title)
+                .content(content)
+                .build();
+    }
+
+    public record ImageInfo(
+            String imagId,
+            int order
+    ) {
+
+    }
+
+    public record FileInfo(
+            String fileId,
+            int order
+    ) {
+
     }
 
 }

--- a/src/main/java/ddingdong/ddingdongBE/domain/notice/service/dto/command/CreateNoticeCommand.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/notice/service/dto/command/CreateNoticeCommand.java
@@ -23,7 +23,7 @@ public record CreateNoticeCommand(
     }
 
     public record ImageInfo(
-            String imagId,
+            String imageId,
             int order
     ) {
 

--- a/src/main/java/ddingdong/ddingdongBE/domain/notice/service/dto/command/UpdateNoticeCommand.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/notice/service/dto/command/UpdateNoticeCommand.java
@@ -9,8 +9,8 @@ public record UpdateNoticeCommand(
     Long noticeId,
     String title,
     String content,
-    List<String> imageIds,
-    List<String> fileIds
+    List<ImageInfo> imageInfos,
+    List<FileInfo> fileInfos
 ) {
 
     public Notice toEntity() {
@@ -18,6 +18,20 @@ public record UpdateNoticeCommand(
             .title(title)
             .content(content)
             .build();
+    }
+
+    public record ImageInfo(
+            String imagId,
+            int order
+    ) {
+
+    }
+
+    public record FileInfo(
+            String fileId,
+            int order
+    ) {
+
     }
 
 }

--- a/src/main/java/ddingdong/ddingdongBE/domain/notice/service/dto/command/UpdateNoticeCommand.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/notice/service/dto/command/UpdateNoticeCommand.java
@@ -21,7 +21,7 @@ public record UpdateNoticeCommand(
     }
 
     public record ImageInfo(
-            String imagId,
+            String imageId,
             int order
     ) {
 

--- a/src/main/java/ddingdong/ddingdongBE/domain/notice/service/dto/query/NoticeQuery.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/notice/service/dto/query/NoticeQuery.java
@@ -1,29 +1,32 @@
 package ddingdong.ddingdongBE.domain.notice.service.dto.query;
 
 import ddingdong.ddingdongBE.domain.notice.entity.Notice;
-import ddingdong.ddingdongBE.file.service.dto.query.UploadedFileUrlAndNameQuery;
-import ddingdong.ddingdongBE.file.service.dto.query.UploadedFileUrlQuery;
+import ddingdong.ddingdongBE.file.service.dto.query.UploadedFileUrlAndNameWithOrderQuery;
+import ddingdong.ddingdongBE.file.service.dto.query.UploadedFileUrlWithOrderQuery;
 import java.time.LocalDateTime;
 import java.util.List;
 import lombok.Builder;
 
 @Builder
 public record NoticeQuery(
-    String title,
-    String content,
-    LocalDateTime createdAt,
-    List<UploadedFileUrlQuery> images,
-    List<UploadedFileUrlAndNameQuery> files
+        String title,
+        String content,
+        LocalDateTime createdAt,
+        List<UploadedFileUrlWithOrderQuery> images,
+        List<UploadedFileUrlAndNameWithOrderQuery> files
 ) {
 
-    public static NoticeQuery of(Notice notice, List<UploadedFileUrlQuery> images,
-        List<UploadedFileUrlAndNameQuery> files) {
+    public static NoticeQuery of(
+            Notice notice,
+            List<UploadedFileUrlWithOrderQuery> images,
+            List<UploadedFileUrlAndNameWithOrderQuery> files
+    ) {
         return NoticeQuery.builder()
-            .title(notice.getTitle())
-            .content(notice.getContent())
-            .createdAt(notice.getCreatedAt())
-            .images(images)
-            .files(files)
-            .build();
+                .title(notice.getTitle())
+                .content(notice.getContent())
+                .createdAt(notice.getCreatedAt())
+                .images(images)
+                .files(files)
+                .build();
     }
 }

--- a/src/main/java/ddingdong/ddingdongBE/file/service/dto/query/UploadedFileUrlAndNameWithOrderQuery.java
+++ b/src/main/java/ddingdong/ddingdongBE/file/service/dto/query/UploadedFileUrlAndNameWithOrderQuery.java
@@ -1,0 +1,20 @@
+package ddingdong.ddingdongBE.file.service.dto.query;
+
+public record UploadedFileUrlAndNameWithOrderQuery(
+        String id,
+        int order,
+        String fileName,
+        String originUrl,
+        String cdnUrl
+) {
+
+    public static UploadedFileUrlAndNameWithOrderQuery of(UploadedFileUrlAndNameQuery query, int order) {
+        return new UploadedFileUrlAndNameWithOrderQuery(
+                query.id(),
+                order,
+                query.fileName(),
+                query.originUrl(),
+                query.cdnUrl());
+    }
+
+}

--- a/src/main/java/ddingdong/ddingdongBE/file/service/dto/query/UploadedFileUrlWithOrderQuery.java
+++ b/src/main/java/ddingdong/ddingdongBE/file/service/dto/query/UploadedFileUrlWithOrderQuery.java
@@ -1,0 +1,18 @@
+package ddingdong.ddingdongBE.file.service.dto.query;
+
+public record UploadedFileUrlWithOrderQuery(
+        String id,
+        int order,
+        String originUrl,
+        String cdnUrl
+) {
+
+    public static UploadedFileUrlWithOrderQuery of(UploadedFileUrlQuery query, int order) {
+        return new UploadedFileUrlWithOrderQuery(
+                query.id(),
+                order,
+                query.originUrl(),
+                query.cdnUrl());
+    }
+
+}

--- a/src/main/resources/db/migration/V30__alter_table_file_meta_data_add_column_order.sql
+++ b/src/main/resources/db/migration/V30__alter_table_file_meta_data_add_column_order.sql
@@ -1,0 +1,2 @@
+ALTER TABLE file_meta_data
+    ADD file_meta_data_order INT DEFAULT 0  Not NULL;

--- a/src/test/java/ddingdong/ddingdongBE/domain/fixzone/service/FacadeCentralGeneralFixZoneServiceTest.java
+++ b/src/test/java/ddingdong/ddingdongBE/domain/fixzone/service/FacadeCentralGeneralFixZoneServiceTest.java
@@ -16,6 +16,7 @@ import ddingdong.ddingdongBE.domain.filemetadata.repository.FileMetaDataReposito
 import ddingdong.ddingdongBE.domain.fixzone.entity.FixZone;
 import ddingdong.ddingdongBE.domain.fixzone.repository.FixZoneRepository;
 import ddingdong.ddingdongBE.domain.fixzone.service.dto.command.CreateFixZoneCommand;
+import ddingdong.ddingdongBE.domain.fixzone.service.dto.command.CreateFixZoneCommand.ImageInfo;
 import ddingdong.ddingdongBE.domain.fixzone.service.dto.command.UpdateFixZoneCommand;
 import ddingdong.ddingdongBE.domain.fixzone.service.dto.query.CentralFixZoneQuery;
 import ddingdong.ddingdongBE.domain.fixzone.service.dto.query.CentralMyFixZoneListQuery;
@@ -68,7 +69,7 @@ class FacadeCentralGeneralFixZoneServiceTest extends TestContainerSupport {
                 savedUser.getId(),
                 "test",
                 "test",
-                List.of(fileId1.toString(), fileId2.toString())
+                List.of(new ImageInfo(fileId1.toString(), 1), new ImageInfo(fileId2.toString(), 2))
         );
         fileMetaDataRepository.saveAll(List.of(
                 fixture.giveMeBuilder(FileMetaData.class)
@@ -214,7 +215,7 @@ class FacadeCentralGeneralFixZoneServiceTest extends TestContainerSupport {
                 savedFixZone.getId(),
                 "test",
                 "test",
-                null
+                List.of()
         );
 
         //when


### PR DESCRIPTION
## 🚀 작업 내용
이미지 순서가 지정되어야 하는 특정 도메인(Notice, FixZone)의 요구사항에 따라 이미지 순서 적용 로직 구현
- FileMetaData 테이블의 order 컬럼을 통해 이미지의 순서 부여
	- `FileMetaDataService` : `updateStatusToCoupledWithOrder()`, `updateWithOrder()` 구현 

- [x] Notice
	- [x] 공지사항 생성
	- [x] 공지사항 수정
- [x] FixZone
	- [x] 픽스존 생성
	- [x] 픽스존 생성

## 🤔 고민했던 내용
- 이미지의 순서를 유지하기 위해 FileMetaData의 ID가 time기반 uuid이기 때문에 해당 특성을 이용해 이미지의 순서를 보장하는 방법을 고려했지만 현재 클라이언트에서 이미지 다중 첨부를 위해 presignedUrl을 요청 시(presignedUrl 발급 시 FileMetaData생성) 비동기 방식으로 요청하기 때문에 이미지의 순서와 presignedUrl을 통한 FileMetaData Id의 시간 순서를 보장할 수 없기 때문에 해당 방식은 사용할 수 없었습니다.
다른 해결책으로 다중 이미지 첨부를 위한 presignedUrl을 다중으로 생성 정렬 후 응답하여 클라이언트 측에서 첨부 이미지 순서에 맞게 적절한 presignedUrl을 사용하는 방식도 생각해보았지만, 이미지 수정 시 새로 첨부된 이미지는 항상 후순위 이미지이기 때문에 해당 방식도 사용할 수 없었습니다.
## 💬 리뷰 중점사항


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **새로운 기능**
	- 파일 메타데이터에 순서 정보 추가
	- 공지사항 및 고정존 이미지와 파일에 순서 지정 기능 도입
	- 이미지와 파일의 순서를 관리할 수 있는 새로운 데이터 구조 구현
	- 이미지 및 파일 정보에 대한 보다 구조화된 표현 제공
	- 유효성 검사를 통한 요청 데이터 검증 기능 추가

- **버그 수정**
	- 파일 및 이미지 관리의 유연성 개선
	- 데이터베이스 스키마 업데이트를 통한 순서 정보 저장 지원

- **리팩토링**
	- 파일 메타데이터 처리 로직 개선
	- 요청 및 응답 DTO 구조 최적화
	- API 메서드의 가독성 및 일관성 향상

<!-- end of auto-generated comment: release notes by coderabbit.ai -->