### PR TITLE
[DDING-55] Feed 삭제 API 구현

### DIFF
--- a/src/main/java/ddingdong/ddingdongBE/domain/feed/api/ClubFeedApi.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/feed/api/ClubFeedApi.java
@@ -10,6 +10,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
@@ -18,14 +19,14 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.ResponseStatus;
 
 @Tag(name = "Feed - Club", description = "Feed API")
-@RequestMapping("/server")
+@RequestMapping("/server/central")
 public interface ClubFeedApi {
 
     @Operation(summary = "동아리 피드 생성 API")
     @ApiResponse(responseCode = "201", description = "동아리 피드 생성 성공")
     @ResponseStatus(HttpStatus.CREATED)
     @SecurityRequirement(name = "AccessToken")
-    @PostMapping("/central/clubs/feeds")
+    @PostMapping("/clubs/feeds")
     void createFeed(
         @RequestBody @Valid CreateFeedRequest createFeedRequest,
         @AuthenticationPrincipal PrincipalDetails principalDetails
@@ -35,9 +36,19 @@ public interface ClubFeedApi {
     @ApiResponse(responseCode = "204", description = "동아리 피드 수정 성공")
     @ResponseStatus(HttpStatus.NO_CONTENT)
     @SecurityRequirement(name = "AccessToken")
-    @PutMapping("/central/clubs/feeds/{feedId}")
+    @PutMapping("/clubs/feeds/{feedId}")
     void updateFeed(
         @PathVariable("feedId") Long feedId,
         @RequestBody @Valid UpdateFeedRequest updateFeedRequest
     );
+
+    @Operation(summary = "동아리 피드 삭제 API")
+    @ApiResponse(responseCode = "204", description = "동아리 피드 삭제 성공")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    @SecurityRequirement(name = "AccessToken")
+    @DeleteMapping("/clubs/feeds/{feedId}")
+    void deleteFeed(
+        @PathVariable("feedId") Long feedId
+    );
+
 }

--- a/src/main/java/ddingdong/ddingdongBE/domain/feed/controller/ClubFeedController.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/feed/controller/ClubFeedController.java
@@ -31,4 +31,9 @@ public class ClubFeedController implements ClubFeedApi {
     ) {
         facadeClubFeedService.update(updateFeedRequest.toCommand(feedId));
     }
+
+    @Override
+    public void deleteFeed(Long feedId) {
+        facadeClubFeedService.delete(feedId);
+    }
 }

--- a/src/main/java/ddingdong/ddingdongBE/domain/feed/entity/FeedType.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/feed/entity/FeedType.java
@@ -1,9 +1,17 @@
 package ddingdong.ddingdongBE.domain.feed.entity;
 
+import ddingdong.ddingdongBE.domain.filemetadata.entity.DomainType;
 import java.util.Arrays;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
 
+@Getter
+@RequiredArgsConstructor
 public enum FeedType {
-  IMAGE, VIDEO;
+  IMAGE(DomainType.FEED_IMAGE),
+  VIDEO(DomainType.FEED_VIDEO);
+
+  private final DomainType domainType;
 
   public static FeedType findByContentType(String contentType) {
     return Arrays.stream(values())

--- a/src/main/java/ddingdong/ddingdongBE/domain/feed/service/FacadeClubFeedService.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/feed/service/FacadeClubFeedService.java
@@ -9,4 +9,5 @@ public interface FacadeClubFeedService {
 
     void update(UpdateFeedCommand command);
 
+    void delete(Long feedId);
 }

--- a/src/main/java/ddingdong/ddingdongBE/domain/feed/service/FacadeClubFeedServiceImpl.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/feed/service/FacadeClubFeedServiceImpl.java
@@ -46,6 +46,7 @@ public class FacadeClubFeedServiceImpl implements FacadeClubFeedService{
     }
 
     @Override
+    @Transactional
     public void delete(Long feedId) {
         Feed feed = feedService.getById(feedId);
         feedService.delete(feed);

--- a/src/main/java/ddingdong/ddingdongBE/domain/feed/service/FacadeClubFeedServiceImpl.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/feed/service/FacadeClubFeedServiceImpl.java
@@ -50,13 +50,6 @@ public class FacadeClubFeedServiceImpl implements FacadeClubFeedService{
     public void delete(Long feedId) {
         Feed feed = feedService.getById(feedId);
         feedService.delete(feed);
-        if (feed.isImage()) {
-            fileMetaDataService.updateStatusToDelete(DomainType.FEED_IMAGE, feedId);
-            return;
-        }
-
-        if (feed.isVideo()) {
-            fileMetaDataService.updateStatusToDelete(DomainType.FEED_VIDEO, feedId);
-        }
+        fileMetaDataService.updateStatusToDeleteByEntityId(Feed.class, feed.getId());
     }
 }

--- a/src/main/java/ddingdong/ddingdongBE/domain/feed/service/FacadeClubFeedServiceImpl.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/feed/service/FacadeClubFeedServiceImpl.java
@@ -29,6 +29,7 @@ public class FacadeClubFeedServiceImpl implements FacadeClubFeedService{
 
         if (feed.isImage()) {
             fileMetaDataService.updateStatusToCoupled(command.mediaId(), DomainType.FEED_IMAGE, createdId);
+            return;
         }
 
         if (feed.isVideo()) {
@@ -42,5 +43,19 @@ public class FacadeClubFeedServiceImpl implements FacadeClubFeedService{
         Feed originFeed = feedService.getById(command.feedId());
         Feed updateFeed = command.toEntity();
         originFeed.update(updateFeed);
+    }
+
+    @Override
+    public void delete(Long feedId) {
+        Feed feed = feedService.getById(feedId);
+        feedService.delete(feed);
+        if (feed.isImage()) {
+            fileMetaDataService.updateStatusToDelete(DomainType.FEED_IMAGE, feedId);
+            return;
+        }
+
+        if (feed.isVideo()) {
+            fileMetaDataService.updateStatusToDelete(DomainType.FEED_VIDEO, feedId);
+        }
     }
 }

--- a/src/main/java/ddingdong/ddingdongBE/domain/feed/service/FacadeClubFeedServiceImpl.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/feed/service/FacadeClubFeedServiceImpl.java
@@ -50,6 +50,6 @@ public class FacadeClubFeedServiceImpl implements FacadeClubFeedService{
     public void delete(Long feedId) {
         Feed feed = feedService.getById(feedId);
         feedService.delete(feed);
-        fileMetaDataService.updateStatusToDeleteByEntityId(Feed.class, feed.getId());
+        fileMetaDataService.updateStatusToDelete(feed.getFeedType().getDomainType(), feed.getId());
     }
 }

--- a/src/main/java/ddingdong/ddingdongBE/domain/feed/service/FeedService.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/feed/service/FeedService.java
@@ -12,4 +12,6 @@ public interface FeedService {
     Feed getById(Long feedId);
 
     Long create(Feed feed);
+
+    void delete(Feed feed);
 }

--- a/src/main/java/ddingdong/ddingdongBE/domain/feed/service/GeneralFeedService.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/feed/service/GeneralFeedService.java
@@ -39,6 +39,7 @@ public class GeneralFeedService implements FeedService {
     }
 
     @Override
+    @Transactional
     public void delete(Feed feed) {
         feedRepository.delete(feed);
     }

--- a/src/main/java/ddingdong/ddingdongBE/domain/feed/service/GeneralFeedService.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/feed/service/GeneralFeedService.java
@@ -37,4 +37,9 @@ public class GeneralFeedService implements FeedService {
         Feed savedFeed = feedRepository.save(feed);
         return savedFeed.getId();
     }
+
+    @Override
+    public void delete(Feed feed) {
+        feedRepository.delete(feed);
+    }
 }

--- a/src/main/java/ddingdong/ddingdongBE/domain/filemetadata/entity/DomainType.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/filemetadata/entity/DomainType.java
@@ -1,15 +1,37 @@
 package ddingdong.ddingdongBE.domain.filemetadata.entity;
 
+import ddingdong.ddingdongBE.domain.activityreport.domain.ActivityReport;
+import ddingdong.ddingdongBE.domain.banner.entity.Banner;
+import ddingdong.ddingdongBE.domain.club.entity.Club;
+import ddingdong.ddingdongBE.domain.documents.entity.Document;
+import ddingdong.ddingdongBE.domain.feed.entity.Feed;
+import ddingdong.ddingdongBE.domain.fixzone.entity.FixZone;
+import ddingdong.ddingdongBE.domain.notice.entity.Notice;
+import java.util.Arrays;
+import java.util.List;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Getter
 public enum DomainType {
-    CLUB_PROFILE,
-    CLUB_INTRODUCTION,
-    FIX_ZONE_IMAGE,
-    NOTICE_IMAGE,
-    NOTICE_FILE,
-    DOCUMENT_FILE,
-    ACTIVITY_REPORT_IMAGE,
-    BANNER_WEB_IMAGE,
-    BANNER_MOBILE_IMAGE,
-    FEED_IMAGE,
-    FEED_VIDEO
+    CLUB_PROFILE(Club.class),
+    CLUB_INTRODUCTION(Club.class),
+    FIX_ZONE_IMAGE(FixZone.class),
+    NOTICE_IMAGE(Notice.class),
+    NOTICE_FILE(Notice.class),
+    DOCUMENT_FILE(Document.class),
+    ACTIVITY_REPORT_IMAGE(ActivityReport.class),
+    BANNER_WEB_IMAGE(Banner.class),
+    BANNER_MOBILE_IMAGE(Banner.class),
+    FEED_IMAGE(Feed.class),
+    FEED_VIDEO(Feed.class);
+
+    private final Class<?> classType;
+
+    public static List<DomainType> findAllByClassType(Class<?> classType) {
+        return Arrays.stream(values())
+            .filter(domainType -> domainType.getClassType() == classType)
+            .toList();
+    }
 }

--- a/src/main/java/ddingdong/ddingdongBE/domain/filemetadata/entity/DomainType.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/filemetadata/entity/DomainType.java
@@ -1,37 +1,20 @@
 package ddingdong.ddingdongBE.domain.filemetadata.entity;
 
-import ddingdong.ddingdongBE.domain.activityreport.domain.ActivityReport;
-import ddingdong.ddingdongBE.domain.banner.entity.Banner;
-import ddingdong.ddingdongBE.domain.club.entity.Club;
-import ddingdong.ddingdongBE.domain.documents.entity.Document;
-import ddingdong.ddingdongBE.domain.feed.entity.Feed;
-import ddingdong.ddingdongBE.domain.fixzone.entity.FixZone;
-import ddingdong.ddingdongBE.domain.notice.entity.Notice;
-import java.util.Arrays;
-import java.util.List;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
 @Getter
 public enum DomainType {
-    CLUB_PROFILE(Club.class),
-    CLUB_INTRODUCTION(Club.class),
-    FIX_ZONE_IMAGE(FixZone.class),
-    NOTICE_IMAGE(Notice.class),
-    NOTICE_FILE(Notice.class),
-    DOCUMENT_FILE(Document.class),
-    ACTIVITY_REPORT_IMAGE(ActivityReport.class),
-    BANNER_WEB_IMAGE(Banner.class),
-    BANNER_MOBILE_IMAGE(Banner.class),
-    FEED_IMAGE(Feed.class),
-    FEED_VIDEO(Feed.class);
-
-    private final Class<?> classType;
-
-    public static List<DomainType> findAllByClassType(Class<?> classType) {
-        return Arrays.stream(values())
-            .filter(domainType -> domainType.getClassType() == classType)
-            .toList();
-    }
+    CLUB_PROFILE,
+    CLUB_INTRODUCTION,
+    FIX_ZONE_IMAGE,
+    NOTICE_IMAGE,
+    NOTICE_FILE,
+    DOCUMENT_FILE,
+    ACTIVITY_REPORT_IMAGE,
+    BANNER_WEB_IMAGE,
+    BANNER_MOBILE_IMAGE,
+    FEED_IMAGE,
+    FEED_VIDEO;
 }

--- a/src/main/java/ddingdong/ddingdongBE/domain/filemetadata/service/FileMetaDataService.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/filemetadata/service/FileMetaDataService.java
@@ -34,4 +34,6 @@ public interface FileMetaDataService {
     void update(List<String> ids, DomainType domainType, Long entityId);
 
     void updateWithOrder(List<FileMetaDataIdOrderDto> fileMetaDataIdOrderDtos, DomainType domainType, Long entityId);
+
+    void updateStatusToDeleteByEntityId(Class<?> classType, Long entityId);
 }

--- a/src/main/java/ddingdong/ddingdongBE/domain/filemetadata/service/FileMetaDataService.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/filemetadata/service/FileMetaDataService.java
@@ -34,6 +34,4 @@ public interface FileMetaDataService {
     void update(List<String> ids, DomainType domainType, Long entityId);
 
     void updateWithOrder(List<FileMetaDataIdOrderDto> fileMetaDataIdOrderDtos, DomainType domainType, Long entityId);
-
-    void updateStatusToDeleteByEntityId(Class<?> classType, Long entityId);
 }

--- a/src/main/java/ddingdong/ddingdongBE/domain/filemetadata/service/FileMetaDataServiceImpl.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/filemetadata/service/FileMetaDataServiceImpl.java
@@ -92,6 +92,7 @@ public class FileMetaDataServiceImpl implements FileMetaDataService {
         fileMetaData.updateStatus(COUPLED);
     }
 
+    @Transactional
     @Override
     public void updateStatusToCoupledWithOrder(
             List<FileMetaDataIdOrderDto> fileMetaDataIdOrderDtos,
@@ -160,6 +161,7 @@ public class FileMetaDataServiceImpl implements FileMetaDataService {
         updateStatusToCoupledWithOrder(fileMetaDataIdOrderDtos, domainType, entityId);
     }
 
+    @Transactional
     @Override
     public void updateStatusToDeleteByEntityId(Class<?> classType, Long entityId) {
         List<DomainType> domainTypes = DomainType.findAllByClassType(classType);

--- a/src/main/java/ddingdong/ddingdongBE/domain/filemetadata/service/FileMetaDataServiceImpl.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/filemetadata/service/FileMetaDataServiceImpl.java
@@ -163,15 +163,6 @@ public class FileMetaDataServiceImpl implements FileMetaDataService {
 
     @Transactional
     @Override
-    public void updateStatusToDeleteByEntityId(Class<?> classType, Long entityId) {
-        List<DomainType> domainTypes = DomainType.findAllByClassType(classType);
-        domainTypes.forEach(domainType -> {
-            updateStatusToDelete(domainType, entityId);
-        });
-    }
-
-    @Transactional
-    @Override
     public void updateStatusToDelete(DomainType domainType, Long entityId) {
         List<FileMetaData> fileMetaDatas = fileMetaDataRepository.findAllByDomainTypeAndEntityId(domainType, entityId);
         fileMetaDatas.forEach(fileMetaData -> fileMetaData.updateStatus(DELETED));

--- a/src/main/java/ddingdong/ddingdongBE/domain/filemetadata/service/FileMetaDataServiceImpl.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/filemetadata/service/FileMetaDataServiceImpl.java
@@ -160,6 +160,14 @@ public class FileMetaDataServiceImpl implements FileMetaDataService {
         updateStatusToCoupledWithOrder(fileMetaDataIdOrderDtos, domainType, entityId);
     }
 
+    @Override
+    public void updateStatusToDeleteByEntityId(Class<?> classType, Long entityId) {
+        List<DomainType> domainTypes = DomainType.findAllByClassType(classType);
+        domainTypes.forEach(domainType -> {
+            updateStatusToDelete(domainType, entityId);
+        });
+    }
+
     @Transactional
     @Override
     public void updateStatusToDelete(DomainType domainType, Long entityId) {

--- a/src/test/java/ddingdong/ddingdongBE/domain/feed/service/FacadeClubFeedServiceImplTest.java
+++ b/src/test/java/ddingdong/ddingdongBE/domain/feed/service/FacadeClubFeedServiceImplTest.java
@@ -115,9 +115,9 @@ class FacadeClubFeedServiceImplTest extends TestContainerSupport {
         assertThat(finded.getActivityContent()).isEqualTo("변경된 활동내용");
     }
 
-    @DisplayName("주어진 feedId를 가진 Feed 엔터티를 삭제 및 fileMetaData 상태를 DELETED로 변경")
+    @DisplayName("주어진 feedId를 가진 Feed 엔터티를 삭제 및 fileMetaData 상태를 DELETED로 변경 - IMAGE")
     @Test
-    void delete() {
+    void deleteImage() {
         // given
         UUID uuid = UuidCreator.getTimeOrderedEpoch();
 
@@ -134,6 +134,40 @@ class FacadeClubFeedServiceImplTest extends TestContainerSupport {
                 .set("id", uuid)
                 .set("entityId", savedFeed.getId())
                 .set("domainType", DomainType.FEED_IMAGE)
+                .set("fileStatus", FileStatus.COUPLED)
+                .sample()
+        );
+        entityManager.flush();
+        // when
+        facadeClubFeedService.delete(savedFeed.getId());
+        entityManager.flush();
+        // then
+        Feed feed = feedRepository.findById(savedFeed.getId()).orElse(null);
+        FileMetaData fileMetaData = fileMetaDataRepository.findById(uuid).orElse(null);
+        assertThat(feed).isNull();
+        assertThat(fileMetaData).isNotNull();
+        assertThat(fileMetaData.getFileStatus()).isEqualTo(FileStatus.DELETED);
+    }
+
+    @DisplayName("주어진 feedId를 가진 Feed 엔터티를 삭제 및 fileMetaData 상태를 DELETED로 변경 - VIDEO")
+    @Test
+    void deleteVideo() {
+        // given
+        UUID uuid = UuidCreator.getTimeOrderedEpoch();
+
+
+        Feed savedFeed = feedRepository.save(
+            fixtureMonkey.giveMeBuilder(Feed.class)
+                .set("feedType", FeedType.VIDEO)
+                .set("activityContent", "활동내용")
+                .set("club", null)
+                .sample()
+        );
+        fileMetaDataRepository.save(
+            fixtureMonkey.giveMeBuilder(FileMetaData.class)
+                .set("id", uuid)
+                .set("entityId", savedFeed.getId())
+                .set("domainType", DomainType.FEED_VIDEO)
                 .set("fileStatus", FileStatus.COUPLED)
                 .sample()
         );

--- a/src/test/java/ddingdong/ddingdongBE/domain/feed/service/FacadeClubFeedServiceImplTest.java
+++ b/src/test/java/ddingdong/ddingdongBE/domain/feed/service/FacadeClubFeedServiceImplTest.java
@@ -119,28 +119,30 @@ class FacadeClubFeedServiceImplTest extends TestContainerSupport {
     @Test
     void delete() {
         // given
-        Long entityId = 1L;
         UUID uuid = UuidCreator.getTimeOrderedEpoch();
 
+
+        Feed savedFeed = feedRepository.save(
+            fixtureMonkey.giveMeBuilder(Feed.class)
+                .set("feedType", FeedType.IMAGE)
+                .set("activityContent", "활동내용")
+                .set("club", null)
+                .sample()
+        );
         fileMetaDataRepository.save(
             fixtureMonkey.giveMeBuilder(FileMetaData.class)
                 .set("id", uuid)
-                .set("entityId", entityId)
+                .set("entityId", savedFeed.getId())
                 .set("domainType", DomainType.FEED_IMAGE)
                 .set("fileStatus", FileStatus.COUPLED)
                 .sample()
         );
-        feedRepository.save(
-            fixtureMonkey.giveMeBuilder(Feed.class)
-                .set("id", entityId)
-                .set("feedType", FeedType.IMAGE)
-                .set("club", null)
-                .sample()
-        );
+        entityManager.flush();
         // when
-        facadeClubFeedService.delete(entityId);
+        facadeClubFeedService.delete(savedFeed.getId());
+        entityManager.flush();
         // then
-        Feed feed = feedRepository.findById(entityId).orElse(null);
+        Feed feed = feedRepository.findById(savedFeed.getId()).orElse(null);
         FileMetaData fileMetaData = fileMetaDataRepository.findById(uuid).orElse(null);
         assertThat(feed).isNull();
         assertThat(fileMetaData).isNotNull();

--- a/src/test/java/ddingdong/ddingdongBE/domain/feed/service/FacadeClubFeedServiceImplTest.java
+++ b/src/test/java/ddingdong/ddingdongBE/domain/feed/service/FacadeClubFeedServiceImplTest.java
@@ -19,6 +19,7 @@ import ddingdong.ddingdongBE.domain.filemetadata.entity.DomainType;
 import ddingdong.ddingdongBE.domain.filemetadata.entity.FileMetaData;
 import ddingdong.ddingdongBE.domain.filemetadata.entity.FileStatus;
 import ddingdong.ddingdongBE.domain.filemetadata.repository.FileMetaDataRepository;
+import ddingdong.ddingdongBE.domain.filemetadata.service.FileMetaDataServiceImpl;
 import ddingdong.ddingdongBE.domain.scorehistory.entity.Score;
 import ddingdong.ddingdongBE.domain.user.entity.User;
 import ddingdong.ddingdongBE.domain.user.repository.UserRepository;
@@ -47,6 +48,8 @@ class FacadeClubFeedServiceImplTest extends TestContainerSupport {
     private EntityManager entityManager;
 
     private final FixtureMonkey fixtureMonkey = FixtureMonkeyFactory.getNotNullBuilderIntrospectorMonkey();
+    @Autowired
+    private FileMetaDataServiceImpl fileMetaDataServiceImpl;
 
     @DisplayName("요청된 Command를 사용하여 feed를 생성하며, FileMetaData를 Couple 상태로 변경한다.")
     @Test
@@ -110,5 +113,37 @@ class FacadeClubFeedServiceImplTest extends TestContainerSupport {
         Feed finded = feedRepository.findById(savedFeed.getId()).orElse(null);
         assertThat(finded).isNotNull();
         assertThat(finded.getActivityContent()).isEqualTo("변경된 활동내용");
+    }
+
+    @DisplayName("주어진 feedId를 가진 Feed 엔터티를 삭제 및 fileMetaData 상태를 DELETED로 변경")
+    @Test
+    void delete() {
+        // given
+        Long entityId = 1L;
+        UUID uuid = UuidCreator.getTimeOrderedEpoch();
+
+        fileMetaDataRepository.save(
+            fixtureMonkey.giveMeBuilder(FileMetaData.class)
+                .set("id", uuid)
+                .set("entityId", entityId)
+                .set("domainType", DomainType.FEED_IMAGE)
+                .set("fileStatus", FileStatus.COUPLED)
+                .sample()
+        );
+        feedRepository.save(
+            fixtureMonkey.giveMeBuilder(Feed.class)
+                .set("id", entityId)
+                .set("feedType", FeedType.IMAGE)
+                .set("club", null)
+                .sample()
+        );
+        // when
+        facadeClubFeedService.delete(entityId);
+        // then
+        Feed feed = feedRepository.findById(entityId).orElse(null);
+        FileMetaData fileMetaData = fileMetaDataRepository.findById(uuid).orElse(null);
+        assertThat(feed).isNull();
+        assertThat(fileMetaData).isNotNull();
+        assertThat(fileMetaData.getFileStatus()).isEqualTo(FileStatus.DELETED);
     }
 }


### PR DESCRIPTION
## 🚀 작업 내용
- Feed 삭제 API 구현하였습니다.
- Facade 클래스의 delete 메소드만 테스트를 작성하였습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리즈 노트

- **새로운 기능**
  - 클럽 피드 삭제 기능 추가
  - 피드 엔드포인트 경로 구조 개선

- **버그 수정**
  - 피드 관련 API 경로 일관성 향상

- **개선 사항**
  - 파일 메타데이터 상태 관리 기능 강화
  - 피드 타입과 도메인 타입 연결 개선

이번 업데이트는 클럽 피드 관리 기능을 확장하고 시스템의 안정성을 높였습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->