### PR TITLE
[DDING-47] media convert job status 업데이트 API 구현

### DIFF
--- a/src/main/java/ddingdong/ddingdongBE/common/config/SecurityConfig.java
+++ b/src/main/java/ddingdong/ddingdongBE/common/config/SecurityConfig.java
@@ -1,7 +1,6 @@
 package ddingdong.ddingdongBE.common.config;
 
 import static org.springframework.http.HttpMethod.GET;
-import static org.springframework.http.HttpMethod.POST;
 
 import ddingdong.ddingdongBE.auth.service.JwtAuthService;
 import ddingdong.ddingdongBE.common.filter.JwtAuthenticationFilter;
@@ -49,7 +48,7 @@ public class SecurityConfig {
                                 API_PREFIX + "/questions/**",
                                 API_PREFIX + "/feeds/**")
                         .permitAll()
-                        .requestMatchers(POST, API_PREFIX + "/internal/**")
+                        .requestMatchers(API_PREFIX + "/internal/**")
                         .permitAll()
                         .requestMatchers("/v3/api-docs/**", "/swagger-ui/**", "/swagger-resources/**")
                         .permitAll()

--- a/src/main/java/ddingdong/ddingdongBE/domain/vodprocessing/controller/VodProcessingJobController.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/vodprocessing/controller/VodProcessingJobController.java
@@ -21,7 +21,7 @@ public class VodProcessingJobController {
     private final FacadeVodProcessingJobService facadeVodProcessingJobService;
 
     @PostMapping()
-    public void createPending(@RequestBody CreatePendingVodProcessingJobRequest request) {
+    public void createPending(@RequestBody @Valid CreatePendingVodProcessingJobRequest request) {
         facadeVodProcessingJobService.create(request.toCommand());
     }
 

--- a/src/main/java/ddingdong/ddingdongBE/domain/vodprocessing/controller/VodProcessingJobController.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/vodprocessing/controller/VodProcessingJobController.java
@@ -1,9 +1,12 @@
 package ddingdong.ddingdongBE.domain.vodprocessing.controller;
 
 import ddingdong.ddingdongBE.domain.vodprocessing.controller.dto.request.CreatePendingVodProcessingJobRequest;
+import ddingdong.ddingdongBE.domain.vodprocessing.controller.dto.request.UpdateVodProcessingJobStatusRequest;
 import ddingdong.ddingdongBE.domain.vodprocessing.service.FacadeVodProcessingJobService;
 import io.swagger.v3.oas.annotations.Hidden;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -20,6 +23,11 @@ public class VodProcessingJobController {
     @PostMapping()
     public void createPending(@RequestBody CreatePendingVodProcessingJobRequest request) {
         facadeVodProcessingJobService.create(request.toCommand());
+    }
+
+    @PatchMapping("/job-status")
+    public void updateJobStatus(@RequestBody @Valid UpdateVodProcessingJobStatusRequest request) {
+        facadeVodProcessingJobService.updateVodProcessingJobStatus(request.toCommand());
     }
 
 }

--- a/src/main/java/ddingdong/ddingdongBE/domain/vodprocessing/controller/dto/request/CreatePendingVodProcessingJobRequest.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/vodprocessing/controller/dto/request/CreatePendingVodProcessingJobRequest.java
@@ -1,9 +1,14 @@
 package ddingdong.ddingdongBE.domain.vodprocessing.controller.dto.request;
 
 import ddingdong.ddingdongBE.domain.vodprocessing.service.dto.command.CreatePendingVodProcessingJobCommand;
+import jakarta.validation.constraints.NotNull;
+import org.hibernate.validator.constraints.UUID;
 
 public record CreatePendingVodProcessingJobRequest(
+        @NotNull
+        @UUID
         String convertJobId,
+        @NotNull
         String userId
 ) {
 

--- a/src/main/java/ddingdong/ddingdongBE/domain/vodprocessing/controller/dto/request/CreatePendingVodProcessingJobRequest.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/vodprocessing/controller/dto/request/CreatePendingVodProcessingJobRequest.java
@@ -5,10 +5,10 @@ import jakarta.validation.constraints.NotNull;
 import org.hibernate.validator.constraints.UUID;
 
 public record CreatePendingVodProcessingJobRequest(
-        @NotNull
+        @NotNull(message = "변환 작업 ID는 필수입니다")
         @UUID
         String convertJobId,
-        @NotNull
+        @NotNull(message = "userId는 필수입니다.")
         String userId
 ) {
 

--- a/src/main/java/ddingdong/ddingdongBE/domain/vodprocessing/controller/dto/request/UpdateVodProcessingJobStatusRequest.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/vodprocessing/controller/dto/request/UpdateVodProcessingJobStatusRequest.java
@@ -1,0 +1,20 @@
+package ddingdong.ddingdongBE.domain.vodprocessing.controller.dto.request;
+
+import ddingdong.ddingdongBE.domain.vodprocessing.entity.ConvertJobStatus;
+import ddingdong.ddingdongBE.domain.vodprocessing.service.dto.command.UpdateVodProcessingJobStatusCommand;
+import jakarta.validation.constraints.NotNull;
+import org.hibernate.validator.constraints.UUID;
+
+public record UpdateVodProcessingJobStatusRequest(
+        @NotNull
+        @UUID
+        String convertJobId,
+        @NotNull
+        ConvertJobStatus status
+) {
+
+    public UpdateVodProcessingJobStatusCommand toCommand() {
+        return new UpdateVodProcessingJobStatusCommand(convertJobId, status);
+    }
+
+}

--- a/src/main/java/ddingdong/ddingdongBE/domain/vodprocessing/controller/dto/request/UpdateVodProcessingJobStatusRequest.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/vodprocessing/controller/dto/request/UpdateVodProcessingJobStatusRequest.java
@@ -6,10 +6,10 @@ import jakarta.validation.constraints.NotNull;
 import org.hibernate.validator.constraints.UUID;
 
 public record UpdateVodProcessingJobStatusRequest(
-        @NotNull
+        @NotNull(message = "변환 작업 ID는 필수입니다")
         @UUID
         String convertJobId,
-        @NotNull
+        @NotNull(message = "상태는 필수입니다")
         ConvertJobStatus status
 ) {
 

--- a/src/main/java/ddingdong/ddingdongBE/domain/vodprocessing/entity/ConvertJobStatus.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/vodprocessing/entity/ConvertJobStatus.java
@@ -1,5 +1,7 @@
 package ddingdong.ddingdongBE.domain.vodprocessing.entity;
 
 public enum ConvertJobStatus {
-    PENDING
+    PENDING,
+    COMPLETE,
+    ERROR
 }

--- a/src/main/java/ddingdong/ddingdongBE/domain/vodprocessing/entity/VodProcessingJob.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/vodprocessing/entity/VodProcessingJob.java
@@ -47,4 +47,8 @@ public class VodProcessingJob extends BaseEntity {
         this.userId = userId;
         this.convertJobStatus = convertJobStatus;
     }
+
+    public void updateConvertJobStatus(ConvertJobStatus convertJobStatus) {
+        this.convertJobStatus = convertJobStatus;
+    }
 }

--- a/src/main/java/ddingdong/ddingdongBE/domain/vodprocessing/service/FacadeVodProcessingJobService.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/vodprocessing/service/FacadeVodProcessingJobService.java
@@ -1,9 +1,12 @@
 package ddingdong.ddingdongBE.domain.vodprocessing.service;
 
+import ddingdong.ddingdongBE.domain.vodprocessing.service.dto.command.UpdateVodProcessingJobStatusCommand;
 import ddingdong.ddingdongBE.domain.vodprocessing.service.dto.command.CreatePendingVodProcessingJobCommand;
 
 public interface FacadeVodProcessingJobService {
 
     Long create(CreatePendingVodProcessingJobCommand command);
+
+    void updateVodProcessingJobStatus(UpdateVodProcessingJobStatusCommand command);
 
 }

--- a/src/main/java/ddingdong/ddingdongBE/domain/vodprocessing/service/FacadeVodProcessingJobServiceImpl.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/vodprocessing/service/FacadeVodProcessingJobServiceImpl.java
@@ -1,6 +1,8 @@
 package ddingdong.ddingdongBE.domain.vodprocessing.service;
 
+import ddingdong.ddingdongBE.domain.vodprocessing.entity.VodProcessingJob;
 import ddingdong.ddingdongBE.domain.vodprocessing.service.dto.command.CreatePendingVodProcessingJobCommand;
+import ddingdong.ddingdongBE.domain.vodprocessing.service.dto.command.UpdateVodProcessingJobStatusCommand;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -17,4 +19,12 @@ public class FacadeVodProcessingJobServiceImpl implements FacadeVodProcessingJob
     public Long create(CreatePendingVodProcessingJobCommand command) {
         return vodProcessingJobService.save(command.toPendingVodProcessingJob());
     }
+
+    @Override
+    @Transactional
+    public void updateVodProcessingJobStatus(UpdateVodProcessingJobStatusCommand command) {
+        VodProcessingJob vodProcessingJob = vodProcessingJobService.getByConvertJobId(command.convertJobId());
+        vodProcessingJob.updateConvertJobStatus(command.convertJobStatus());
+    }
+
 }

--- a/src/main/java/ddingdong/ddingdongBE/domain/vodprocessing/service/FacadeVodProcessingJobServiceImpl.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/vodprocessing/service/FacadeVodProcessingJobServiceImpl.java
@@ -24,7 +24,7 @@ public class FacadeVodProcessingJobServiceImpl implements FacadeVodProcessingJob
     @Transactional
     public void updateVodProcessingJobStatus(UpdateVodProcessingJobStatusCommand command) {
         VodProcessingJob vodProcessingJob = vodProcessingJobService.getByConvertJobId(command.convertJobId());
-        vodProcessingJob.updateConvertJobStatus(command.convertJobStatus());
+        vodProcessingJob.updateConvertJobStatus(command.status());
     }
 
 }

--- a/src/main/java/ddingdong/ddingdongBE/domain/vodprocessing/service/dto/command/UpdateVodProcessingJobStatusCommand.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/vodprocessing/service/dto/command/UpdateVodProcessingJobStatusCommand.java
@@ -1,0 +1,10 @@
+package ddingdong.ddingdongBE.domain.vodprocessing.service.dto.command;
+
+import ddingdong.ddingdongBE.domain.vodprocessing.entity.ConvertJobStatus;
+
+public record UpdateVodProcessingJobStatusCommand(
+        String convertJobId,
+        ConvertJobStatus convertJobStatus
+) {
+
+}

--- a/src/main/java/ddingdong/ddingdongBE/domain/vodprocessing/service/dto/command/UpdateVodProcessingJobStatusCommand.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/vodprocessing/service/dto/command/UpdateVodProcessingJobStatusCommand.java
@@ -4,7 +4,7 @@ import ddingdong.ddingdongBE.domain.vodprocessing.entity.ConvertJobStatus;
 
 public record UpdateVodProcessingJobStatusCommand(
         String convertJobId,
-        ConvertJobStatus convertJobStatus
+        ConvertJobStatus status
 ) {
 
 }

--- a/src/test/java/ddingdong/ddingdongBE/domain/vodprocessing/service/FacadeGeneralVodProcessingJobServiceTest.java
+++ b/src/test/java/ddingdong/ddingdongBE/domain/vodprocessing/service/FacadeGeneralVodProcessingJobServiceTest.java
@@ -1,13 +1,16 @@
 package ddingdong.ddingdongBE.domain.vodprocessing.service;
 
+import static ddingdong.ddingdongBE.domain.vodprocessing.entity.ConvertJobStatus.COMPLETE;
+import static ddingdong.ddingdongBE.domain.vodprocessing.entity.ConvertJobStatus.PENDING;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import ddingdong.ddingdongBE.common.support.TestContainerSupport;
-import ddingdong.ddingdongBE.domain.vodprocessing.entity.ConvertJobStatus;
 import ddingdong.ddingdongBE.domain.vodprocessing.entity.VodProcessingJob;
 import ddingdong.ddingdongBE.domain.vodprocessing.repository.VodProcessingJobRepository;
 import ddingdong.ddingdongBE.domain.vodprocessing.service.dto.command.CreatePendingVodProcessingJobCommand;
+import ddingdong.ddingdongBE.domain.vodprocessing.service.dto.command.UpdateVodProcessingJobStatusCommand;
 import java.util.Optional;
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -39,7 +42,29 @@ class FacadeGeneralVodProcessingJobServiceTest extends TestContainerSupport {
         assertThat(result.get())
                 .extracting(VodProcessingJob::getConvertJobId, VodProcessingJob::getUserId,
                         VodProcessingJob::getConvertJobStatus)
-                .containsExactly(convertJobId, userId, ConvertJobStatus.PENDING);
+                .containsExactly(convertJobId, userId, PENDING);
+    }
+
+    @DisplayName("CodProcessingJob 상태를 변경한다.")
+    @Test
+    void updateVodProcessingJobStatus() {
+        //given
+        VodProcessingJob savedVodProcessingJob = vodProcessingJobRepository.save(VodProcessingJob.builder()
+                .convertJobStatus(PENDING)
+                .userId("1")
+                .convertJobId("test")
+                .build());
+
+        UpdateVodProcessingJobStatusCommand command = new UpdateVodProcessingJobStatusCommand("test", COMPLETE);
+
+        //when
+        facadeVodProcessingJobService.updateVodProcessingJobStatus(command);
+
+        //then
+        Optional<VodProcessingJob> result = vodProcessingJobRepository.findByConvertJobId("test");
+        assertThat(result).isPresent();
+        assertThat(result.get().getUserId()).isEqualTo("1");
+        assertThat(result.get().getConvertJobStatus()).isEqualTo(COMPLETE);
     }
 
 }

--- a/src/test/java/ddingdong/ddingdongBE/domain/vodprocessing/service/FacadeGeneralVodProcessingJobServiceTest.java
+++ b/src/test/java/ddingdong/ddingdongBE/domain/vodprocessing/service/FacadeGeneralVodProcessingJobServiceTest.java
@@ -10,7 +10,6 @@ import ddingdong.ddingdongBE.domain.vodprocessing.repository.VodProcessingJobRep
 import ddingdong.ddingdongBE.domain.vodprocessing.service.dto.command.CreatePendingVodProcessingJobCommand;
 import ddingdong.ddingdongBE.domain.vodprocessing.service.dto.command.UpdateVodProcessingJobStatusCommand;
 import java.util.Optional;
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;


### PR DESCRIPTION
## 🚀 작업 내용
- [x]  vod_processing_job status 상태 변경 API 구현 - PATCH /server/internal/trigging/vod-processing-job/job-status
	- status: PENDING, COMPLETE, ERROR


## 🤔 고민했던 내용
## 💬 리뷰 중점사항

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **보안 설정**
	- 내부 엔드포인트에 대한 HTTP 메서드 제한 해제

- **새로운 기능**
	- VOD 처리 작업의 상태를 업데이트하는 새로운 엔드포인트 추가
	- VOD 처리 작업 상태에 대한 새로운 상태 값(COMPLETE, ERROR) 도입

- **유효성 검사**
	- 요청 데이터에 대한 검증 로직 강화
	- 필수 필드 및 UUID 형식 검증 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->