### PR TITLE
[DDING-000] VodProcessingJob 필드 수정

### DIFF
--- a/src/main/java/ddingdong/ddingdongBE/domain/vodprocessing/controller/dto/request/CreatePendingVodProcessingJobRequest.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/vodprocessing/controller/dto/request/CreatePendingVodProcessingJobRequest.java
@@ -9,11 +9,14 @@ public record CreatePendingVodProcessingJobRequest(
         @UUID
         String convertJobId,
         @NotNull(message = "userId는 필수입니다.")
-        String userId
+        String userId,
+        @NotNull(message = "파일Id는 빌수입니다.")
+        @UUID
+        String fileId
 ) {
 
     public CreatePendingVodProcessingJobCommand toCommand() {
-        return new CreatePendingVodProcessingJobCommand(convertJobId, userId);
+        return new CreatePendingVodProcessingJobCommand(convertJobId, userId, fileId);
     }
 
 }

--- a/src/main/java/ddingdong/ddingdongBE/domain/vodprocessing/entity/VodProcessingJob.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/vodprocessing/entity/VodProcessingJob.java
@@ -1,6 +1,7 @@
 package ddingdong.ddingdongBE.domain.vodprocessing.entity;
 
 import ddingdong.ddingdongBE.common.BaseEntity;
+import ddingdong.ddingdongBE.domain.filemetadata.entity.FileMetaData;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -29,6 +30,10 @@ public class VodProcessingJob extends BaseEntity {
     @JoinColumn(name = "notification_id")
     private VodProcessingNotification vodProcessingNotification;
 
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "file_meta_data_id")
+    private FileMetaData fileMetaData;
+
     @Column(nullable = false)
     private String convertJobId;
 
@@ -39,10 +44,11 @@ public class VodProcessingJob extends BaseEntity {
     private ConvertJobStatus convertJobStatus;
 
     @Builder
-    private VodProcessingJob(Long id, VodProcessingNotification vodProcessingNotification, String convertJobId,
-                             String userId, ConvertJobStatus convertJobStatus) {
+    private VodProcessingJob(Long id, VodProcessingNotification vodProcessingNotification, FileMetaData fileMetaData,
+                             String convertJobId, String userId, ConvertJobStatus convertJobStatus) {
         this.id = id;
         this.vodProcessingNotification = vodProcessingNotification;
+        this.fileMetaData = fileMetaData;
         this.convertJobId = convertJobId;
         this.userId = userId;
         this.convertJobStatus = convertJobStatus;

--- a/src/main/java/ddingdong/ddingdongBE/domain/vodprocessing/service/FacadeVodProcessingJobServiceImpl.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/vodprocessing/service/FacadeVodProcessingJobServiceImpl.java
@@ -1,5 +1,7 @@
 package ddingdong.ddingdongBE.domain.vodprocessing.service;
 
+import ddingdong.ddingdongBE.domain.filemetadata.entity.FileMetaData;
+import ddingdong.ddingdongBE.domain.filemetadata.service.FileMetaDataService;
 import ddingdong.ddingdongBE.domain.vodprocessing.entity.VodProcessingJob;
 import ddingdong.ddingdongBE.domain.vodprocessing.service.dto.command.CreatePendingVodProcessingJobCommand;
 import ddingdong.ddingdongBE.domain.vodprocessing.service.dto.command.UpdateVodProcessingJobStatusCommand;
@@ -13,11 +15,13 @@ import org.springframework.transaction.annotation.Transactional;
 public class FacadeVodProcessingJobServiceImpl implements FacadeVodProcessingJobService {
 
     private final VodProcessingJobService vodProcessingJobService;
+    private final FileMetaDataService fileMetaDataService;
 
     @Override
     @Transactional
     public Long create(CreatePendingVodProcessingJobCommand command) {
-        return vodProcessingJobService.save(command.toPendingVodProcessingJob());
+        FileMetaData fileMetaData = fileMetaDataService.getById(command.fileId());
+        return vodProcessingJobService.save(command.toPendingVodProcessingJob(fileMetaData));
     }
 
     @Override

--- a/src/main/java/ddingdong/ddingdongBE/domain/vodprocessing/service/dto/command/CreatePendingVodProcessingJobCommand.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/vodprocessing/service/dto/command/CreatePendingVodProcessingJobCommand.java
@@ -1,16 +1,19 @@
 package ddingdong.ddingdongBE.domain.vodprocessing.service.dto.command;
 
+import ddingdong.ddingdongBE.domain.filemetadata.entity.FileMetaData;
 import ddingdong.ddingdongBE.domain.vodprocessing.entity.ConvertJobStatus;
 import ddingdong.ddingdongBE.domain.vodprocessing.entity.VodProcessingJob;
 
 public record CreatePendingVodProcessingJobCommand(
         String convertJobId,
-        String userId
+        String userId,
+        String fileId
 ) {
 
-    public VodProcessingJob toPendingVodProcessingJob() {
+    public VodProcessingJob toPendingVodProcessingJob(FileMetaData fileMetaData) {
         return VodProcessingJob.builder()
                 .convertJobId(convertJobId)
+                .fileMetaData(fileMetaData)
                 .userId(userId)
                 .convertJobStatus(ConvertJobStatus.PENDING)
                 .build();

--- a/src/main/resources/db/migration/V32__alter_table_vod_proceessing_job_add_column.sql
+++ b/src/main/resources/db/migration/V32__alter_table_vod_proceessing_job_add_column.sql
@@ -1,0 +1,8 @@
+ALTER TABLE vod_processing_job
+    ADD file_meta_data_id BINARY(16) NULL;
+
+ALTER TABLE vod_processing_job
+    ADD CONSTRAINT UK_VOD_PROCESSING_JOB_FILE_META_DATA UNIQUE (file_meta_data_id);
+
+ALTER TABLE vod_processing_job
+    ADD CONSTRAINT FK_VOD_PROCESSING_JOB_FILE_META_DATA_FILE_META_DATA_ID FOREIGN KEY (file_meta_data_id) REFERENCES file_meta_data (id);

--- a/src/test/java/ddingdong/ddingdongBE/domain/vodprocessing/service/FacadeGeneralVodProcessingJobServiceTest.java
+++ b/src/test/java/ddingdong/ddingdongBE/domain/vodprocessing/service/FacadeGeneralVodProcessingJobServiceTest.java
@@ -4,12 +4,16 @@ import static ddingdong.ddingdongBE.domain.vodprocessing.entity.ConvertJobStatus
 import static ddingdong.ddingdongBE.domain.vodprocessing.entity.ConvertJobStatus.PENDING;
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.github.f4b6a3.uuid.UuidCreator;
 import ddingdong.ddingdongBE.common.support.TestContainerSupport;
+import ddingdong.ddingdongBE.domain.filemetadata.entity.FileMetaData;
+import ddingdong.ddingdongBE.domain.filemetadata.repository.FileMetaDataRepository;
 import ddingdong.ddingdongBE.domain.vodprocessing.entity.VodProcessingJob;
 import ddingdong.ddingdongBE.domain.vodprocessing.repository.VodProcessingJobRepository;
 import ddingdong.ddingdongBE.domain.vodprocessing.service.dto.command.CreatePendingVodProcessingJobCommand;
 import ddingdong.ddingdongBE.domain.vodprocessing.service.dto.command.UpdateVodProcessingJobStatusCommand;
 import java.util.Optional;
+import java.util.UUID;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -22,16 +26,21 @@ class FacadeGeneralVodProcessingJobServiceTest extends TestContainerSupport {
     private FacadeVodProcessingJobService facadeVodProcessingJobService;
     @Autowired
     private VodProcessingJobRepository vodProcessingJobRepository;
+    @Autowired
+    private FileMetaDataRepository fileMetaDataRepository;
 
     @DisplayName("VodProcessingJob 생성: PENDING")
     @Test
     void createPendingVodProcessingJob() {
         //given
+        UUID fileId = UuidCreator.getTimeBased();
+        FileMetaData fileMetaData = FileMetaData.createPending(fileId, "test", "test");
+        FileMetaData savedFileMetaData = fileMetaDataRepository.save(fileMetaData);
+
         String convertJobId = "testId";
         String userId = "testId";
-        CreatePendingVodProcessingJobCommand command = new CreatePendingVodProcessingJobCommand(
-                convertJobId, userId);
-
+        CreatePendingVodProcessingJobCommand command =
+                new CreatePendingVodProcessingJobCommand(convertJobId, userId, savedFileMetaData.getId().toString());
         //when
         Long createdPendingVodProcessingJobId = facadeVodProcessingJobService.create(command);
 
@@ -39,16 +48,19 @@ class FacadeGeneralVodProcessingJobServiceTest extends TestContainerSupport {
         Optional<VodProcessingJob> result = vodProcessingJobRepository.findById(createdPendingVodProcessingJobId);
         assertThat(result).isPresent();
         assertThat(result.get())
-                .extracting(VodProcessingJob::getConvertJobId, VodProcessingJob::getUserId,
+                .extracting(
+                        VodProcessingJob::getConvertJobId,
+                        VodProcessingJob::getUserId,
                         VodProcessingJob::getConvertJobStatus)
                 .containsExactly(convertJobId, userId, PENDING);
+        assertThat(result.get().getFileMetaData().getId()).isEqualTo(fileId);
     }
 
     @DisplayName("CodProcessingJob 상태를 변경한다.")
     @Test
     void updateVodProcessingJobStatus() {
         //given
-        VodProcessingJob savedVodProcessingJob = vodProcessingJobRepository.save(VodProcessingJob.builder()
+        vodProcessingJobRepository.save(VodProcessingJob.builder()
                 .convertJobStatus(PENDING)
                 .userId("1")
                 .convertJobId("test")


### PR DESCRIPTION
## 🚀 작업 내용
- VodProcessingJob 엔티티 필드 추가
	- FileMetaData
- 트리깅을 통한 VodProcessingJob 생성 시 FileMetaData 지정 로직 추가

## 🤔 고민했던 내용
- 피드 업로드 시 VodProcessingJob status에 따른 notification 전송 시 2가지 케이스가 존재하는데 이를 모두 만족하기 위해 feedId를 확인해야 하기 때문에 VodProcessingJob 필드에 FileMetaData를 추가하여 이를 해결했습니다.
- 2가지 케이스
	1. 피드 업로드 완료 시 이미 jobStatus가 COMPLETE일 경우 즉시 notification 전송
	(Feed 기준 내 vodProcessingJob을 식별해야 함)
	2. 피드 업로드 완료 시 아직 jobStatus가 COMPLETE가 아닐 경우 jobStatus가 complete로 변경되는 시점에 notify
	(VodPorcessingJob 기준 해당되는 Feed 식별해야 함)

## 💬 리뷰 중점사항


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
	- VOD 처리 작업에 파일 메타데이터 연결 기능 추가
	- 파일 ID를 사용한 VOD 처리 작업 생성 지원

- **개선 사항**
	- VOD 처리 작업과 파일 메타데이터 간 일대일 관계 구현
	- 데이터베이스 스키마 업데이트로 파일 메타데이터 참조 지원

- **기술적 변경**
	- 관련 서비스 및 엔티티 클래스 업데이트
	- 테스트 케이스 확장 및 검증 로직 개선

<!-- end of auto-generated comment: release notes by coderabbit.ai -->