### PR TITLE
[DDING-000] VodProcessingJob 상태 변경 API entityId null 체킹 누락 수정

### DIFF
--- a/src/main/java/ddingdong/ddingdongBE/domain/vodprocessing/controller/dto/request/CreatePendingVodProcessingJobRequest.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/vodprocessing/controller/dto/request/CreatePendingVodProcessingJobRequest.java
@@ -6,11 +6,10 @@ import org.hibernate.validator.constraints.UUID;
 
 public record CreatePendingVodProcessingJobRequest(
         @NotNull(message = "변환 작업 ID는 필수입니다")
-        @UUID
         String convertJobId,
         @NotNull(message = "userId는 필수입니다.")
         String userId,
-        @NotNull(message = "파일Id는 빌수입니다.")
+        @NotNull(message = "파일Id는 필수입니다.")
         @UUID
         String fileId
 ) {

--- a/src/main/java/ddingdong/ddingdongBE/domain/vodprocessing/service/FacadeVodProcessingJobServiceImpl.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/vodprocessing/service/FacadeVodProcessingJobServiceImpl.java
@@ -52,7 +52,11 @@ public class FacadeVodProcessingJobServiceImpl implements FacadeVodProcessingJob
     }
 
     private void checkExistingFeedAndNotify(VodProcessingJob vodProcessingJob) {
-        Optional<Feed> optionalFeed = feedService.findById(vodProcessingJob.getFileMetaData().getEntityId());
+        Long entityId = vodProcessingJob.getFileMetaData().getEntityId();
+        if(entityId == null) {
+            return;
+        }
+        Optional<Feed> optionalFeed = feedService.findById(entityId);
         if (optionalFeed.isPresent()) {
             SseEvent<SseVodProcessingNotificationDto> sseEvent = SseEvent.of(
                     "vod-processing",


### PR DESCRIPTION
## 🚀 작업 내용
- `PATCH /server/internal/trigger/vod-processing-job/job-status` API entityId null 체킹 누락 수정

## 🤔 고민했던 내용


## 💬 리뷰 중점사항


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **버그 수정**
	- 비디오 처리 작업 요청의 유효성 검사 로직 개선
	- 파일 ID 오류 메시지 수정
	- 엔티티 ID에 대한 null 체크 로직 추가하여 안정성 향상

- **개선 사항**
	- 비디오 처리 작업 요청의 유효성 검사 방식 변경
	- 잠재적인 널 포인터 예외 방지를 위한 로직 업데이트

<!-- end of auto-generated comment: release notes by coderabbit.ai -->