### PR TITLE
[DDING-78] 중앙동아리 피드 목록 조회 API 구현

### DIFF
--- a/src/main/java/ddingdong/ddingdongBE/domain/feed/api/ClubFeedApi.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/feed/api/ClubFeedApi.java
@@ -14,6 +14,7 @@ import jakarta.validation.Valid;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
@@ -60,7 +61,7 @@ public interface ClubFeedApi {
         content = @Content(schema = @Schema(implementation = MyFeedPageResponse.class)))
     @ResponseStatus(HttpStatus.OK)
     @SecurityRequirement(name = "AccessToken")
-    @DeleteMapping("/my/feeds")
+    @GetMapping("/my/feeds")
     MyFeedPageResponse getMyFeedPage(
         @AuthenticationPrincipal PrincipalDetails principalDetails,
         @RequestParam(value = "size", defaultValue = "9") int size,

--- a/src/main/java/ddingdong/ddingdongBE/domain/feed/api/ClubFeedApi.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/feed/api/ClubFeedApi.java
@@ -3,7 +3,10 @@ package ddingdong.ddingdongBE.domain.feed.api;
 import ddingdong.ddingdongBE.auth.PrincipalDetails;
 import ddingdong.ddingdongBE.domain.feed.controller.dto.request.CreateFeedRequest;
 import ddingdong.ddingdongBE.domain.feed.controller.dto.request.UpdateFeedRequest;
+import ddingdong.ddingdongBE.domain.feed.controller.dto.response.MyFeedPageResponse;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -16,6 +19,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseStatus;
 
 @Tag(name = "Feed - Club", description = "Feed API")
@@ -26,7 +30,7 @@ public interface ClubFeedApi {
     @ApiResponse(responseCode = "201", description = "동아리 피드 생성 성공")
     @ResponseStatus(HttpStatus.CREATED)
     @SecurityRequirement(name = "AccessToken")
-    @PostMapping("/clubs/feeds")
+    @PostMapping("/my/feeds")
     void createFeed(
         @RequestBody @Valid CreateFeedRequest createFeedRequest,
         @AuthenticationPrincipal PrincipalDetails principalDetails
@@ -36,7 +40,7 @@ public interface ClubFeedApi {
     @ApiResponse(responseCode = "204", description = "동아리 피드 수정 성공")
     @ResponseStatus(HttpStatus.NO_CONTENT)
     @SecurityRequirement(name = "AccessToken")
-    @PutMapping("/clubs/feeds/{feedId}")
+    @PutMapping("/my/feeds/{feedId}")
     void updateFeed(
         @PathVariable("feedId") Long feedId,
         @RequestBody @Valid UpdateFeedRequest updateFeedRequest
@@ -46,9 +50,20 @@ public interface ClubFeedApi {
     @ApiResponse(responseCode = "204", description = "동아리 피드 삭제 성공")
     @ResponseStatus(HttpStatus.NO_CONTENT)
     @SecurityRequirement(name = "AccessToken")
-    @DeleteMapping("/clubs/feeds/{feedId}")
+    @DeleteMapping("/my/feeds/{feedId}")
     void deleteFeed(
         @PathVariable("feedId") Long feedId
     );
 
+    @Operation(summary = "중앙 동아리 피드 목록 조회 API")
+    @ApiResponse(responseCode = "200", description = "중앙 동아리 피드 목록 조회 성공",
+        content = @Content(schema = @Schema(implementation = MyFeedPageResponse.class)))
+    @ResponseStatus(HttpStatus.OK)
+    @SecurityRequirement(name = "AccessToken")
+    @DeleteMapping("/my/feeds")
+    MyFeedPageResponse getMyFeedPage(
+        @AuthenticationPrincipal PrincipalDetails principalDetails,
+        @RequestParam(value = "size", defaultValue = "9") int size,
+        @RequestParam(value = "currentCursorId", defaultValue = "-1") Long currentCursorId
+    );
 }

--- a/src/main/java/ddingdong/ddingdongBE/domain/feed/controller/ClubFeedController.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/feed/controller/ClubFeedController.java
@@ -4,7 +4,9 @@ import ddingdong.ddingdongBE.auth.PrincipalDetails;
 import ddingdong.ddingdongBE.domain.feed.api.ClubFeedApi;
 import ddingdong.ddingdongBE.domain.feed.controller.dto.request.CreateFeedRequest;
 import ddingdong.ddingdongBE.domain.feed.controller.dto.request.UpdateFeedRequest;
+import ddingdong.ddingdongBE.domain.feed.controller.dto.response.MyFeedPageResponse;
 import ddingdong.ddingdongBE.domain.feed.service.FacadeClubFeedService;
+import ddingdong.ddingdongBE.domain.feed.service.dto.query.MyFeedPageQuery;
 import ddingdong.ddingdongBE.domain.user.entity.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.RestController;
@@ -35,5 +37,12 @@ public class ClubFeedController implements ClubFeedApi {
     @Override
     public void deleteFeed(Long feedId) {
         facadeClubFeedService.delete(feedId);
+    }
+
+    @Override
+    public MyFeedPageResponse getMyFeedPage(PrincipalDetails principalDetails, int size, Long currentCursorId) {
+        User user = principalDetails.getUser();
+        MyFeedPageQuery query = facadeClubFeedService.getMyFeedPage(user, size, currentCursorId);
+        return MyFeedPageResponse.from(query);
     }
 }

--- a/src/main/java/ddingdong/ddingdongBE/domain/feed/controller/dto/request/CreateFeedRequest.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/feed/controller/dto/request/CreateFeedRequest.java
@@ -12,16 +12,16 @@ public record CreateFeedRequest(
     @Schema(description = "이미지/비디오 식별자 id", example = "0192c828-ffce-7ee8-94a8-d9d4c8cdec00")
     @NotNull(message = "mediaId는 null이 될 수 없습니다.")
     String mediaId,
-    @Schema(description = "컨텐츠 종류", example = "IMAGE")
+    @Schema(description = "컨텐츠 종류", example = "image/png")
     @NotNull(message = "contentType은 null이 될 수 없습니다.")
-    String contentType
+    String mimeType
 ) {
 
     public CreateFeedCommand toCommand(User user) {
         return CreateFeedCommand.builder()
             .activityContent(activityContent)
             .mediaId(mediaId)
-            .contentType(contentType)
+            .mimeType(mimeType)
             .user(user)
             .build();
     }

--- a/src/main/java/ddingdong/ddingdongBE/domain/feed/controller/dto/request/CreateFeedRequest.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/feed/controller/dto/request/CreateFeedRequest.java
@@ -13,7 +13,7 @@ public record CreateFeedRequest(
     @NotNull(message = "mediaId는 null이 될 수 없습니다.")
     String mediaId,
     @Schema(description = "컨텐츠 종류", example = "image/png")
-    @NotNull(message = "contentType은 null이 될 수 없습니다.")
+    @NotNull(message = "mimeType은 null이 될 수 없습니다.")
     String mimeType
 ) {
 

--- a/src/main/java/ddingdong/ddingdongBE/domain/feed/controller/dto/response/MyFeedPageResponse.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/feed/controller/dto/response/MyFeedPageResponse.java
@@ -1,0 +1,46 @@
+package ddingdong.ddingdongBE.domain.feed.controller.dto.response;
+
+import ddingdong.ddingdongBE.domain.feed.service.dto.query.FeedListQuery;
+import ddingdong.ddingdongBE.domain.feed.service.dto.query.MyFeedPageQuery;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+import lombok.Builder;
+
+public record MyFeedPageResponse(
+    @ArraySchema(schema = @Schema(name = "동아리 피드 정보", implementation = MyFeedPageResponse.class))
+    List<MyFeedListResponse> clubFeeds,
+    @Schema(name = "피드 페이지 정보", implementation = PagingResponse.class)
+    PagingResponse pagingInfo
+) {
+
+
+    public static MyFeedPageResponse from(MyFeedPageQuery myFeedPageQuery) {
+        List<MyFeedListResponse> clubFeeds = myFeedPageQuery.feedListQueries().stream()
+            .map(MyFeedListResponse::from)
+            .toList();
+        return new MyFeedPageResponse(clubFeeds, PagingResponse.from(myFeedPageQuery.pagingQuery()));
+    }
+
+    @Builder
+    record MyFeedListResponse(
+        @Schema(description = "피드 ID", example = "1")
+        Long id,
+        @Schema(description = "피드 썸네일 CDN URL", example = "https://%s.s3.%s.amazonaws.com/%s/%s/%s")
+        String thumbnailCdnUrl,
+        @Schema(description = "피드 썸네일 S3 URL", example = "https://%s.s3.%s.amazonaws.com/%s/%s/%s")
+        String thumbnailOriginUrl,
+        @Schema(description = "피드 타입", example = "IMAGE")
+        String feedType
+    ) {
+
+        public static MyFeedListResponse from(FeedListQuery feedListQuery) {
+            return MyFeedListResponse.builder()
+                .id(feedListQuery.id())
+                .thumbnailCdnUrl(feedListQuery.thumbnailCdnUrl())
+                .thumbnailOriginUrl(feedListQuery.thumbnailOriginUrl())
+                .feedType(feedListQuery.feedType())
+                .build();
+        }
+    }
+}

--- a/src/main/java/ddingdong/ddingdongBE/domain/feed/service/FacadeClubFeedService.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/feed/service/FacadeClubFeedService.java
@@ -2,6 +2,8 @@ package ddingdong.ddingdongBE.domain.feed.service;
 
 import ddingdong.ddingdongBE.domain.feed.service.dto.command.CreateFeedCommand;
 import ddingdong.ddingdongBE.domain.feed.service.dto.command.UpdateFeedCommand;
+import ddingdong.ddingdongBE.domain.feed.service.dto.query.MyFeedPageQuery;
+import ddingdong.ddingdongBE.domain.user.entity.User;
 
 public interface FacadeClubFeedService {
 
@@ -10,4 +12,6 @@ public interface FacadeClubFeedService {
     void update(UpdateFeedCommand command);
 
     void delete(Long feedId);
+
+    MyFeedPageQuery getMyFeedPage(User user, int size, Long currentCursorId);
 }

--- a/src/main/java/ddingdong/ddingdongBE/domain/feed/service/FacadeFeedService.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/feed/service/FacadeFeedService.java
@@ -22,7 +22,6 @@ public class FacadeFeedService {
   private final FeedService feedService;
   private final FeedFileService feedFileService;
 
-
   public ClubFeedPageQuery getFeedPageByClub(Long clubId, int size, Long currentCursorId) {
     Slice<Feed> feedPage = feedService.getFeedPageByClubId(clubId, size, currentCursorId);
     List<Feed> feeds = feedPage.getContent();

--- a/src/main/java/ddingdong/ddingdongBE/domain/feed/service/FacadeFeedService.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/feed/service/FacadeFeedService.java
@@ -8,6 +8,8 @@ import ddingdong.ddingdongBE.domain.feed.service.dto.query.FeedListQuery;
 import ddingdong.ddingdongBE.domain.feed.service.dto.query.FeedQuery;
 import ddingdong.ddingdongBE.domain.feed.service.dto.query.NewestFeedPerClubPageQuery;
 import ddingdong.ddingdongBE.domain.feed.service.dto.query.PagingQuery;
+import ddingdong.ddingdongBE.domain.vodprocessing.entity.VodProcessingJob;
+import ddingdong.ddingdongBE.domain.vodprocessing.service.VodProcessingJobService;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Slice;
@@ -21,13 +23,21 @@ public class FacadeFeedService {
 
   private final FeedService feedService;
   private final FeedFileService feedFileService;
+  private final VodProcessingJobService vodProcessingJobService;
 
   public ClubFeedPageQuery getFeedPageByClub(Long clubId, int size, Long currentCursorId) {
     Slice<Feed> feedPage = feedService.getFeedPageByClubId(clubId, size, currentCursorId);
-    List<Feed> feeds = feedPage.getContent();
+    List<Feed> completeFeeds = feedPage.getContent().stream()
+        .filter(feed -> {
+          if (feed.isVideo()) {
+            VodProcessingJob vodProcessingJob = vodProcessingJobService.findByVideoFeedId(feed.getId());
+            return vodProcessingJob.isCompleteNotification();
+          }
+          return true;
+        }).toList();
 
-    List<FeedListQuery> feedListQueries = feeds.stream().map(feedFileService::extractFeedThumbnailInfo).toList();
-    PagingQuery pagingQuery = PagingQuery.of(currentCursorId, feeds.get(feeds.size() -1).getId(), feedPage.hasNext());
+    List<FeedListQuery> feedListQueries = completeFeeds.stream().map(feedFileService::extractFeedThumbnailInfo).toList();
+    PagingQuery pagingQuery = PagingQuery.of(currentCursorId, completeFeeds.get(completeFeeds.size() -1).getId(), feedPage.hasNext());
 
     return ClubFeedPageQuery.of(feedListQueries, pagingQuery);
   }

--- a/src/main/java/ddingdong/ddingdongBE/domain/feed/service/FacadeFeedService.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/feed/service/FacadeFeedService.java
@@ -1,7 +1,5 @@
 package ddingdong.ddingdongBE.domain.feed.service;
 
-import ddingdong.ddingdongBE.common.exception.PersistenceException.ResourceNotFound;
-import ddingdong.ddingdongBE.domain.club.entity.Club;
 import ddingdong.ddingdongBE.domain.feed.entity.Feed;
 import ddingdong.ddingdongBE.domain.feed.service.dto.query.ClubFeedPageQuery;
 import ddingdong.ddingdongBE.domain.feed.service.dto.query.ClubProfileQuery;
@@ -10,12 +8,6 @@ import ddingdong.ddingdongBE.domain.feed.service.dto.query.FeedListQuery;
 import ddingdong.ddingdongBE.domain.feed.service.dto.query.FeedQuery;
 import ddingdong.ddingdongBE.domain.feed.service.dto.query.NewestFeedPerClubPageQuery;
 import ddingdong.ddingdongBE.domain.feed.service.dto.query.PagingQuery;
-import ddingdong.ddingdongBE.domain.filemetadata.entity.DomainType;
-import ddingdong.ddingdongBE.domain.filemetadata.entity.FileMetaData;
-import ddingdong.ddingdongBE.domain.filemetadata.service.FileMetaDataService;
-import ddingdong.ddingdongBE.file.service.S3FileService;
-import ddingdong.ddingdongBE.file.service.dto.query.UploadedFileUrlQuery;
-import ddingdong.ddingdongBE.file.service.dto.query.UploadedVideoUrlQuery;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Slice;
@@ -28,14 +20,14 @@ import org.springframework.transaction.annotation.Transactional;
 public class FacadeFeedService {
 
   private final FeedService feedService;
-  private final FileMetaDataService fileMetaDataService;
-  private final S3FileService s3FileService;
+  private final FeedFileService feedFileService;
+
 
   public ClubFeedPageQuery getFeedPageByClub(Long clubId, int size, Long currentCursorId) {
     Slice<Feed> feedPage = feedService.getFeedPageByClubId(clubId, size, currentCursorId);
     List<Feed> feeds = feedPage.getContent();
 
-    List<FeedListQuery> feedListQueries = feeds.stream().map(this::extractFeedThumbnailInfo).toList();
+    List<FeedListQuery> feedListQueries = feeds.stream().map(feedFileService::extractFeedThumbnailInfo).toList();
     PagingQuery pagingQuery = PagingQuery.of(currentCursorId, feeds.get(feeds.size() -1).getId(), feedPage.hasNext());
 
     return ClubFeedPageQuery.of(feedListQueries, pagingQuery);
@@ -45,7 +37,7 @@ public class FacadeFeedService {
     Slice<Feed> feedPage = feedService.getNewestFeedPerClubPage(size, currentCursorId);
     List<Feed> feeds = feedPage.getContent();
 
-    List<FeedListQuery> feedListQueries = feeds.stream().map(this::extractFeedThumbnailInfo).toList();
+    List<FeedListQuery> feedListQueries = feeds.stream().map(feedFileService::extractFeedThumbnailInfo).toList();
     PagingQuery pagingQuery = PagingQuery.of(currentCursorId, feeds.get(feeds.size() -1).getId(), feedPage.hasNext());
 
     return NewestFeedPerClubPageQuery.of(feedListQueries, pagingQuery);
@@ -53,62 +45,8 @@ public class FacadeFeedService {
 
   public FeedQuery getById(Long feedId) {
     Feed feed = feedService.getById(feedId);
-    ClubProfileQuery clubProfileQuery = extractClubInfo(feed.getClub());
-    FeedFileUrlQuery feedFileUrlQuery = extractFeedFileInfo(feed);
+    ClubProfileQuery clubProfileQuery = feedFileService.extractClubInfo(feed.getClub());
+    FeedFileUrlQuery feedFileUrlQuery = feedFileService.extractFeedFileInfo(feed);
     return FeedQuery.of(feed, clubProfileQuery, feedFileUrlQuery);
-  }
-
-  private FeedListQuery extractFeedThumbnailInfo(Feed feed) {
-    FileMetaData fileMetaData = getFileMetaData(feed.getFeedType().getDomainType(), feed.getId());
-    if (feed.isImage()) {
-      UploadedFileUrlQuery urlQuery = s3FileService.getUploadedFileUrl(fileMetaData.getFileKey());
-      return new FeedListQuery(feed.getId(), urlQuery.cdnUrl(), urlQuery.originUrl(), feed.getFeedType().name());
-    }
-
-    if (feed.isVideo()) {
-      UploadedVideoUrlQuery urlQuery = s3FileService.getUploadedVideoUrl(fileMetaData.getFileKey());
-      return new FeedListQuery(feed.getId(), urlQuery.thumbnailCdnUrl(), urlQuery.thumbnailOriginUrl(), feed.getFeedType().name());
-    }
-
-    throw new IllegalArgumentException("FeedType은 Image 혹은 Video여야 합니다.");
-  }
-
-  private FeedFileUrlQuery extractFeedFileInfo(Feed feed) {
-    FileMetaData fileMetaData = getFileMetaData(feed.getFeedType().getDomainType(), feed.getId());
-    if (feed.isImage()) {
-      UploadedFileUrlQuery urlQuery = s3FileService.getUploadedFileUrl(fileMetaData.getFileKey());
-      return new FeedFileUrlQuery(urlQuery.id(), urlQuery.originUrl(), urlQuery.cdnUrl());
-    }
-
-    if (feed.isVideo()) {
-      UploadedVideoUrlQuery urlQuery = s3FileService.getUploadedVideoUrl(fileMetaData.getFileKey());
-      return new FeedFileUrlQuery(fileMetaData.getId().toString(), urlQuery.videoOriginUrl(), urlQuery.videoCdnUrl());
-    }
-
-    throw new IllegalArgumentException("FeedType은 Image 혹은 Video여야 합니다.");
-  }
-
-  private ClubProfileQuery extractClubInfo(Club club) {
-    String clubName = club.getName();
-    UploadedFileUrlQuery urlQuery = getFileUrl(DomainType.CLUB_PROFILE, club.getId());
-    if (urlQuery == null) {
-      return new ClubProfileQuery(club.getId(), clubName, null, null);
-    }
-    return new ClubProfileQuery(club.getId(), clubName, urlQuery.originUrl(), urlQuery.cdnUrl());
-  }
-
-  private FileMetaData getFileMetaData(DomainType domainType, Long id) {
-    return fileMetaDataService.getCoupledAllByDomainTypeAndEntityId(domainType, id)
-        .stream()
-        .findFirst()
-        .orElseThrow(() -> new ResourceNotFound("해당 FileMetaData(feedId: " + id + ")를 찾을 수 없습니다.)"));
-  }
-
-  private UploadedFileUrlQuery getFileUrl(DomainType domainType, Long clubId) {
-    return fileMetaDataService.getCoupledAllByDomainTypeAndEntityId(domainType, clubId)
-        .stream()
-        .map(fileMetaData -> s3FileService.getUploadedFileUrl(fileMetaData.getFileKey()))
-        .findFirst()
-        .orElse(null);
   }
 }

--- a/src/main/java/ddingdong/ddingdongBE/domain/feed/service/FeedFileService.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/feed/service/FeedFileService.java
@@ -1,0 +1,80 @@
+package ddingdong.ddingdongBE.domain.feed.service;
+
+import ddingdong.ddingdongBE.common.exception.PersistenceException.ResourceNotFound;
+import ddingdong.ddingdongBE.domain.club.entity.Club;
+import ddingdong.ddingdongBE.domain.feed.entity.Feed;
+import ddingdong.ddingdongBE.domain.feed.service.dto.query.ClubProfileQuery;
+import ddingdong.ddingdongBE.domain.feed.service.dto.query.FeedFileUrlQuery;
+import ddingdong.ddingdongBE.domain.feed.service.dto.query.FeedListQuery;
+import ddingdong.ddingdongBE.domain.filemetadata.entity.DomainType;
+import ddingdong.ddingdongBE.domain.filemetadata.entity.FileMetaData;
+import ddingdong.ddingdongBE.domain.filemetadata.service.FileMetaDataService;
+import ddingdong.ddingdongBE.file.service.S3FileService;
+import ddingdong.ddingdongBE.file.service.dto.query.UploadedFileUrlQuery;
+import ddingdong.ddingdongBE.file.service.dto.query.UploadedVideoUrlQuery;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class FeedFileService {
+
+    private final FileMetaDataService fileMetaDataService;
+    private final S3FileService s3FileService;
+
+    public FeedListQuery extractFeedThumbnailInfo(Feed feed) {
+        FileMetaData fileMetaData = getFileMetaData(feed.getFeedType().getDomainType(), feed.getId());
+        if (feed.isImage()) {
+            UploadedFileUrlQuery urlQuery = s3FileService.getUploadedFileUrl(fileMetaData.getFileKey());
+            return new FeedListQuery(feed.getId(), urlQuery.cdnUrl(), urlQuery.originUrl(), feed.getFeedType().name());
+        }
+
+        if (feed.isVideo()) {
+            UploadedVideoUrlQuery urlQuery = s3FileService.getUploadedVideoUrl(fileMetaData.getFileKey());
+            return new FeedListQuery(feed.getId(), urlQuery.thumbnailCdnUrl(), urlQuery.thumbnailOriginUrl(), feed.getFeedType().name());
+        }
+
+        throw new IllegalArgumentException("FeedType은 Image 혹은 Video여야 합니다.");
+    }
+
+    public FeedFileUrlQuery extractFeedFileInfo(Feed feed) {
+        FileMetaData fileMetaData = getFileMetaData(feed.getFeedType().getDomainType(), feed.getId());
+        if (feed.isImage()) {
+            UploadedFileUrlQuery urlQuery = s3FileService.getUploadedFileUrl(fileMetaData.getFileKey());
+            return new FeedFileUrlQuery(urlQuery.id(), urlQuery.originUrl(), urlQuery.cdnUrl());
+        }
+
+        if (feed.isVideo()) {
+            UploadedVideoUrlQuery urlQuery = s3FileService.getUploadedVideoUrl(fileMetaData.getFileKey());
+            return new FeedFileUrlQuery(fileMetaData.getId().toString(), urlQuery.videoOriginUrl(), urlQuery.videoCdnUrl());
+        }
+
+        throw new IllegalArgumentException("FeedType은 Image 혹은 Video여야 합니다.");
+    }
+
+    public ClubProfileQuery extractClubInfo(Club club) {
+        String clubName = club.getName();
+        UploadedFileUrlQuery urlQuery = getFileUrl(DomainType.CLUB_PROFILE, club.getId());
+        if (urlQuery == null) {
+            return new ClubProfileQuery(club.getId(), clubName, null, null);
+        }
+        return new ClubProfileQuery(club.getId(), clubName, urlQuery.originUrl(), urlQuery.cdnUrl());
+    }
+
+    private FileMetaData getFileMetaData(DomainType domainType, Long id) {
+        return fileMetaDataService.getCoupledAllByDomainTypeAndEntityId(domainType, id)
+            .stream()
+            .findFirst()
+            .orElseThrow(() -> new ResourceNotFound("해당 FileMetaData(feedId: " + id + ")를 찾을 수 없습니다.)"));
+    }
+
+    private UploadedFileUrlQuery getFileUrl(DomainType domainType, Long clubId) {
+        return fileMetaDataService.getCoupledAllByDomainTypeAndEntityId(domainType, clubId)
+            .stream()
+            .map(fileMetaData -> s3FileService.getUploadedFileUrl(fileMetaData.getFileKey()))
+            .findFirst()
+            .orElse(null);
+    }
+}

--- a/src/main/java/ddingdong/ddingdongBE/domain/feed/service/FeedService.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/feed/service/FeedService.java
@@ -1,8 +1,8 @@
 package ddingdong.ddingdongBE.domain.feed.service;
 
 import ddingdong.ddingdongBE.domain.feed.entity.Feed;
-import org.springframework.data.domain.Slice;
 import java.util.Optional;
+import org.springframework.data.domain.Slice;
 
 public interface FeedService {
 

--- a/src/main/java/ddingdong/ddingdongBE/domain/feed/service/dto/command/CreateFeedCommand.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/feed/service/dto/command/CreateFeedCommand.java
@@ -4,21 +4,23 @@ import ddingdong.ddingdongBE.domain.club.entity.Club;
 import ddingdong.ddingdongBE.domain.feed.entity.Feed;
 import ddingdong.ddingdongBE.domain.feed.entity.FeedType;
 import ddingdong.ddingdongBE.domain.user.entity.User;
+import ddingdong.ddingdongBE.file.service.ContentType;
 import lombok.Builder;
 
 @Builder
 public record CreateFeedCommand(
     String activityContent,
     String mediaId,
-    String contentType,
+    String mimeType,
     User user
 ) {
 
     public Feed toEntity(Club club) {
+        String mediaType = ContentType.fromMimeType(mimeType).getKeyMediaType();
         return Feed.builder()
             .activityContent(activityContent)
             .club(club)
-            .feedType(FeedType.findByContentType(contentType))
+            .feedType(FeedType.findByContentType(mediaType))
             .build();
     }
 }

--- a/src/main/java/ddingdong/ddingdongBE/domain/feed/service/dto/query/MyFeedPageQuery.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/feed/service/dto/query/MyFeedPageQuery.java
@@ -1,0 +1,13 @@
+package ddingdong.ddingdongBE.domain.feed.service.dto.query;
+
+import java.util.List;
+
+public record MyFeedPageQuery(
+    List<FeedListQuery> feedListQueries,
+    PagingQuery pagingQuery
+) {
+
+    public static MyFeedPageQuery of(List<FeedListQuery> feedListQueries, PagingQuery pagingQuery) {
+        return new MyFeedPageQuery(feedListQueries, pagingQuery);
+    }
+}

--- a/src/main/java/ddingdong/ddingdongBE/domain/vodprocessing/entity/VodProcessingJob.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/vodprocessing/entity/VodProcessingJob.java
@@ -61,4 +61,8 @@ public class VodProcessingJob extends BaseEntity {
     public boolean isPossibleNotify() {
         return this.convertJobStatus == ConvertJobStatus.COMPLETE || this.convertJobStatus == ConvertJobStatus.ERROR;
     }
+
+    public boolean isCompleteNotification() {
+        return this.vodProcessingNotification.getVodNotificationStatus() == VodNotificationStatus.COMPLETED;
+    }
 }

--- a/src/main/java/ddingdong/ddingdongBE/domain/vodprocessing/service/GeneralVodProcessingJobService.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/vodprocessing/service/GeneralVodProcessingJobService.java
@@ -44,4 +44,12 @@ public class GeneralVodProcessingJobService implements VodProcessingJobService {
                 .orElseThrow(() -> new ResourceNotFound(
                         "VodProcessingJob(videoFeedId=" + videoFeedId + ")를 찾을 수 없습니다."));
     }
+
+    @Override
+    public VodProcessingJob findByVideoFeedId(Long videoFeedId) {
+        return vodProcessingJobRepository.findFirstByFileMetaDataEntityIdAndDomainType(
+                videoFeedId,
+                DomainType.FEED_VIDEO)
+            .orElse(null);
+    }
 }

--- a/src/main/java/ddingdong/ddingdongBE/domain/vodprocessing/service/VodProcessingJobService.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/vodprocessing/service/VodProcessingJobService.java
@@ -12,4 +12,5 @@ public interface VodProcessingJobService {
 
     VodProcessingJob getByVideoFeedId(Long videoFeedId);
 
+    VodProcessingJob findByVideoFeedId(Long id);
 }

--- a/src/main/java/ddingdong/ddingdongBE/file/service/ContentType.java
+++ b/src/main/java/ddingdong/ddingdongBE/file/service/ContentType.java
@@ -50,4 +50,14 @@ public enum ContentType {
         return OCTET_STREAM;
     }
 
+
+    public static ContentType fromMimeType(String mimeType) {
+        String lowerExtension = mimeType.substring(mimeType.lastIndexOf("/") + 1).toLowerCase();
+        for (ContentType contentType : values()) {
+            if (contentType.extensions.contains(lowerExtension)) {
+                return contentType;
+            }
+        }
+        return OCTET_STREAM;
+    }
 }


### PR DESCRIPTION
## 🚀 작업 내용
- 중앙동아리 피드 목록 조회 API 구현하였습니다.
- 기존 피드 생성 API에서 ContentType으로 피드 타입을 구별하였는데, mimeType으로 구별하도록 수정하였습니다.
- vodProcessingJob의 notification이 Complete일 때만 feed 조회가능하도록 수정하였습니다

## 🤔 고민했던 내용
- Feed관련된 file 서비스의 코드가 중복되고, 부피가 커져 리팩토링의 필요성이 느껴져 Feed의 파일 로직을 담당하는 클래스를 생성하였습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **새로운 기능**
	- 사용자별 피드 페이지 조회 기능 추가
	- 피드 썸네일 정보 추출 및 페이징 지원
	- 클럽 관련 파일 및 정보 처리 서비스 개선
	- 비디오 피드 ID로 VOD 처리 작업 조회 기능 추가

- **버그 수정**
	- 피드 엔드포인트 경로 업데이트 및 일관성 개선

- **리팩토링**
	- 파일 서비스 로직 중앙화 및 모듈화
	- 파일 및 피드 관련 서비스 구조 최적화

<!-- end of auto-generated comment: release notes by coderabbit.ai -->