### PR TITLE
[DDING-82] OSIV 비활성화로 인한 지연로딩 에러 수정

### DIFF
--- a/src/main/java/ddingdong/ddingdongBE/domain/club/repository/ClubRepository.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/club/repository/ClubRepository.java
@@ -2,6 +2,7 @@ package ddingdong.ddingdongBE.domain.club.repository;
 
 import ddingdong.ddingdongBE.domain.club.entity.Club;
 import java.util.Optional;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -10,4 +11,6 @@ public interface ClubRepository extends JpaRepository<Club, Long> {
 
     Optional<Club> findByUserId(Long userId);
 
+    @EntityGraph(attributePaths = {"clubMembers"})
+    Optional<Club> findEntityGraphByUserId(Long userId);
 }

--- a/src/main/java/ddingdong/ddingdongBE/domain/club/service/ClubService.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/club/service/ClubService.java
@@ -17,6 +17,5 @@ public interface ClubService {
 
     void delete(Long clubId);
 
-
-
+    Club getByUserIdWithFetch(Long userId);
 }

--- a/src/main/java/ddingdong/ddingdongBE/domain/club/service/GeneralClubService.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/club/service/GeneralClubService.java
@@ -37,6 +37,11 @@ public class GeneralClubService implements ClubService {
     }
 
     @Override
+    public Club getByUserIdWithFetch(Long userId) {
+        return clubRepository.findEntityGraphByUserId(userId)
+                .orElseThrow(() -> new ResourceNotFound("Club(userId=" + userId + ")를 찾을 수 없습니다."));    }
+
+    @Override
     public List<Club> findAll() {
         return clubRepository.findAll();
     }
@@ -53,5 +58,4 @@ public class GeneralClubService implements ClubService {
         Club club = getById(clubId);
         clubRepository.delete(club);
     }
-
 }

--- a/src/main/java/ddingdong/ddingdongBE/domain/club/service/GeneralClubService.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/club/service/GeneralClubService.java
@@ -5,12 +5,14 @@ import ddingdong.ddingdongBE.domain.club.entity.Club;
 import ddingdong.ddingdongBE.domain.club.repository.ClubRepository;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @Transactional(readOnly = true)
 @RequiredArgsConstructor
+@Slf4j
 public class GeneralClubService implements ClubService {
 
     private final ClubRepository clubRepository;

--- a/src/main/java/ddingdong/ddingdongBE/domain/clubmember/service/FacadeCentralClubMemberServiceImpl.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/clubmember/service/FacadeCentralClubMemberServiceImpl.java
@@ -34,10 +34,8 @@ public class FacadeCentralClubMemberServiceImpl implements FacadeCentralClubMemb
 
     @Override
     public AllClubMemberInfoQuery getAllMyClubMember(Long userId) {
-        Club club = clubService.getByUserId(userId);
-        List<ClubMember> clubMembers = club.getClubMembers();
-        clubMembers.size(); //프록시 객체 초기화
-        return AllClubMemberInfoQuery.of(club.getName(), clubMembers);
+        Club club = clubService.getByUserIdWithFetch(userId);
+        return AllClubMemberInfoQuery.of(club.getName(), club.getClubMembers());
     }
 
     @Override

--- a/src/main/java/ddingdong/ddingdongBE/domain/clubmember/service/FacadeCentralClubMemberServiceImpl.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/clubmember/service/FacadeCentralClubMemberServiceImpl.java
@@ -12,12 +12,14 @@ import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @Transactional(readOnly = true)
 @RequiredArgsConstructor
+@Slf4j
 public class FacadeCentralClubMemberServiceImpl implements FacadeCentralClubMemberService {
 
     private final ClubService clubService;
@@ -33,7 +35,9 @@ public class FacadeCentralClubMemberServiceImpl implements FacadeCentralClubMemb
     @Override
     public AllClubMemberInfoQuery getAllMyClubMember(Long userId) {
         Club club = clubService.getByUserId(userId);
-        return AllClubMemberInfoQuery.of(club.getName(), club.getClubMembers());
+        List<ClubMember> clubMembers = club.getClubMembers();
+        clubMembers.size(); //프록시 객체 초기화
+        return AllClubMemberInfoQuery.of(club.getName(), clubMembers);
     }
 
     @Override

--- a/src/main/java/ddingdong/ddingdongBE/domain/scorehistory/controller/dto/response/AdminScoreHistoryListResponse.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/scorehistory/controller/dto/response/AdminScoreHistoryListResponse.java
@@ -24,7 +24,7 @@ public record AdminScoreHistoryListResponse(
 
     public static AdminScoreHistoryListResponse from(AdminClubScoreHistoryListQuery query) {
         return new AdminScoreHistoryListResponse(
-                query.club().getScore().getValue(),
+                query.clubTotalScore(),
                 query.scoreHistories().stream()
                         .map(ScoreHistoryResponse::from)
                         .toList()

--- a/src/main/java/ddingdong/ddingdongBE/domain/scorehistory/controller/dto/response/ClubScoreHistoryListResponse.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/scorehistory/controller/dto/response/ClubScoreHistoryListResponse.java
@@ -23,7 +23,7 @@ public record ClubScoreHistoryListResponse(
 
     public static ClubScoreHistoryListResponse from(ClubScoreHistoryListQuery query) {
         return new ClubScoreHistoryListResponse(
-                query.club().getScore().getValue(),
+                query.clubTotalScore(),
                 query.scoreHistories().stream()
                         .map(ScoreHistoryResponse::from)
                         .toList()

--- a/src/main/java/ddingdong/ddingdongBE/domain/scorehistory/service/FacadeAdminScoreHistoryServiceImpl.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/scorehistory/service/FacadeAdminScoreHistoryServiceImpl.java
@@ -34,7 +34,7 @@ public class FacadeAdminScoreHistoryServiceImpl implements FacadeAdminScoreHisto
     public AdminClubScoreHistoryListQuery findAllByClubId(Long clubId) {
         Club club = clubService.getById(clubId);
         List<ScoreHistory> scoreHistories = scoreHistoryService.findAllByClubId(clubId);
-        return AdminClubScoreHistoryListQuery.of(club, scoreHistories);
+        return AdminClubScoreHistoryListQuery.of(club.getScore().getValue(), scoreHistories);
     }
 
     private BigDecimal roundToThirdPoint(BigDecimal value) {

--- a/src/main/java/ddingdong/ddingdongBE/domain/scorehistory/service/FacadeClubScoreHistoryServiceImpl.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/scorehistory/service/FacadeClubScoreHistoryServiceImpl.java
@@ -3,7 +3,6 @@ package ddingdong.ddingdongBE.domain.scorehistory.service;
 import ddingdong.ddingdongBE.domain.club.entity.Club;
 import ddingdong.ddingdongBE.domain.club.service.ClubService;
 import ddingdong.ddingdongBE.domain.scorehistory.entity.ScoreHistory;
-import ddingdong.ddingdongBE.domain.scorehistory.service.dto.query.AdminClubScoreHistoryListQuery;
 import ddingdong.ddingdongBE.domain.scorehistory.service.dto.query.ClubScoreHistoryListQuery;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -22,6 +21,6 @@ public class FacadeClubScoreHistoryServiceImpl implements FacadeClubScoreHistory
     public ClubScoreHistoryListQuery findMyScoreHistories(Long userId) {
         Club club = clubService.getByUserId(userId);
         List<ScoreHistory> scoreHistories = scoreHistoryService.findAllByClubId(club.getId());
-        return ClubScoreHistoryListQuery.of(club, scoreHistories);
+        return ClubScoreHistoryListQuery.of(club.getScore().getValue(), scoreHistories);
     }
 }

--- a/src/main/java/ddingdong/ddingdongBE/domain/scorehistory/service/dto/query/AdminClubScoreHistoryListQuery.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/scorehistory/service/dto/query/AdminClubScoreHistoryListQuery.java
@@ -1,15 +1,15 @@
 package ddingdong.ddingdongBE.domain.scorehistory.service.dto.query;
 
-import ddingdong.ddingdongBE.domain.club.entity.Club;
 import ddingdong.ddingdongBE.domain.scorehistory.entity.ScoreHistory;
+import java.math.BigDecimal;
 import java.util.List;
 
 public record AdminClubScoreHistoryListQuery(
-        Club club,
+        BigDecimal clubTotalScore,
         List<ScoreHistory> scoreHistories
 ) {
 
-    public static AdminClubScoreHistoryListQuery of(Club club, List<ScoreHistory> scoreHistories) {
-        return new AdminClubScoreHistoryListQuery(club, scoreHistories);
+    public static AdminClubScoreHistoryListQuery of(BigDecimal clubTotalScore, List<ScoreHistory> scoreHistories) {
+        return new AdminClubScoreHistoryListQuery(clubTotalScore, scoreHistories);
     }
 }

--- a/src/main/java/ddingdong/ddingdongBE/domain/scorehistory/service/dto/query/ClubScoreHistoryListQuery.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/scorehistory/service/dto/query/ClubScoreHistoryListQuery.java
@@ -1,15 +1,15 @@
 package ddingdong.ddingdongBE.domain.scorehistory.service.dto.query;
 
-import ddingdong.ddingdongBE.domain.club.entity.Club;
 import ddingdong.ddingdongBE.domain.scorehistory.entity.ScoreHistory;
+import java.math.BigDecimal;
 import java.util.List;
 
 public record ClubScoreHistoryListQuery(
-        Club club,
+        BigDecimal clubTotalScore,
         List<ScoreHistory> scoreHistories
 ) {
 
-    public static ClubScoreHistoryListQuery of(Club club, List<ScoreHistory> scoreHistories) {
-        return new ClubScoreHistoryListQuery(club, scoreHistories);
+    public static ClubScoreHistoryListQuery of(BigDecimal clubTotalScore, List<ScoreHistory> scoreHistories) {
+        return new ClubScoreHistoryListQuery(clubTotalScore, scoreHistories);
     }
 }


### PR DESCRIPTION
## 🚀 작업 내용
- clubMember 명단 조회시 발생하는 Lazy Loading 초기화 오류를 수정하였습니다.
- 할당된 프록시 객체를 초기화 하지 않고, 영속성 컨텍스트가 활성화되는 Hibernate Session 범위 밖에서 프록시 객체의 속성을 사용하려다 보니 에러가 발생했던 것 같습니다.
- Session 범위 밖으로 나가기 전, 프록시 객체를 할당하도록 하였습니다.

## 🤔 고민했던 내용
- 프록시 객체를 초기화하는 방법이 여러개 있었는데 .size()를 호출함으로써 초기화하는 방법을 사용했습니다.
- 장점
  -  구현 단순
- 단점
  - 의미가 명확하지 않다.(.size()라는 이름때문에)

--- Change!!!
리뷰받고 .size() 호출 방법 -> EntityGraph를 활용하여 초기화된 객체를 가져왔습니다
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리즈 노트

- **개선 사항**
	- 클럽 점수 히스토리 관련 데이터 처리 방식 최적화
	- 클럽 엔티티와 관련된 데이터의 효율적인 조회 기능 추가

- **기술적 변경**
	- 클럽 점수 조회 로직 간소화
	- 점수 관련 쿼리 객체 구조 변경

- **기타**
	- 내부 서비스 및 컨트롤러 로깅 기능 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->