### PR TITLE
[DDING-83] Form 및 FormField 엔터티 세팅

### DIFF
--- a/src/main/java/ddingdong/ddingdongBE/common/converter/StringListConverter.java
+++ b/src/main/java/ddingdong/ddingdongBE/common/converter/StringListConverter.java
@@ -1,0 +1,31 @@
+package ddingdong.ddingdongBE.common.converter;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+import java.util.List;
+
+@Converter
+public class StringListConverter implements AttributeConverter<List<String>, String> {
+
+    private final ObjectMapper mapper = new ObjectMapper();
+
+    @Override
+    public String convertToDatabaseColumn(List<String> dataList) {
+        try {
+            return mapper.writeValueAsString(dataList);
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public List<String> convertToEntityAttribute(String data) {
+        try {
+            return mapper.readValue(data, List.class);
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/src/main/java/ddingdong/ddingdongBE/domain/form/entity/FieldType.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/form/entity/FieldType.java
@@ -1,0 +1,9 @@
+package ddingdong.ddingdongBE.domain.form.entity;
+
+public enum FieldType {
+    CHECK_BOX,
+    RADIO,
+    TEXT,
+    LONG_TEXT,
+    FILE
+}

--- a/src/main/java/ddingdong/ddingdongBE/domain/form/entity/Form.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/form/entity/Form.java
@@ -1,5 +1,6 @@
 package ddingdong.ddingdongBE.domain.form.entity;
 
+import ddingdong.ddingdongBE.common.BaseEntity;
 import ddingdong.ddingdongBE.domain.club.entity.Club;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -17,7 +18,7 @@ import lombok.NoArgsConstructor;
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
-public class Form {
+public class Form extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/ddingdong/ddingdongBE/domain/form/entity/Form.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/form/entity/Form.java
@@ -8,6 +8,7 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.ManyToOne;
+import java.time.LocalDate;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -26,6 +27,15 @@ public class Form {
     private String title;
 
     private String description;
+
+    @Column(nullable = false)
+    private LocalDate startDate;
+
+    @Column(nullable = false)
+    private LocalDate endDate;
+
+    @Column(nullable = false)
+    private boolean hasInterview;
 
     @ManyToOne(fetch = FetchType.LAZY)
     private Club club;

--- a/src/main/java/ddingdong/ddingdongBE/domain/form/entity/Form.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/form/entity/Form.java
@@ -1,0 +1,40 @@
+package ddingdong.ddingdongBE.domain.form.entity;
+
+import ddingdong.ddingdongBE.domain.club.entity.Club;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.ManyToOne;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class Form {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String title;
+
+    private String description;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Club club;
+
+    @Builder
+    public Form(String title, String description, Club club) {
+        this.title = title;
+        this.description = description;
+        this.club = club;
+    }
+
+}

--- a/src/main/java/ddingdong/ddingdongBE/domain/form/entity/Form.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/form/entity/Form.java
@@ -42,10 +42,13 @@ public class Form extends BaseEntity {
     private Club club;
 
     @Builder
-    private Form(String title, String description, Club club) {
+    private Form(String title, String description, LocalDate startDate, LocalDate endDate, boolean hasInterview,
+            Club club) {
         this.title = title;
         this.description = description;
+        this.startDate = startDate;
+        this.endDate = endDate;
+        this.hasInterview = hasInterview;
         this.club = club;
     }
-
 }

--- a/src/main/java/ddingdong/ddingdongBE/domain/form/entity/Form.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/form/entity/Form.java
@@ -31,7 +31,7 @@ public class Form {
     private Club club;
 
     @Builder
-    public Form(String title, String description, Club club) {
+    private Form(String title, String description, Club club) {
         this.title = title;
         this.description = description;
         this.club = club;

--- a/src/main/java/ddingdong/ddingdongBE/domain/form/entity/FormField.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/form/entity/FormField.java
@@ -34,7 +34,7 @@ public class FormField extends BaseEntity {
     private boolean required;
 
     @Column(nullable = false)
-    private int order;
+    private int fieldOrder;
 
     @Column(nullable = false)
     private String section;
@@ -50,12 +50,12 @@ public class FormField extends BaseEntity {
     private Form form;
 
     @Builder
-    private FormField(String question, FieldType fieldType, boolean required, int order, String section,
+    private FormField(String question, FieldType fieldType, boolean required, int fieldOrder, String section,
             List<String> options, Form form) {
         this.question = question;
         this.fieldType = fieldType;
         this.required = required;
-        this.order = order;
+        this.fieldOrder = fieldOrder;
         this.section = section;
         this.options = options;
         this.form = form;

--- a/src/main/java/ddingdong/ddingdongBE/domain/form/entity/FormField.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/form/entity/FormField.java
@@ -1,5 +1,6 @@
 package ddingdong.ddingdongBE.domain.form.entity;
 
+import ddingdong.ddingdongBE.common.BaseEntity;
 import ddingdong.ddingdongBE.common.converter.StringListConverter;
 import jakarta.persistence.Column;
 import jakarta.persistence.Convert;
@@ -20,7 +21,7 @@ import lombok.NoArgsConstructor;
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
-public class FormField {
+public class FormField extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/ddingdong/ddingdongBE/domain/form/entity/FormField.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/form/entity/FormField.java
@@ -49,7 +49,7 @@ public class FormField {
     private Form form;
 
     @Builder
-    public FormField(String question, FieldType fieldType, boolean required, int order, String section,
+    private FormField(String question, FieldType fieldType, boolean required, int order, String section,
             List<String> options, Form form) {
         this.question = question;
         this.fieldType = fieldType;

--- a/src/main/java/ddingdong/ddingdongBE/domain/form/entity/FormField.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/form/entity/FormField.java
@@ -1,0 +1,62 @@
+package ddingdong.ddingdongBE.domain.form.entity;
+
+import ddingdong.ddingdongBE.common.converter.StringListConverter;
+import jakarta.persistence.Column;
+import jakarta.persistence.Convert;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.ManyToOne;
+import java.util.List;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class FormField {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String question;
+
+    @Column(nullable = false)
+    private boolean required;
+
+    @Column(nullable = false)
+    private int order;
+
+    @Column(nullable = false)
+    private String section;
+
+    @Convert(converter = StringListConverter.class)
+    private List<String> options;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private FieldType fieldType;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Form form;
+
+    @Builder
+    public FormField(String question, FieldType fieldType, boolean required, int order, String section,
+            List<String> options, Form form) {
+        this.question = question;
+        this.fieldType = fieldType;
+        this.required = required;
+        this.order = order;
+        this.section = section;
+        this.options = options;
+        this.form = form;
+    }
+}

--- a/src/main/java/ddingdong/ddingdongBE/domain/form/repository/FormFieldRepository.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/form/repository/FormFieldRepository.java
@@ -1,0 +1,8 @@
+package ddingdong.ddingdongBE.domain.form.repository;
+
+import ddingdong.ddingdongBE.domain.form.entity.FormField;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface FormFieldRepository extends JpaRepository<FormField, Long> {
+
+}

--- a/src/main/java/ddingdong/ddingdongBE/domain/form/repository/FormRepository.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/form/repository/FormRepository.java
@@ -1,0 +1,8 @@
+package ddingdong.ddingdongBE.domain.form.repository;
+
+import ddingdong.ddingdongBE.domain.form.entity.Form;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface FormRepository extends JpaRepository<Form, Long> {
+
+}

--- a/src/main/resources/db/migration/V34__from_and_field_create_table.sql
+++ b/src/main/resources/db/migration/V34__from_and_field_create_table.sql
@@ -7,6 +7,8 @@ CREATE TABLE form
     end_date      DATE         NOT NULL,
     has_interview BOOLEAN      NOT NULL,
     club_id       BIGINT,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP NULL,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP NULL,
     CONSTRAINT fk_form_club FOREIGN KEY (club_id) REFERENCES club (id) ON DELETE CASCADE
 );
 
@@ -20,5 +22,7 @@ CREATE TABLE form_field
     section    VARCHAR(255) NOT NULL,
     options    TEXT,
     form_id    BIGINT,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP NULL,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP NULL,
     CONSTRAINT fk_form_field_form FOREIGN KEY (form_id) REFERENCES form (id) ON DELETE CASCADE
 );

--- a/src/main/resources/db/migration/V34__from_and_field_create_table.sql
+++ b/src/main/resources/db/migration/V34__from_and_field_create_table.sql
@@ -1,0 +1,21 @@
+CREATE TABLE form
+(
+    id          BIGINT       NOT NULL AUTO_INCREMENT PRIMARY KEY,
+    title       VARCHAR(255) NOT NULL,
+    description VARCHAR(255),
+    club_id     BIGINT,
+    CONSTRAINT fk_form_club FOREIGN KEY (club_id) REFERENCES club (id) ON DELETE CASCADE
+);
+
+CREATE TABLE form_field
+(
+    id         BIGINT       NOT NULL AUTO_INCREMENT PRIMARY KEY,
+    question   VARCHAR(255) NOT NULL,
+    field_type VARCHAR(50)  NOT NULL,
+    required   BOOLEAN      NOT NULL,
+    `order`    INT          NOT NULL,
+    section    VARCHAR(255) NOT NULL,
+    options    TEXT,
+    form_id    BIGINT,
+    CONSTRAINT fk_form_field_form FOREIGN KEY (form_id) REFERENCES form (id) ON DELETE CASCADE
+);

--- a/src/main/resources/db/migration/V34__from_and_field_create_table.sql
+++ b/src/main/resources/db/migration/V34__from_and_field_create_table.sql
@@ -18,7 +18,7 @@ CREATE TABLE form_field
     question   VARCHAR(255) NOT NULL,
     field_type VARCHAR(50)  NOT NULL,
     required   BOOLEAN      NOT NULL,
-    `order`    INT          NOT NULL,
+    field_order    INT          NOT NULL,
     section    VARCHAR(255) NOT NULL,
     options    TEXT,
     form_id    BIGINT,

--- a/src/main/resources/db/migration/V34__from_and_field_create_table.sql
+++ b/src/main/resources/db/migration/V34__from_and_field_create_table.sql
@@ -1,9 +1,12 @@
 CREATE TABLE form
 (
-    id          BIGINT       NOT NULL AUTO_INCREMENT PRIMARY KEY,
-    title       VARCHAR(255) NOT NULL,
-    description VARCHAR(255),
-    club_id     BIGINT,
+    id            BIGINT       NOT NULL AUTO_INCREMENT PRIMARY KEY,
+    title         VARCHAR(255) NOT NULL,
+    description   VARCHAR(255),
+    start_date    DATE         NOT NULL,
+    end_date      DATE         NOT NULL,
+    has_interview BOOLEAN      NOT NULL,
+    club_id       BIGINT,
     CONSTRAINT fk_form_club FOREIGN KEY (club_id) REFERENCES club (id) ON DELETE CASCADE
 );
 


### PR DESCRIPTION
## 🚀 작업 내용
- Form 및 FormField 엔터티 세팅
- 두 엔터티 repository 생성
- 테이블 생성 스크립트 작성

## 🤔 고민했던 내용
- options를 테이블로 분리할까 정말 고민되네요.
생각해보면 통계 쪽 구현할 때 정말 힘들 것 같아요... 특히 체크박스.
그래도 일단 테이블은 만들지 않은 것으로 했고, 바꿔야한다면 통계쪽 구현하다 수정하겠습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **새로운 기능**
	- 양식(Form) 및 양식 필드(FormField) 생성을 위한 데이터베이스 모델 추가
	- 양식 필드 유형(FieldType)을 정의하여 다양한 입력 방식 지원 (체크박스, 라디오 버튼, 텍스트 등)

- **기술적 개선**
	- 문자열 리스트를 데이터베이스에 저장하기 위한 컨버터 클래스 도입
	- 양식 및 양식 필드에 대한 데이터베이스 마이그레이션 스크립트 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->