### PR TITLE
[DDING-88] 동아리 지원 폼지 전체 조회 API 구현

### DIFF
--- a/src/main/java/ddingdong/ddingdongBE/common/utils/TimeUtils.java
+++ b/src/main/java/ddingdong/ddingdongBE/common/utils/TimeUtils.java
@@ -1,9 +1,10 @@
 package ddingdong.ddingdongBE.common.utils;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 
-public class TimeParser {
+public class TimeUtils {
 
   private static final String DATE_FORMAT = "yyyy-MM-dd HH:mm";
 
@@ -26,4 +27,10 @@ public class TimeParser {
 
     return parseToLocalDateTime(dateString);
   }
+
+  public static boolean isDateInRange(LocalDate nowDate, LocalDate startDate, LocalDate endDate) {
+    if (nowDate == null || startDate == null || endDate == null) {
+      return false;
+    }
+    return !nowDate.isBefore(startDate) && !nowDate.isAfter(endDate);  }
 }

--- a/src/main/java/ddingdong/ddingdongBE/domain/activityreport/service/dto/command/CreateActivityReportCommand.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/activityreport/service/dto/command/CreateActivityReportCommand.java
@@ -1,6 +1,6 @@
 package ddingdong.ddingdongBE.domain.activityreport.service.dto.command;
 
-import ddingdong.ddingdongBE.common.utils.TimeParser;
+import ddingdong.ddingdongBE.common.utils.TimeUtils;
 import ddingdong.ddingdongBE.domain.activityreport.domain.ActivityReport;
 import ddingdong.ddingdongBE.domain.activityreport.domain.Participant;
 import ddingdong.ddingdongBE.domain.club.entity.Club;
@@ -23,8 +23,8 @@ public record CreateActivityReportCommand(
             .term(term)
             .content(content)
             .place(place)
-            .startDate(TimeParser.parseToLocalDateTime(startDate))
-            .endDate(TimeParser.parseToLocalDateTime(endDate))
+            .startDate(TimeUtils.parseToLocalDateTime(startDate))
+            .endDate(TimeUtils.parseToLocalDateTime(endDate))
             .participants(participants)
             .club(club)
             .build();

--- a/src/main/java/ddingdong/ddingdongBE/domain/activityreport/service/dto/command/UpdateActivityReportCommand.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/activityreport/service/dto/command/UpdateActivityReportCommand.java
@@ -1,6 +1,6 @@
 package ddingdong.ddingdongBE.domain.activityreport.service.dto.command;
 
-import ddingdong.ddingdongBE.common.utils.TimeParser;
+import ddingdong.ddingdongBE.common.utils.TimeUtils;
 import ddingdong.ddingdongBE.domain.activityreport.domain.ActivityReport;
 import ddingdong.ddingdongBE.domain.activityreport.domain.Participant;
 import java.time.LocalDateTime;
@@ -22,8 +22,8 @@ public record UpdateActivityReportCommand(
         return ActivityReport.builder()
             .content(content)
             .place(place)
-            .startDate(TimeParser.processDate(startDate, LocalDateTime.now()))
-            .endDate(TimeParser.processDate(endDate, LocalDateTime.now()))
+            .startDate(TimeUtils.processDate(startDate, LocalDateTime.now()))
+            .endDate(TimeUtils.processDate(endDate, LocalDateTime.now()))
             .participants(participants)
             .build();
     }

--- a/src/main/java/ddingdong/ddingdongBE/domain/form/api/CentralFormApi.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/form/api/CentralFormApi.java
@@ -3,14 +3,20 @@ package ddingdong.ddingdongBE.domain.form.api;
 import ddingdong.ddingdongBE.auth.PrincipalDetails;
 import ddingdong.ddingdongBE.domain.form.controller.dto.request.CreateFormRequest;
 import ddingdong.ddingdongBE.domain.form.controller.dto.request.UpdateFormRequest;
+import ddingdong.ddingdongBE.domain.form.controller.dto.response.FormListResponse;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import java.util.List;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
@@ -50,6 +56,18 @@ public interface CentralFormApi {
     @DeleteMapping("/my/forms/{formId}")
     void deleteForm(
             @PathVariable("formId") Long formId,
+            @AuthenticationPrincipal PrincipalDetails principalDetails
+    );
+
+    @Operation(summary = "동아리 지원 폼지 전체조회 API")
+    @ApiResponse(responseCode = "200", description = "동아리 지원 폼지 전체조회 성공",
+            content = @Content(
+                    array = @ArraySchema(schema = @Schema(implementation = FormListResponse.class))
+            ))
+    @ResponseStatus(HttpStatus.OK)
+    @SecurityRequirement(name = "AccessToken")
+    @GetMapping("/my/forms")
+    List<FormListResponse> getAllMyForm(
             @AuthenticationPrincipal PrincipalDetails principalDetails
     );
 }

--- a/src/main/java/ddingdong/ddingdongBE/domain/form/controller/CentralFormController.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/form/controller/CentralFormController.java
@@ -4,8 +4,11 @@ import ddingdong.ddingdongBE.auth.PrincipalDetails;
 import ddingdong.ddingdongBE.domain.form.api.CentralFormApi;
 import ddingdong.ddingdongBE.domain.form.controller.dto.request.CreateFormRequest;
 import ddingdong.ddingdongBE.domain.form.controller.dto.request.UpdateFormRequest;
+import ddingdong.ddingdongBE.domain.form.controller.dto.response.FormListResponse;
 import ddingdong.ddingdongBE.domain.form.service.FacadeCentralFormService;
+import ddingdong.ddingdongBE.domain.form.service.dto.query.FormListQuery;
 import ddingdong.ddingdongBE.domain.user.entity.User;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -37,5 +40,14 @@ public class CentralFormController implements CentralFormApi {
     public void deleteForm(Long formId, PrincipalDetails principalDetails) {
         User user = principalDetails.getUser();
         facadeCentralFormService.deleteForm(formId, user);
+    }
+
+    @Override
+    public List<FormListResponse> getAllMyForm(PrincipalDetails principalDetails) {
+        User user = principalDetails.getUser();
+        List<FormListQuery> queries = facadeCentralFormService.getAllMyForm(user);
+        return queries.stream()
+                .map(FormListResponse::from)
+                .toList();
     }
 }

--- a/src/main/java/ddingdong/ddingdongBE/domain/form/controller/dto/response/FormListResponse.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/form/controller/dto/response/FormListResponse.java
@@ -1,0 +1,31 @@
+package ddingdong.ddingdongBE.domain.form.controller.dto.response;
+
+import ddingdong.ddingdongBE.domain.form.service.dto.query.FormListQuery;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.LocalDate;
+import lombok.Builder;
+
+@Builder
+public record FormListResponse(
+        @Schema(description = "지원 폼지 ID", example = "1")
+        Long formId,
+        @Schema(description = "지원 폼지 제목", example = "폼지 제목입니다.")
+        String title,
+        @Schema(description = "지원 폼지 시작일", example = "2001-01-01")
+        LocalDate startDate,
+        @Schema(description = "지원 폼지 종료일", example = "2001-01-02")
+        LocalDate endData,
+        @Schema(description = "활성화 여부", example = "true")
+        boolean isActive
+) {
+
+    public static FormListResponse from(FormListQuery query) {
+        return FormListResponse.builder()
+                .formId(query.formId())
+                .title(query.title())
+                .startDate(query.startDate())
+                .endData(query.endData())
+                .isActive(query.isActive())
+                .build();
+    }
+}

--- a/src/main/java/ddingdong/ddingdongBE/domain/form/repository/FormRepository.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/form/repository/FormRepository.java
@@ -1,8 +1,11 @@
 package ddingdong.ddingdongBE.domain.form.repository;
 
+import ddingdong.ddingdongBE.domain.club.entity.Club;
 import ddingdong.ddingdongBE.domain.form.entity.Form;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface FormRepository extends JpaRepository<Form, Long> {
 
+    List<Form> findAllByClub(Club club);
 }

--- a/src/main/java/ddingdong/ddingdongBE/domain/form/service/FacadeCentralFormService.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/form/service/FacadeCentralFormService.java
@@ -2,7 +2,9 @@ package ddingdong.ddingdongBE.domain.form.service;
 
 import ddingdong.ddingdongBE.domain.form.service.dto.command.CreateFormCommand;
 import ddingdong.ddingdongBE.domain.form.service.dto.command.UpdateFormCommand;
+import ddingdong.ddingdongBE.domain.form.service.dto.query.FormListQuery;
 import ddingdong.ddingdongBE.domain.user.entity.User;
+import java.util.List;
 
 public interface FacadeCentralFormService {
 
@@ -11,4 +13,6 @@ public interface FacadeCentralFormService {
     void updateForm(UpdateFormCommand command);
 
     void deleteForm(Long formId, User user);
+
+    List<FormListQuery> getAllMyForm(User user);
 }

--- a/src/main/java/ddingdong/ddingdongBE/domain/form/service/FacadeCentralFormServiceImpl.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/form/service/FacadeCentralFormServiceImpl.java
@@ -1,6 +1,7 @@
 package ddingdong.ddingdongBE.domain.form.service;
 
 import ddingdong.ddingdongBE.common.exception.AuthenticationException.NonHaveAuthority;
+import ddingdong.ddingdongBE.common.utils.TimeUtils;
 import ddingdong.ddingdongBE.domain.club.entity.Club;
 import ddingdong.ddingdongBE.domain.club.service.ClubService;
 import ddingdong.ddingdongBE.domain.form.entity.Form;
@@ -9,7 +10,9 @@ import ddingdong.ddingdongBE.domain.form.service.dto.command.CreateFormCommand;
 import ddingdong.ddingdongBE.domain.form.service.dto.command.CreateFormCommand.CreateFormFieldCommand;
 import ddingdong.ddingdongBE.domain.form.service.dto.command.UpdateFormCommand;
 import ddingdong.ddingdongBE.domain.form.service.dto.command.UpdateFormCommand.UpdateFormFieldCommand;
+import ddingdong.ddingdongBE.domain.form.service.dto.query.FormListQuery;
 import ddingdong.ddingdongBE.domain.user.entity.User;
+import java.time.LocalDate;
 import java.util.List;
 import java.util.Objects;
 import lombok.RequiredArgsConstructor;
@@ -19,7 +22,7 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
-public class FacadeCentralFormServiceImpl implements FacadeCentralFormService{
+public class FacadeCentralFormServiceImpl implements FacadeCentralFormService {
 
     private final FormService formService;
     private final FormFieldService formFieldService;
@@ -57,6 +60,20 @@ public class FacadeCentralFormServiceImpl implements FacadeCentralFormService{
         Form form = formService.getById(formId);
         validateEqualsClub(club, form);
         formService.delete(form); //테이블 생성 시 외래 키에 cascade 설정하여 formField 삭제도 자동으로 됨.
+    }
+
+    @Override
+    public List<FormListQuery> getAllMyForm(User user) {
+        Club club = clubService.getByUserId(user.getId());
+        List<Form> forms = formService.getAllByClub(club);
+        return forms.stream()
+                .map(this::buildFormListQuery)
+                .toList();
+    }
+
+    private FormListQuery buildFormListQuery(Form form) {
+        boolean isActive = TimeUtils.isDateInRange(LocalDate.now(), form.getStartDate(), form.getEndDate());
+        return FormListQuery.from(form, isActive);
     }
 
     private void validateEqualsClub(Club club, Form form) {

--- a/src/main/java/ddingdong/ddingdongBE/domain/form/service/FormService.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/form/service/FormService.java
@@ -1,6 +1,8 @@
 package ddingdong.ddingdongBE.domain.form.service;
 
+import ddingdong.ddingdongBE.domain.club.entity.Club;
 import ddingdong.ddingdongBE.domain.form.entity.Form;
+import java.util.List;
 
 public interface FormService {
 
@@ -9,4 +11,6 @@ public interface FormService {
     Form getById(Long formId);
 
     void delete(Form form);
+
+    List<Form> getAllByClub(Club club);
 }

--- a/src/main/java/ddingdong/ddingdongBE/domain/form/service/GeneralFormService.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/form/service/GeneralFormService.java
@@ -1,8 +1,10 @@
 package ddingdong.ddingdongBE.domain.form.service;
 
 import ddingdong.ddingdongBE.common.exception.PersistenceException.ResourceNotFound;
+import ddingdong.ddingdongBE.domain.club.entity.Club;
 import ddingdong.ddingdongBE.domain.form.entity.Form;
 import ddingdong.ddingdongBE.domain.form.repository.FormRepository;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -30,5 +32,10 @@ public class GeneralFormService implements FormService{
     @Override
     public void delete(Form form) {
         formRepository.delete(form);
+    }
+
+    @Override
+    public List<Form> getAllByClub(Club club) {
+        return formRepository.findAllByClub(club);
     }
 }

--- a/src/main/java/ddingdong/ddingdongBE/domain/form/service/dto/query/FormListQuery.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/form/service/dto/query/FormListQuery.java
@@ -1,0 +1,26 @@
+package ddingdong.ddingdongBE.domain.form.service.dto.query;
+
+import ddingdong.ddingdongBE.domain.form.entity.Form;
+import java.time.LocalDate;
+import lombok.Builder;
+
+@Builder
+public record FormListQuery(
+        Long formId,
+        String title,
+        LocalDate startDate,
+        LocalDate endData,
+        boolean isActive
+) {
+
+    public static FormListQuery from(Form form, boolean isActive) {
+        return FormListQuery.builder()
+                .formId(form.getId())
+                .title(form.getTitle())
+                .startDate(form.getStartDate())
+                .endData(form.getEndDate())
+                .isActive(isActive)
+                .build();
+    }
+
+}

--- a/src/test/java/ddingdong/ddingdongBE/common/utils/TimeUtilsTest.java
+++ b/src/test/java/ddingdong/ddingdongBE/common/utils/TimeUtilsTest.java
@@ -1,0 +1,22 @@
+package ddingdong.ddingdongBE.common.utils;
+
+import java.time.LocalDate;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class TimeUtilsTest {
+
+    @DisplayName("현재 날짜가 기간 내 포함된다면 true를 반환한다.")
+    @Test
+    void isDateInRange() {
+        // given
+        LocalDate now = LocalDate.now();
+        LocalDate startDate = now.minusDays(1);
+        LocalDate endDate = now.plusDays(1);
+        // when
+        boolean isActive = TimeUtils.isDateInRange(now, startDate, endDate);
+        // then
+        Assertions.assertThat(isActive).isTrue();
+    }
+}

--- a/src/test/java/ddingdong/ddingdongBE/domain/form/service/FacadeCentralFormServiceImplTest.java
+++ b/src/test/java/ddingdong/ddingdongBE/domain/form/service/FacadeCentralFormServiceImplTest.java
@@ -16,6 +16,7 @@ import ddingdong.ddingdongBE.domain.form.repository.FormRepository;
 import ddingdong.ddingdongBE.domain.form.service.dto.command.CreateFormCommand;
 import ddingdong.ddingdongBE.domain.form.service.dto.command.UpdateFormCommand;
 import ddingdong.ddingdongBE.domain.form.service.dto.command.UpdateFormCommand.UpdateFormFieldCommand;
+import ddingdong.ddingdongBE.domain.form.service.dto.query.FormListQuery;
 import ddingdong.ddingdongBE.domain.user.entity.Role;
 import ddingdong.ddingdongBE.domain.user.entity.User;
 import ddingdong.ddingdongBE.domain.user.repository.UserRepository;
@@ -206,5 +207,44 @@ class FacadeCentralFormServiceImplTest extends TestContainerSupport {
         assertThrows(NonHaveAuthority.class, () -> {
             facadeCentralFormService.deleteForm(savedForm.getId(), user2);
         });
+    }
+
+    @DisplayName("동아리는 자신의 폼지를 전부 조회할 수 있다.")
+    @Test
+    void getAllMyForm() {
+        // given
+        User user = fixtureMonkey.giveMeBuilder(User.class)
+                .set("id", 1L)
+                .set("Role", Role.CLUB)
+                .set("deletedAt", null)
+                .sample();
+        User savedUser = userRepository.save(user);
+        Club club = fixtureMonkey.giveMeBuilder(Club.class)
+                .set("id", 1L)
+                .set("user", savedUser)
+                .set("score", null)
+                .set("clubMembers", null)
+                .set("deletedAt", null)
+                .sample();
+        clubRepository.save(club);
+        Form form = fixtureMonkey.giveMeBuilder(Form.class)
+                .set("title", "제목1")
+                .set("club", club)
+                .sample();
+        Form form2 = fixtureMonkey.giveMeBuilder(Form.class)
+                .set("title", "제목2")
+                .set("club", club)
+                .sample();
+        formService.create(form);
+        formService.create(form2);
+
+        // when
+        List<FormListQuery> queries = facadeCentralFormService.getAllMyForm(savedUser);
+        // then
+        assertThat(queries).isNotEmpty();
+        assertThat(queries.size()).isEqualTo(2);
+        assertThat(queries.get(0).title()).isEqualTo("제목1");
+        assertThat(queries.get(1).title()).isEqualTo("제목2");
+
     }
 }


### PR DESCRIPTION
## 🚀 작업 내용
- 동아리 지원 폼지 전체 조회 API 구현하였습니다.
- 현재 날짜가 startDate, endDate 사이에 있다면 활성화되도록 구현하였습니다. util성 메소드인 것 같아 util클래스에 함수 구현했습니다.

## 🤔 고민했던 내용


## 💬 리뷰 중점사항


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **새로운 기능**
  - 인증 사용자가 자신의 폼 목록을 조회할 수 있는 기능을 추가하여, 내 폼을 쉽게 확인할 수 있게 되었습니다.
  - 클럽에 연결된 모든 폼을 조회할 수 있는 기능이 추가되었습니다.

- **리팩토링**
  - 날짜 처리 로직이 개선되어, 폼의 활성 상태 판정이 보다 정확해졌습니다.
  - 클럽별 폼 조회와 관련된 서비스와 저장소가 업데이트되어, 폼 관리 효율성이 향상되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->