### PR TITLE
[DDING-95] 지원자 상세 조회 API 구현

### DIFF
--- a/src/main/java/ddingdong/ddingdongBE/domain/form/service/dto/query/FormQuery.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/form/service/dto/query/FormQuery.java
@@ -20,7 +20,6 @@ public record FormQuery(
 
     @Builder
     public record FormFieldListQuery(
-            Long id,
             String question,
             FieldType type,
             List<String> options,
@@ -30,7 +29,6 @@ public record FormQuery(
     ) {
         public static FormFieldListQuery from(FormField formField) {
             return FormFieldListQuery.builder()
-                    .id(formField.getId())
                     .question(formField.getQuestion())
                     .type(formField.getFieldType())
                     .options(formField.getOptions())

--- a/src/main/java/ddingdong/ddingdongBE/domain/form/service/dto/query/FormQuery.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/form/service/dto/query/FormQuery.java
@@ -20,6 +20,7 @@ public record FormQuery(
 
     @Builder
     public record FormFieldListQuery(
+            Long id,
             String question,
             FieldType type,
             List<String> options,
@@ -29,6 +30,7 @@ public record FormQuery(
     ) {
         public static FormFieldListQuery from(FormField formField) {
             return FormFieldListQuery.builder()
+                    .id(formField.getId())
                     .question(formField.getQuestion())
                     .type(formField.getFieldType())
                     .options(formField.getOptions())

--- a/src/main/java/ddingdong/ddingdongBE/domain/formapplication/api/CentralFormApplicationApi.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/formapplication/api/CentralFormApplicationApi.java
@@ -1,6 +1,7 @@
 package ddingdong.ddingdongBE.domain.formapplication.api;
 
 import ddingdong.ddingdongBE.auth.PrincipalDetails;
+import ddingdong.ddingdongBE.domain.formapplication.controller.dto.response.FormApplicationResponse;
 import ddingdong.ddingdongBE.domain.formapplication.controller.dto.response.MyFormApplicationPageResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -28,6 +29,18 @@ public interface CentralFormApplicationApi {
             @PathVariable("formId") Long formId,
             @RequestParam(value = "size", defaultValue = "15") int size,
             @RequestParam(value = "currentCursorId", defaultValue = "-1") Long currentCursorId,
+            @AuthenticationPrincipal PrincipalDetails principalDetails
+    );
+
+    @Operation(summary = "지원자 상세 조회 API")
+    @ApiResponse(responseCode = "200", description = "지원자 상세 조회 성공",
+            content = @Content(schema = @Schema(implementation = FormApplicationResponse.class)))
+    @ResponseStatus(HttpStatus.OK)
+    @SecurityRequirement(name = "AccessToken")
+    @GetMapping("/my/forms/{formId}/applications/{applicationId}")
+    FormApplicationResponse getFormApplication(
+            @PathVariable("formId") Long formId,
+            @PathVariable("applicationId") Long applicationId,
             @AuthenticationPrincipal PrincipalDetails principalDetails
     );
 

--- a/src/main/java/ddingdong/ddingdongBE/domain/formapplication/controller/CentralFormApplicationController.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/formapplication/controller/CentralFormApplicationController.java
@@ -1,9 +1,11 @@
 package ddingdong.ddingdongBE.domain.formapplication.controller;
 
 import ddingdong.ddingdongBE.auth.PrincipalDetails;
+import ddingdong.ddingdongBE.domain.formapplication.controller.dto.response.FormApplicationResponse;
 import ddingdong.ddingdongBE.domain.formapplication.service.FacadeCentralFormApplicationService;
 import ddingdong.ddingdongBE.domain.formapplication.api.CentralFormApplicationApi;
 import ddingdong.ddingdongBE.domain.formapplication.controller.dto.response.MyFormApplicationPageResponse;
+import ddingdong.ddingdongBE.domain.formapplication.service.dto.query.FormApplicationQuery;
 import ddingdong.ddingdongBE.domain.formapplication.service.dto.query.MyFormApplicationPageQuery;
 import ddingdong.ddingdongBE.domain.user.entity.User;
 import lombok.RequiredArgsConstructor;
@@ -20,5 +22,12 @@ public class CentralFormApplicationController implements CentralFormApplicationA
         User user = principalDetails.getUser();
         MyFormApplicationPageQuery query = facadeCentralFormService.getMyFormApplicationPage(formId, user, size, currentCursorId);
         return MyFormApplicationPageResponse.from(query);
+    }
+
+    @Override
+    public FormApplicationResponse getFormApplication(Long formId, Long applicationId, PrincipalDetails principalDetails) {
+        User user = principalDetails.getUser();
+        FormApplicationQuery query = facadeCentralFormService.getFormApplication(formId, applicationId, user);
+        return FormApplicationResponse.from(query);
     }
 }

--- a/src/main/java/ddingdong/ddingdongBE/domain/formapplication/controller/dto/response/FormApplicationResponse.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/formapplication/controller/dto/response/FormApplicationResponse.java
@@ -48,6 +48,7 @@ public record FormApplicationResponse (
     ) {
         public static FormFieldAnswerListResponse from(FormFieldAnswerListQuery formFieldAnswerListQuery) {
             return FormFieldAnswerListResponse.builder()
+                    .fieldId(formFieldAnswerListQuery.fieldId())
                     .question(formFieldAnswerListQuery.question())
                     .type(formFieldAnswerListQuery.type())
                     .options(formFieldAnswerListQuery.options())

--- a/src/main/java/ddingdong/ddingdongBE/domain/formapplication/controller/dto/response/FormApplicationResponse.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/formapplication/controller/dto/response/FormApplicationResponse.java
@@ -1,0 +1,75 @@
+package ddingdong.ddingdongBE.domain.formapplication.controller.dto.response;
+
+import ddingdong.ddingdongBE.domain.form.entity.FieldType;
+import ddingdong.ddingdongBE.domain.formapplication.entity.FormApplicationStatus;
+import ddingdong.ddingdongBE.domain.formapplication.service.dto.query.FormApplicationQuery;
+import ddingdong.ddingdongBE.domain.formapplication.service.dto.query.FormApplicationQuery.FormFieldAnswerListQuery;
+
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Builder
+public record FormApplicationResponse (
+        @Schema(description = "제출일시", example = "2025-01-01T00:00")
+        LocalDateTime submittedAt,
+        @Schema(description = "지원자 이름", example = "김띵동")
+        String name,
+        @Schema(description = "지원자 학번", example = "60201111")
+        String studentNumber,
+        @Schema(description = "지원자 학과", example = "융합소프트웨어학부")
+        String department,
+        @Schema(description = "status", example = "SUBMITTED")
+        FormApplicationStatus status,
+        @ArraySchema(schema = @Schema(implementation = FormFieldAnswerListResponse.class))
+        List<FormFieldAnswerListResponse> formFieldAnswers
+){
+    @Builder
+    record FormFieldAnswerListResponse (
+            @Schema(description = "폼지 질문 ID", example = "1")
+            Long fieldId,
+            @Schema(description = "폼지 질문", example = "성별이 무엇입니까??")
+            String question,
+            @Schema(description = "폼지 질문 유형", example = "RADIO", allowableValues = {"CHECK_BOX", "RADIO", "TEXT", "LONG_TEXT", "FILE"})
+            FieldType type,
+            @Schema(description = "폼지 지문", example = "[\"여성\", \"남성\"]")
+            List<String> options,
+            @Schema(description = "필수 여부", example = "true")
+            Boolean required,
+            @Schema(description = "질문 순서", example = "1")
+            Integer order,
+            @Schema(description = "섹션", example = "공통")
+            String section,
+            @Schema(description = "질문 답변 값", example = "[\"지문1\"]")
+            List<String> value
+    ) {
+        public static FormFieldAnswerListResponse from(FormFieldAnswerListQuery formFieldAnswerListQuery) {
+            return FormFieldAnswerListResponse.builder()
+                    .question(formFieldAnswerListQuery.question())
+                    .type(formFieldAnswerListQuery.type())
+                    .options(formFieldAnswerListQuery.options())
+                    .required(formFieldAnswerListQuery.required())
+                    .order(formFieldAnswerListQuery.order())
+                    .section(formFieldAnswerListQuery.section())
+                    .value(formFieldAnswerListQuery.value())
+                    .build();
+        }
+    }
+    public static FormApplicationResponse from(FormApplicationQuery formApplicationQuery) {
+        List<FormFieldAnswerListResponse> responses = formApplicationQuery.formFieldAnswers().stream()
+                .map(FormFieldAnswerListResponse::from)
+                .toList();
+
+        return FormApplicationResponse.builder()
+                .submittedAt(formApplicationQuery.createdAt())
+                .name(formApplicationQuery.name())
+                .studentNumber(formApplicationQuery.studentNumber())
+                .department(formApplicationQuery.department())
+                .status(formApplicationQuery.status())
+                .formFieldAnswers(responses)
+                .build();
+    }
+}

--- a/src/main/java/ddingdong/ddingdongBE/domain/formapplication/repository/FormAnswerRepository.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/formapplication/repository/FormAnswerRepository.java
@@ -1,7 +1,11 @@
 package ddingdong.ddingdongBE.domain.formapplication.repository;
 
 import ddingdong.ddingdongBE.domain.formapplication.entity.FormAnswer;
+import ddingdong.ddingdongBE.domain.formapplication.entity.FormApplication;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface FormAnswerRepository extends JpaRepository<FormAnswer, Long> {
+    List<FormAnswer> findAllByFormApplication(FormApplication formApplication);
 }

--- a/src/main/java/ddingdong/ddingdongBE/domain/formapplication/service/FacadeCentralFormApplicationService.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/formapplication/service/FacadeCentralFormApplicationService.java
@@ -1,5 +1,6 @@
 package ddingdong.ddingdongBE.domain.formapplication.service;
 
+import ddingdong.ddingdongBE.domain.formapplication.service.dto.query.FormApplicationQuery;
 import ddingdong.ddingdongBE.domain.formapplication.service.dto.query.MyFormApplicationPageQuery;
 import ddingdong.ddingdongBE.domain.user.entity.User;
 
@@ -7,4 +8,5 @@ public interface FacadeCentralFormApplicationService {
 
     MyFormApplicationPageQuery getMyFormApplicationPage(Long formId, User user, int size, Long currentCursorId);
 
+    FormApplicationQuery getFormApplication(Long formId, Long applicationId, User user);
 }

--- a/src/main/java/ddingdong/ddingdongBE/domain/formapplication/service/FacadeCentralFormApplicationServiceImpl.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/formapplication/service/FacadeCentralFormApplicationServiceImpl.java
@@ -2,8 +2,6 @@ package ddingdong.ddingdongBE.domain.formapplication.service;
 
 import ddingdong.ddingdongBE.domain.club.entity.Club;
 import ddingdong.ddingdongBE.domain.club.service.ClubService;
-import ddingdong.ddingdongBE.domain.form.entity.FormField;
-import ddingdong.ddingdongBE.domain.form.service.FormFieldService;
 import ddingdong.ddingdongBE.domain.formapplication.entity.FormAnswer;
 import ddingdong.ddingdongBE.domain.formapplication.service.dto.query.FormApplicationQuery;
 import ddingdong.ddingdongBE.domain.formapplication.service.dto.query.PagingQuery;
@@ -15,7 +13,6 @@ import ddingdong.ddingdongBE.domain.formapplication.service.dto.query.MyFormAppl
 import ddingdong.ddingdongBE.domain.user.entity.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Slice;
-import org.springframework.security.access.AccessDeniedException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -26,19 +23,11 @@ import java.util.List;
 @Transactional(readOnly = true)
 public class FacadeCentralFormApplicationServiceImpl implements FacadeCentralFormApplicationService {
 
-    private final ClubService clubService;
-    private final FormService formService;
     private final FormApplicationService formApplicationService;
     private final FormAnswerService formAnswerService;
-    private final FormFieldService formFieldService;
 
     @Override
     public MyFormApplicationPageQuery getMyFormApplicationPage(Long formId, User user, int size, Long currentCursorId) {
-        Club club = clubService.getByUserId(user.getId());
-        Form form = formService.getById(formId);
-        if (!form.getClub().equals(club)) {
-            throw new AccessDeniedException("권한이 없습니다.");
-        }
         Slice<FormApplication> formApplicationPage = formApplicationService.getFormApplicationPageByFormId(formId, size, currentCursorId);
         if (formApplicationPage == null) {
             return MyFormApplicationPageQuery.createEmpty();
@@ -54,14 +43,8 @@ public class FacadeCentralFormApplicationServiceImpl implements FacadeCentralFor
 
     @Override
     public FormApplicationQuery getFormApplication(Long formId, Long applicationId, User user) {
-        Club club = clubService.getByUserId(user.getId());
-        Form form = formService.getById(formId);
-        if (!form.getClub().equals(club)) {
-            throw new AccessDeniedException("권한이 없습니다.");
-        }
         FormApplication formApplication = formApplicationService.getById(applicationId);
-        List<FormField> formFields = formFieldService.findAllByForm(form);
         List<FormAnswer> formAnswers = formAnswerService.getAllByApplication(formApplication);
-        return FormApplicationQuery.of(formApplication, formFields, formAnswers);
+        return FormApplicationQuery.of(formApplication, formAnswers);
     }
 }

--- a/src/main/java/ddingdong/ddingdongBE/domain/formapplication/service/FacadeCentralFormApplicationServiceImpl.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/formapplication/service/FacadeCentralFormApplicationServiceImpl.java
@@ -2,6 +2,10 @@ package ddingdong.ddingdongBE.domain.formapplication.service;
 
 import ddingdong.ddingdongBE.domain.club.entity.Club;
 import ddingdong.ddingdongBE.domain.club.service.ClubService;
+import ddingdong.ddingdongBE.domain.form.entity.FormField;
+import ddingdong.ddingdongBE.domain.form.service.FormFieldService;
+import ddingdong.ddingdongBE.domain.formapplication.entity.FormAnswer;
+import ddingdong.ddingdongBE.domain.formapplication.service.dto.query.FormApplicationQuery;
 import ddingdong.ddingdongBE.domain.formapplication.service.dto.query.PagingQuery;
 import ddingdong.ddingdongBE.domain.form.entity.Form;
 import ddingdong.ddingdongBE.domain.form.service.FormService;
@@ -25,6 +29,8 @@ public class FacadeCentralFormApplicationServiceImpl implements FacadeCentralFor
     private final ClubService clubService;
     private final FormService formService;
     private final FormApplicationService formApplicationService;
+    private final FormAnswerService formAnswerService;
+    private final FormFieldService formFieldService;
 
     @Override
     public MyFormApplicationPageQuery getMyFormApplicationPage(Long formId, User user, int size, Long currentCursorId) {
@@ -44,6 +50,18 @@ public class FacadeCentralFormApplicationServiceImpl implements FacadeCentralFor
         PagingQuery pagingQuery = PagingQuery.of(currentCursorId, completeFormApplications, formApplicationPage.hasNext());
 
         return MyFormApplicationPageQuery.of(formApplicationListQueries, pagingQuery);
+    }
 
+    @Override
+    public FormApplicationQuery getFormApplication(Long formId, Long applicationId, User user) {
+        Club club = clubService.getByUserId(user.getId());
+        Form form = formService.getById(formId);
+        if (!form.getClub().equals(club)) {
+            throw new AccessDeniedException("권한이 없습니다.");
+        }
+        FormApplication formApplication = formApplicationService.getById(applicationId);
+        List<FormField> formFields = formFieldService.findAllByForm(form);
+        List<FormAnswer> formAnswers = formAnswerService.getAllByApplication(formApplication);
+        return FormApplicationQuery.of(formApplication, formFields, formAnswers);
     }
 }

--- a/src/main/java/ddingdong/ddingdongBE/domain/formapplication/service/FormAnswerService.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/formapplication/service/FormAnswerService.java
@@ -1,10 +1,14 @@
 package ddingdong.ddingdongBE.domain.formapplication.service;
 
 import ddingdong.ddingdongBE.domain.formapplication.entity.FormAnswer;
+import ddingdong.ddingdongBE.domain.formapplication.entity.FormApplication;
+
 import java.util.List;
 
 public interface FormAnswerService {
 
     void createAll(List<FormAnswer> formAnswers);
+
+    List<FormAnswer> getAllByApplication(FormApplication formApplication);
 
 }

--- a/src/main/java/ddingdong/ddingdongBE/domain/formapplication/service/FormApplicationService.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/formapplication/service/FormApplicationService.java
@@ -8,4 +8,6 @@ public interface FormApplicationService {
     FormApplication create(FormApplication formApplication);
 
     Slice<FormApplication> getFormApplicationPageByFormId(Long formId, int size, Long currentCursorId);
+
+    FormApplication getById(Long applicationId);
 }

--- a/src/main/java/ddingdong/ddingdongBE/domain/formapplication/service/GeneralFormAnswerService.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/formapplication/service/GeneralFormAnswerService.java
@@ -1,6 +1,7 @@
 package ddingdong.ddingdongBE.domain.formapplication.service;
 
 import ddingdong.ddingdongBE.domain.formapplication.entity.FormAnswer;
+import ddingdong.ddingdongBE.domain.formapplication.entity.FormApplication;
 import ddingdong.ddingdongBE.domain.formapplication.repository.FormAnswerRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -21,4 +22,8 @@ public class GeneralFormAnswerService implements FormAnswerService {
         formAnswerRepository.saveAll(formAnswers);
     }
 
+    @Override
+    public List<FormAnswer> getAllByApplication(FormApplication formApplication) {
+        return formAnswerRepository.findAllByFormApplication(formApplication);
+    }
 }

--- a/src/main/java/ddingdong/ddingdongBE/domain/formapplication/service/GeneralFormApplicationService.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/formapplication/service/GeneralFormApplicationService.java
@@ -31,6 +31,11 @@ public class GeneralFormApplicationService implements FormApplicationService {
         return buildSlice(formApplicationPages, size);
     }
 
+    @Override
+    public FormApplication getById(Long applicationId) {
+        return formApplicationRepository.findById(applicationId).orElse(null);
+    }
+
     private Slice<FormApplication> buildSlice(Slice<FormApplication> originalSlice, int size) {
         List<FormApplication> content = new ArrayList<>(originalSlice.getContent());
         if (content.isEmpty()) {

--- a/src/main/java/ddingdong/ddingdongBE/domain/formapplication/service/GeneralFormApplicationService.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/formapplication/service/GeneralFormApplicationService.java
@@ -1,5 +1,6 @@
 package ddingdong.ddingdongBE.domain.formapplication.service;
 
+import ddingdong.ddingdongBE.common.exception.PersistenceException.ResourceNotFound;
 import ddingdong.ddingdongBE.domain.formapplication.entity.FormApplication;
 import ddingdong.ddingdongBE.domain.formapplication.repository.FormApplicationRepository;
 import lombok.RequiredArgsConstructor;
@@ -33,7 +34,8 @@ public class GeneralFormApplicationService implements FormApplicationService {
 
     @Override
     public FormApplication getById(Long applicationId) {
-        return formApplicationRepository.findById(applicationId).orElse(null);
+        return formApplicationRepository.findById(applicationId)
+            .orElseThrow(() -> new ResourceNotFound("주어진 id로 해당 지원자를 찾을 수 없습니다.:"+applicationId));
     }
 
     private Slice<FormApplication> buildSlice(Slice<FormApplication> originalSlice, int size) {

--- a/src/main/java/ddingdong/ddingdongBE/domain/formapplication/service/dto/query/FormApplicationQuery.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/formapplication/service/dto/query/FormApplicationQuery.java
@@ -1,0 +1,94 @@
+package ddingdong.ddingdongBE.domain.formapplication.service.dto.query;
+
+import ddingdong.ddingdongBE.domain.form.entity.FieldType;
+
+import ddingdong.ddingdongBE.domain.form.entity.FormField;
+import ddingdong.ddingdongBE.domain.formapplication.entity.FormAnswer;
+import ddingdong.ddingdongBE.domain.formapplication.entity.FormApplication;
+import ddingdong.ddingdongBE.domain.formapplication.entity.FormApplicationStatus;
+import ddingdong.ddingdongBE.domain.form.service.dto.query.FormQuery.FormFieldListQuery;
+
+import lombok.Builder;
+
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+
+@Builder
+public record FormApplicationQuery (
+        LocalDateTime createdAt,
+        String name,
+        String studentNumber,
+        String department,
+        FormApplicationStatus status,
+        List<FormFieldAnswerListQuery> formFieldAnswers
+) {
+    @Builder
+    public record FormAnswerListQuery (
+            Long fieldId,
+            List<String> value
+    ) {
+        public static FormAnswerListQuery from(FormAnswer formAnswer) {
+            return FormAnswerListQuery.builder()
+                    .fieldId(formAnswer.getFormField().getId())
+                    .value(formAnswer.getValue())
+                    .build();
+        }
+    }
+    @Builder
+    public record FormFieldAnswerListQuery (
+            Long fieldId,
+            String question,
+            FieldType type,
+            List<String> options,
+            Boolean required,
+            Integer order,
+            String section,
+            List<String> value
+    ) {
+        public static FormFieldAnswerListQuery from(FormFieldListQuery formFieldListQuery, FormAnswerListQuery formAnswerListQuery) {
+            return FormFieldAnswerListQuery.builder()
+                    .fieldId(formFieldListQuery.id())
+                    .question(formFieldListQuery.question())
+                    .type(formFieldListQuery.type())
+                    .options(formFieldListQuery.options())
+                    .required(formFieldListQuery.required())
+                    .order(formFieldListQuery.order())
+                    .section(formFieldListQuery.section())
+                    .value(formAnswerListQuery.value())
+                    .build();
+        }
+    }
+    public static FormApplicationQuery of(FormApplication formApplication, List<FormField> formFields, List<FormAnswer> formAnswers) {
+        List<FormFieldListQuery> formFieldListQueries = formFields.stream()
+                .map(FormFieldListQuery::from)
+                .toList();
+        List<FormAnswerListQuery> formAnswerListQueries = formAnswers.stream()
+                .map(FormAnswerListQuery::from)
+                .toList();
+        Map<Long, FormAnswerListQuery> answerMap = formAnswerListQueries.stream()
+                .collect(Collectors.toMap(FormAnswerListQuery::fieldId, Function.identity()));
+        List<FormFieldAnswerListQuery> formFieldAnswerListQueries = formFieldListQueries.stream()
+                .map(fieldQuery -> {
+                    FormAnswerListQuery answerQuery = answerMap.get(fieldQuery.id());
+                    if (answerQuery == null) {
+                        answerQuery = FormAnswerListQuery.builder()
+                                .fieldId(fieldQuery.id())
+                                .value(null)
+                                .build();
+                    }
+                    return FormFieldAnswerListQuery.from(fieldQuery, answerQuery);
+                })
+                .collect(Collectors.toList());
+        return FormApplicationQuery.builder()
+                .createdAt(formApplication.getCreatedAt())
+                .name(formApplication.getName())
+                .studentNumber(formApplication.getStudentNumber())
+                .department(formApplication.getDepartment())
+                .status(formApplication.getStatus())
+                .formFieldAnswers(formFieldAnswerListQueries)
+                .build();
+    }
+}

--- a/src/main/java/ddingdong/ddingdongBE/domain/formapplication/service/dto/query/FormApplicationQuery.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/formapplication/service/dto/query/FormApplicationQuery.java
@@ -2,19 +2,14 @@ package ddingdong.ddingdongBE.domain.formapplication.service.dto.query;
 
 import ddingdong.ddingdongBE.domain.form.entity.FieldType;
 
-import ddingdong.ddingdongBE.domain.form.entity.FormField;
 import ddingdong.ddingdongBE.domain.formapplication.entity.FormAnswer;
 import ddingdong.ddingdongBE.domain.formapplication.entity.FormApplication;
 import ddingdong.ddingdongBE.domain.formapplication.entity.FormApplicationStatus;
-import ddingdong.ddingdongBE.domain.form.service.dto.query.FormQuery.FormFieldListQuery;
 
 import lombok.Builder;
 
-import java.util.function.Function;
-import java.util.stream.Collectors;
 import java.time.LocalDateTime;
 import java.util.List;
-import java.util.Map;
 
 @Builder
 public record FormApplicationQuery (
@@ -26,18 +21,6 @@ public record FormApplicationQuery (
         List<FormFieldAnswerListQuery> formFieldAnswers
 ) {
     @Builder
-    public record FormAnswerListQuery (
-            Long fieldId,
-            List<String> value
-    ) {
-        public static FormAnswerListQuery from(FormAnswer formAnswer) {
-            return FormAnswerListQuery.builder()
-                    .fieldId(formAnswer.getFormField().getId())
-                    .value(formAnswer.getValue())
-                    .build();
-        }
-    }
-    @Builder
     public record FormFieldAnswerListQuery (
             Long fieldId,
             String question,
@@ -48,40 +31,23 @@ public record FormApplicationQuery (
             String section,
             List<String> value
     ) {
-        public static FormFieldAnswerListQuery from(FormFieldListQuery formFieldListQuery, FormAnswerListQuery formAnswerListQuery) {
+        public static FormFieldAnswerListQuery from(FormAnswer formAnswer) {
             return FormFieldAnswerListQuery.builder()
-                    .fieldId(formFieldListQuery.id())
-                    .question(formFieldListQuery.question())
-                    .type(formFieldListQuery.type())
-                    .options(formFieldListQuery.options())
-                    .required(formFieldListQuery.required())
-                    .order(formFieldListQuery.order())
-                    .section(formFieldListQuery.section())
-                    .value(formAnswerListQuery.value())
+                    .fieldId(formAnswer.getFormField().getId())
+                    .question(formAnswer.getFormField().getQuestion())
+                    .type(formAnswer.getFormField().getFieldType())
+                    .options(formAnswer.getFormField().getOptions())
+                    .required(formAnswer.getFormField().isRequired())
+                    .order(formAnswer.getFormField().getFieldOrder())
+                    .section(formAnswer.getFormField().getSection())
+                    .value(formAnswer.getValue())
                     .build();
         }
     }
-    public static FormApplicationQuery of(FormApplication formApplication, List<FormField> formFields, List<FormAnswer> formAnswers) {
-        List<FormFieldListQuery> formFieldListQueries = formFields.stream()
-                .map(FormFieldListQuery::from)
+    public static FormApplicationQuery of(FormApplication formApplication, List<FormAnswer> formAnswers) {
+        List<FormFieldAnswerListQuery> formFieldAnswerListQueries = formAnswers.stream()
+                .map(FormFieldAnswerListQuery::from)
                 .toList();
-        List<FormAnswerListQuery> formAnswerListQueries = formAnswers.stream()
-                .map(FormAnswerListQuery::from)
-                .toList();
-        Map<Long, FormAnswerListQuery> answerMap = formAnswerListQueries.stream()
-                .collect(Collectors.toMap(FormAnswerListQuery::fieldId, Function.identity()));
-        List<FormFieldAnswerListQuery> formFieldAnswerListQueries = formFieldListQueries.stream()
-                .map(fieldQuery -> {
-                    FormAnswerListQuery answerQuery = answerMap.get(fieldQuery.id());
-                    if (answerQuery == null) {
-                        answerQuery = FormAnswerListQuery.builder()
-                                .fieldId(fieldQuery.id())
-                                .value(null)
-                                .build();
-                    }
-                    return FormFieldAnswerListQuery.from(fieldQuery, answerQuery);
-                })
-                .collect(Collectors.toList());
         return FormApplicationQuery.builder()
                 .createdAt(formApplication.getCreatedAt())
                 .name(formApplication.getName())

--- a/src/test/java/ddingdong/ddingdongBE/domain/form/service/FacadeCentralFormApplicationServiceImplTest.java
+++ b/src/test/java/ddingdong/ddingdongBE/domain/form/service/FacadeCentralFormApplicationServiceImplTest.java
@@ -1,263 +1,83 @@
 package ddingdong.ddingdongBE.domain.form.service;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-
 import com.navercorp.fixturemonkey.FixtureMonkey;
-import ddingdong.ddingdongBE.common.exception.AuthenticationException.NonHaveAuthority;
 import ddingdong.ddingdongBE.common.support.FixtureMonkeyFactory;
 import ddingdong.ddingdongBE.common.support.TestContainerSupport;
 import ddingdong.ddingdongBE.domain.club.entity.Club;
 import ddingdong.ddingdongBE.domain.club.repository.ClubRepository;
 import ddingdong.ddingdongBE.domain.form.entity.Form;
-import ddingdong.ddingdongBE.domain.form.entity.FormField;
-import ddingdong.ddingdongBE.domain.form.repository.FormFieldRepository;
 import ddingdong.ddingdongBE.domain.form.repository.FormRepository;
-import ddingdong.ddingdongBE.domain.form.service.dto.command.CreateFormCommand;
-import ddingdong.ddingdongBE.domain.form.service.dto.command.UpdateFormCommand;
-import ddingdong.ddingdongBE.domain.form.service.dto.command.UpdateFormCommand.UpdateFormFieldCommand;
-import ddingdong.ddingdongBE.domain.form.service.dto.query.FormListQuery;
-import ddingdong.ddingdongBE.domain.form.service.dto.query.FormQuery;
+import ddingdong.ddingdongBE.domain.formapplication.entity.FormApplication;
+import ddingdong.ddingdongBE.domain.formapplication.entity.FormApplicationStatus;
+import ddingdong.ddingdongBE.domain.formapplication.service.FacadeCentralFormApplicationService;
+import ddingdong.ddingdongBE.domain.formapplication.service.FormApplicationService;
+import ddingdong.ddingdongBE.domain.formapplication.service.dto.query.FormApplicationQuery;
 import ddingdong.ddingdongBE.domain.user.entity.Role;
 import ddingdong.ddingdongBE.domain.user.entity.User;
 import ddingdong.ddingdongBE.domain.user.repository.UserRepository;
-import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
 @SpringBootTest
-class FacadeCentralFormServiceImplTest extends TestContainerSupport {
-
-    @Autowired
-    private FormService formService;
-
-    @Autowired
-    private FormRepository formRepository;
-
-    @Autowired
-    private FacadeCentralFormService facadeCentralFormService;
-
-    @Autowired
-    private ClubRepository clubRepository;
+class FacadeCentralFormApplicationServiceImplTest extends TestContainerSupport {
 
     @Autowired
     private UserRepository userRepository;
 
     @Autowired
-    private FormFieldRepository formFieldRepository;
+    private ClubRepository clubRepository;
 
-    private static final FixtureMonkey fixtureMonkey = FixtureMonkeyFactory.getNotNullBuilderIntrospectorMonkey();
+    @Autowired
+    private FormRepository formRepository;
 
-    @DisplayName("폼지와 폼지 질문을 생성할 수 있다.")
+    @Autowired
+    private FormApplicationService formApplicationService;
+
+    @Autowired
+    private FacadeCentralFormApplicationService facadeCentralFormApplicationService;
+
+    private static final FixtureMonkey fixture = FixtureMonkeyFactory.getNotNullBuilderIntrospectorMonkey();
+
+    @DisplayName("동아리는 지원자 응답을 상세조회 할 수 있다.")
     @Test
-    void createForm() {
+    void getFormApplication() {
         // given
-        User user = fixtureMonkey.giveMeBuilder(User.class)
+        User user = fixture.giveMeBuilder(User.class)
                 .set("id", 1L)
                 .set("Role", Role.CLUB)
                 .set("deletedAt", null)
                 .sample();
-        User savedUser = userRepository.save(user);
-        Club club = fixtureMonkey.giveMeBuilder(Club.class)
+        User savedUser = userRepository.saveAndFlush(user);
+        Club club = fixture.giveMeBuilder(Club.class)
                 .set("id", 1L)
                 .set("user", savedUser)
                 .set("score", null)
                 .set("clubMembers", null)
                 .set("deletedAt", null)
                 .sample();
-        clubRepository.save(club);
-        CreateFormCommand createFormCommand = fixtureMonkey.giveMeBuilder(CreateFormCommand.class)
-                .set("user", savedUser)
-                .sample();
-        // when
-        facadeCentralFormService.createForm(createFormCommand);
-        // then
-        List<Form> form = formRepository.findAll();
-        List<FormField> formFields = formFieldRepository.findAll();
-
-        assertThat(form).isNotEmpty();
-        assertThat(formFields).isNotEmpty();
-    }
-
-    @DisplayName("폼지와 폼지 질문을 수정할 수 있다.")
-    @Test
-    void updateForm() {
-        // given
-        User user = fixtureMonkey.giveMeBuilder(User.class)
-                .set("id", 1L)
-                .set("Role", Role.CLUB)
-                .set("deletedAt", null)
-                .sample();
-        User savedUser = userRepository.save(user);
-        Club club = fixtureMonkey.giveMeBuilder(Club.class)
-                .set("id", 1L)
-                .set("user", savedUser)
-                .set("score", null)
-                .set("clubMembers", null)
-                .set("deletedAt", null)
-                .sample();
-        clubRepository.save(club);
-        Form form = fixtureMonkey.giveMeBuilder(Form.class)
-                .set("club", club)
-                .sample();
-        Form savedForm = formService.create(form);
-        UpdateFormCommand updateFormCommand = fixtureMonkey.giveMeBuilder(UpdateFormCommand.class)
-                .set("title", "수정된 제목")
-                .set("description", "수정된 설명")
-                .set("formId", savedForm.getId())
-                .set("formFieldCommands", List.of(
-                        fixtureMonkey.giveMeBuilder(UpdateFormFieldCommand.class)
-                                .set("question", "수정된 질문")
-                                .sample())
-                )
-                .sample();
-        // when
-        facadeCentralFormService.updateForm(updateFormCommand);
-        // then
-        Form found = formRepository.findById(savedForm.getId()).orElse(null);
-        List<FormField> formFields = formFieldRepository.findAllByForm(found);
-        assertThat(found).isNotNull();
-        assertThat(found.getTitle()).isEqualTo("수정된 제목");
-        assertThat(found.getDescription()).isEqualTo("수정된 설명");
-        assertThat(formFields).isNotEmpty();
-        assertThat(formFields.get(0).getQuestion()).isEqualTo("수정된 질문");
-
-    }
-
-    @DisplayName("폼지를 삭제할 수 있다. 폼지를 삭제하면, 하위 폼지 필드도 모두 삭제된다.")
-    @Test
-    void deleteForm() {
-        // given
-        User user = fixtureMonkey.giveMeBuilder(User.class)
-                .set("id", 1L)
-                .set("Role", Role.CLUB)
-                .set("deletedAt", null)
-                .sample();
-        User savedUser = userRepository.save(user);
-        Club club = fixtureMonkey.giveMeBuilder(Club.class)
-                .set("id", 1L)
-                .set("user", savedUser)
-                .set("score", null)
-                .set("clubMembers", null)
-                .set("deletedAt", null)
-                .sample();
-        clubRepository.save(club);
-        Form form = fixtureMonkey.giveMeBuilder(Form.class)
-                .set("club", club)
-                .sample();
-        Form savedForm = formService.create(form);
-        // when
-        facadeCentralFormService.deleteForm(savedForm.getId(), user);
-        // then
-        Form found = formRepository.findById(savedForm.getId()).orElse(null);
-        List<FormField> formFields = formFieldRepository.findAllByForm(savedForm);
-        assertThat(found).isNull();
-        assertThat(formFields).isEmpty();
-    }
-
-    @DisplayName("Club은 자신의 폼지가 아닌 폼지를 삭제할 수 없다.")
-    @Test
-    void validateEqualsClub() {
-        // given
-        User user = fixtureMonkey.giveMeBuilder(User.class)
-                .set("id", 1L)
-                .set("Role", Role.CLUB)
-                .set("deletedAt", null)
-                .sample();
-        User savedUser = userRepository.save(user);
-        Club club = fixtureMonkey.giveMeBuilder(Club.class)
-                .set("id", 1L)
-                .set("user", savedUser)
-                .set("score", null)
-                .set("clubMembers", null)
-                .set("deletedAt", null)
-                .sample();
-        clubRepository.save(club);
-        User user2 = fixtureMonkey.giveMeBuilder(User.class)
-                .set("id", 2L)
-                .set("Role", Role.CLUB)
-                .set("deletedAt", null)
-                .sample();
-        User savedUser2 = userRepository.save(user2);
-        Club club2 = fixtureMonkey.giveMeBuilder(Club.class)
-                .set("id", 2L)
-                .set("user", savedUser2)
-                .set("score", null)
-                .set("clubMembers", null)
-                .set("deletedAt", null)
-                .sample();
-        clubRepository.save(club2);
-
-        Form form = fixtureMonkey.giveMeBuilder(Form.class)
-                .set("club", club)
-                .sample();
-        Form savedForm = formService.create(form);
-        // when //then
-        assertThrows(NonHaveAuthority.class, () -> {
-            facadeCentralFormService.deleteForm(savedForm.getId(), user2);
-        });
-    }
-
-    @DisplayName("동아리는 자신의 폼지를 전부 조회할 수 있다.")
-    @Test
-    void getAllMyForm() {
-        // given
-        User user = fixtureMonkey.giveMeBuilder(User.class)
-                .set("id", 1L)
-                .set("Role", Role.CLUB)
-                .set("deletedAt", null)
-                .sample();
-        User savedUser = userRepository.save(user);
-        Club club = fixtureMonkey.giveMeBuilder(Club.class)
-                .set("id", 1L)
-                .set("user", savedUser)
-                .set("score", null)
-                .set("clubMembers", null)
-                .set("deletedAt", null)
-                .sample();
-        clubRepository.save(club);
-        Form form = fixtureMonkey.giveMeBuilder(Form.class)
-                .set("title", "제목1")
-                .set("club", club)
-                .sample();
-        Form form2 = fixtureMonkey.giveMeBuilder(Form.class)
-                .set("title", "제목2")
-                .set("club", club)
-                .sample();
-        formService.create(form);
-        formService.create(form2);
-
-        // when
-        List<FormListQuery> queries = facadeCentralFormService.getAllMyForm(savedUser);
-        // then
-        assertThat(queries).isNotEmpty();
-        assertThat(queries.size()).isEqualTo(2);
-        assertThat(queries.get(0).title()).isEqualTo("제목1");
-        assertThat(queries.get(1).title()).isEqualTo("제목2");
-
-    }
-
-    @DisplayName("동아리는 폼지를 상세조회 할 수 있다.")
-    @Test
-    void getForm() {
-      // given
-        Form form = fixtureMonkey.giveMeBuilder(Form.class)
+        Club savedClub = clubRepository.saveAndFlush(club);
+        Form form = fixture.giveMeBuilder(Form.class)
                 .set("id", 1L)
                 .set("title", "제목1")
-                .set("club", null)
+                .set("club", savedClub)
                 .sample();
-        Form form2 = fixtureMonkey.giveMeBuilder(Form.class)
-                .set("id", 2L)
-                .set("title", "제목2")
-                .set("club", null)
-                .sample();
-        formService.create(form);
-        formService.create(form2);
-      // when
-        FormQuery formQuery = facadeCentralFormService.getForm(1L);
+        Form savedForm = formRepository.saveAndFlush(form);
+        FormApplication formApplication = FormApplication.builder()
+                .name("지원자1")
+                .studentNumber("60201115")
+                .department("융합소프트웨어학부")
+                .status(FormApplicationStatus.SUBMITTED)
+                .form(savedForm)
+                .build();
+        FormApplication savedApplication = formApplicationService.create(formApplication);
+        // when
+        FormApplicationQuery formApplicationQuery = facadeCentralFormApplicationService.getFormApplication(1L, savedApplication.getId(), savedUser);
         // then
-        assertThat(formQuery.title()).isEqualTo("제목1");
+        assertThat(formApplicationQuery.name()).isEqualTo("지원자1");
     }
 }

--- a/src/test/java/ddingdong/ddingdongBE/domain/form/service/FacadeCentralFormServiceImplTest.java
+++ b/src/test/java/ddingdong/ddingdongBE/domain/form/service/FacadeCentralFormServiceImplTest.java
@@ -1,0 +1,263 @@
+package ddingdong.ddingdongBE.domain.form.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import com.navercorp.fixturemonkey.FixtureMonkey;
+import ddingdong.ddingdongBE.common.exception.AuthenticationException.NonHaveAuthority;
+import ddingdong.ddingdongBE.common.support.FixtureMonkeyFactory;
+import ddingdong.ddingdongBE.common.support.TestContainerSupport;
+import ddingdong.ddingdongBE.domain.club.entity.Club;
+import ddingdong.ddingdongBE.domain.club.repository.ClubRepository;
+import ddingdong.ddingdongBE.domain.form.entity.Form;
+import ddingdong.ddingdongBE.domain.form.entity.FormField;
+import ddingdong.ddingdongBE.domain.form.repository.FormFieldRepository;
+import ddingdong.ddingdongBE.domain.form.repository.FormRepository;
+import ddingdong.ddingdongBE.domain.form.service.dto.command.CreateFormCommand;
+import ddingdong.ddingdongBE.domain.form.service.dto.command.UpdateFormCommand;
+import ddingdong.ddingdongBE.domain.form.service.dto.command.UpdateFormCommand.UpdateFormFieldCommand;
+import ddingdong.ddingdongBE.domain.form.service.dto.query.FormListQuery;
+import ddingdong.ddingdongBE.domain.form.service.dto.query.FormQuery;
+import ddingdong.ddingdongBE.domain.user.entity.Role;
+import ddingdong.ddingdongBE.domain.user.entity.User;
+import ddingdong.ddingdongBE.domain.user.repository.UserRepository;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+class FacadeCentralFormServiceImplTest extends TestContainerSupport {
+
+    @Autowired
+    private FormService formService;
+
+    @Autowired
+    private FormRepository formRepository;
+
+    @Autowired
+    private FacadeCentralFormService facadeCentralFormService;
+
+    @Autowired
+    private ClubRepository clubRepository;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private FormFieldRepository formFieldRepository;
+
+    private static final FixtureMonkey fixtureMonkey = FixtureMonkeyFactory.getNotNullBuilderIntrospectorMonkey();
+
+    @DisplayName("폼지와 폼지 질문을 생성할 수 있다.")
+    @Test
+    void createForm() {
+        // given
+        User user = fixtureMonkey.giveMeBuilder(User.class)
+                .set("id", 1L)
+                .set("Role", Role.CLUB)
+                .set("deletedAt", null)
+                .sample();
+        User savedUser = userRepository.save(user);
+        Club club = fixtureMonkey.giveMeBuilder(Club.class)
+                .set("id", 1L)
+                .set("user", savedUser)
+                .set("score", null)
+                .set("clubMembers", null)
+                .set("deletedAt", null)
+                .sample();
+        clubRepository.save(club);
+        CreateFormCommand createFormCommand = fixtureMonkey.giveMeBuilder(CreateFormCommand.class)
+                .set("user", savedUser)
+                .sample();
+        // when
+        facadeCentralFormService.createForm(createFormCommand);
+        // then
+        List<Form> form = formRepository.findAll();
+        List<FormField> formFields = formFieldRepository.findAll();
+
+        assertThat(form).isNotEmpty();
+        assertThat(formFields).isNotEmpty();
+    }
+
+    @DisplayName("폼지와 폼지 질문을 수정할 수 있다.")
+    @Test
+    void updateForm() {
+        // given
+        User user = fixtureMonkey.giveMeBuilder(User.class)
+                .set("id", 1L)
+                .set("Role", Role.CLUB)
+                .set("deletedAt", null)
+                .sample();
+        User savedUser = userRepository.save(user);
+        Club club = fixtureMonkey.giveMeBuilder(Club.class)
+                .set("id", 1L)
+                .set("user", savedUser)
+                .set("score", null)
+                .set("clubMembers", null)
+                .set("deletedAt", null)
+                .sample();
+        clubRepository.save(club);
+        Form form = fixtureMonkey.giveMeBuilder(Form.class)
+                .set("club", club)
+                .sample();
+        Form savedForm = formService.create(form);
+        UpdateFormCommand updateFormCommand = fixtureMonkey.giveMeBuilder(UpdateFormCommand.class)
+                .set("title", "수정된 제목")
+                .set("description", "수정된 설명")
+                .set("formId", savedForm.getId())
+                .set("formFieldCommands", List.of(
+                        fixtureMonkey.giveMeBuilder(UpdateFormFieldCommand.class)
+                                .set("question", "수정된 질문")
+                                .sample())
+                )
+                .sample();
+        // when
+        facadeCentralFormService.updateForm(updateFormCommand);
+        // then
+        Form found = formRepository.findById(savedForm.getId()).orElse(null);
+        List<FormField> formFields = formFieldRepository.findAllByForm(found);
+        assertThat(found).isNotNull();
+        assertThat(found.getTitle()).isEqualTo("수정된 제목");
+        assertThat(found.getDescription()).isEqualTo("수정된 설명");
+        assertThat(formFields).isNotEmpty();
+        assertThat(formFields.get(0).getQuestion()).isEqualTo("수정된 질문");
+
+    }
+
+    @DisplayName("폼지를 삭제할 수 있다. 폼지를 삭제하면, 하위 폼지 필드도 모두 삭제된다.")
+    @Test
+    void deleteForm() {
+        // given
+        User user = fixtureMonkey.giveMeBuilder(User.class)
+                .set("id", 1L)
+                .set("Role", Role.CLUB)
+                .set("deletedAt", null)
+                .sample();
+        User savedUser = userRepository.save(user);
+        Club club = fixtureMonkey.giveMeBuilder(Club.class)
+                .set("id", 1L)
+                .set("user", savedUser)
+                .set("score", null)
+                .set("clubMembers", null)
+                .set("deletedAt", null)
+                .sample();
+        clubRepository.save(club);
+        Form form = fixtureMonkey.giveMeBuilder(Form.class)
+                .set("club", club)
+                .sample();
+        Form savedForm = formService.create(form);
+        // when
+        facadeCentralFormService.deleteForm(savedForm.getId(), user);
+        // then
+        Form found = formRepository.findById(savedForm.getId()).orElse(null);
+        List<FormField> formFields = formFieldRepository.findAllByForm(savedForm);
+        assertThat(found).isNull();
+        assertThat(formFields).isEmpty();
+    }
+
+    @DisplayName("Club은 자신의 폼지가 아닌 폼지를 삭제할 수 없다.")
+    @Test
+    void validateEqualsClub() {
+        // given
+        User user = fixtureMonkey.giveMeBuilder(User.class)
+                .set("id", 1L)
+                .set("Role", Role.CLUB)
+                .set("deletedAt", null)
+                .sample();
+        User savedUser = userRepository.save(user);
+        Club club = fixtureMonkey.giveMeBuilder(Club.class)
+                .set("id", 1L)
+                .set("user", savedUser)
+                .set("score", null)
+                .set("clubMembers", null)
+                .set("deletedAt", null)
+                .sample();
+        clubRepository.save(club);
+        User user2 = fixtureMonkey.giveMeBuilder(User.class)
+                .set("id", 2L)
+                .set("Role", Role.CLUB)
+                .set("deletedAt", null)
+                .sample();
+        User savedUser2 = userRepository.save(user2);
+        Club club2 = fixtureMonkey.giveMeBuilder(Club.class)
+                .set("id", 2L)
+                .set("user", savedUser2)
+                .set("score", null)
+                .set("clubMembers", null)
+                .set("deletedAt", null)
+                .sample();
+        clubRepository.save(club2);
+
+        Form form = fixtureMonkey.giveMeBuilder(Form.class)
+                .set("club", club)
+                .sample();
+        Form savedForm = formService.create(form);
+        // when //then
+        assertThrows(NonHaveAuthority.class, () -> {
+            facadeCentralFormService.deleteForm(savedForm.getId(), user2);
+        });
+    }
+
+    @DisplayName("동아리는 자신의 폼지를 전부 조회할 수 있다.")
+    @Test
+    void getAllMyForm() {
+        // given
+        User user = fixtureMonkey.giveMeBuilder(User.class)
+                .set("id", 1L)
+                .set("Role", Role.CLUB)
+                .set("deletedAt", null)
+                .sample();
+        User savedUser = userRepository.save(user);
+        Club club = fixtureMonkey.giveMeBuilder(Club.class)
+                .set("id", 1L)
+                .set("user", savedUser)
+                .set("score", null)
+                .set("clubMembers", null)
+                .set("deletedAt", null)
+                .sample();
+        clubRepository.save(club);
+        Form form = fixtureMonkey.giveMeBuilder(Form.class)
+                .set("title", "제목1")
+                .set("club", club)
+                .sample();
+        Form form2 = fixtureMonkey.giveMeBuilder(Form.class)
+                .set("title", "제목2")
+                .set("club", club)
+                .sample();
+        formService.create(form);
+        formService.create(form2);
+
+        // when
+        List<FormListQuery> queries = facadeCentralFormService.getAllMyForm(savedUser);
+        // then
+        assertThat(queries).isNotEmpty();
+        assertThat(queries.size()).isEqualTo(2);
+        assertThat(queries.get(0).title()).isEqualTo("제목1");
+        assertThat(queries.get(1).title()).isEqualTo("제목2");
+
+    }
+
+    @DisplayName("동아리는 폼지를 상세조회 할 수 있다.")
+    @Test
+    void getForm() {
+      // given
+        Form form = fixtureMonkey.giveMeBuilder(Form.class)
+                .set("id", 1L)
+                .set("title", "제목1")
+                .set("club", null)
+                .sample();
+        Form form2 = fixtureMonkey.giveMeBuilder(Form.class)
+                .set("id", 2L)
+                .set("title", "제목2")
+                .set("club", null)
+                .sample();
+        formService.create(form);
+        formService.create(form2);
+      // when
+        FormQuery formQuery = facadeCentralFormService.getForm(1L);
+        // then
+        assertThat(formQuery.title()).isEqualTo("제목1");
+    }
+}


### PR DESCRIPTION
## 🚀 작업 내용

지원자 상세 조회 API 구현하였습니다.

## 🤔 고민했던 내용

FormAnswerListQuery의 위치를 고민했습니다. FormFieldAnswerListQuery와 같은 뎁스에 있으니 가독성이 좋지 않은 것 같기도 합니다.... 
FormFieldAnswerListQuery의 위치 또한 고민됩니다. FormFieldListQuery는 FormQuery에 있고, FormAnswerListQuery는 FormApplicationListQuery에 있어서 이들을 어떻게 위치시켜야 가독성 측면에서 좋을지 궁금합니다. 그냥 FormFieldAnswerListQuery를 외부로 빼버리는 건 어떨까요?
 

## 💬 리뷰 중점사항
현재 로컬 swagger에서 폼 관련 요청 전부 500 에러가 납니다.
test 코드를 실행하면 FacadeCentralFormApplicationServiceImpl에서 예외처리한 사용자 소유 이외의 폼지를 조회했을 때 나는 에러(권한 없음 에러)가 나는데, swagger로도 테스트 해봐야 무엇 때문에 오류가 나는지 알 수 있을 것 같습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **새로운 기능**
  - 특정 양식에 대한 신청 내역을 상세하게 조회할 수 있는 기능이 추가되었습니다.
  - 신청 정보와 함께 응답 구조가 개선되어, 제출일, 이름, 학번, 부서, 상태 및 각 양식 항목의 답변 내용을 확인할 수 있습니다.
  - 사용자 인증 정보를 반영하여, 사용자의 신청 내역을 안전하게 처리할 수 있도록 업데이트되었습니다.
  - API 문서 자동 생성 기능이 강화되어, 보다 명확한 안내를 제공합니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->