### PR TITLE
[DDING-102] 폼지 섹션 조회 API 구현

### DIFF
--- a/src/main/java/ddingdong/ddingdongBE/domain/form/api/UserFormApi.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/form/api/UserFormApi.java
@@ -1,0 +1,21 @@
+package ddingdong.ddingdongBE.domain.form.api;
+
+import ddingdong.ddingdongBE.domain.form.controller.dto.response.FormSectionResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+@Tag(name = "Form - User", description = "User Form API")
+@RequestMapping("/server")
+public interface UserFormApi {
+
+  @Operation(summary = "폼지 섹션 조회 API")
+  @ApiResponse(responseCode = "200", description = "폼지 섹션 조회 성공")
+  @GetMapping("/forms/{formId}/sections")
+  FormSectionResponse getFormSections(
+      @PathVariable("formId") Long formId
+  );
+}

--- a/src/main/java/ddingdong/ddingdongBE/domain/form/api/UserFormApi.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/form/api/UserFormApi.java
@@ -2,18 +2,24 @@ package ddingdong.ddingdongBE.domain.form.api;
 
 import ddingdong.ddingdongBE.domain.form.controller.dto.response.FormSectionResponse;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
 
 @Tag(name = "Form - User", description = "User Form API")
 @RequestMapping("/server")
 public interface UserFormApi {
 
   @Operation(summary = "폼지 섹션 조회 API")
-  @ApiResponse(responseCode = "200", description = "폼지 섹션 조회 성공")
+  @ApiResponse(responseCode = "200", description = "폼지 섹션 조회 성공",
+      content = @Content(schema = @Schema(implementation = FormSectionResponse.class)))
+  @ResponseStatus(HttpStatus.OK)
   @GetMapping("/forms/{formId}/sections")
   FormSectionResponse getFormSections(
       @PathVariable("formId") Long formId

--- a/src/main/java/ddingdong/ddingdongBE/domain/form/controller/UserFormController.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/form/controller/UserFormController.java
@@ -1,0 +1,21 @@
+package ddingdong.ddingdongBE.domain.form.controller;
+
+import ddingdong.ddingdongBE.domain.form.api.UserFormApi;
+import ddingdong.ddingdongBE.domain.form.controller.dto.response.FormSectionResponse;
+import ddingdong.ddingdongBE.domain.form.service.FacadeUserFormService;
+import ddingdong.ddingdongBE.domain.form.service.dto.query.FormSectionQuery;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class UserFormController implements UserFormApi {
+
+  private final FacadeUserFormService facadeUserFormService;
+
+  @Override
+  public FormSectionResponse getFormSections(Long formId) {
+    FormSectionQuery query = facadeUserFormService.getFormSection(formId);
+    return FormSectionResponse.from(query);
+  }
+}

--- a/src/main/java/ddingdong/ddingdongBE/domain/form/controller/dto/response/FormSectionResponse.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/form/controller/dto/response/FormSectionResponse.java
@@ -1,0 +1,24 @@
+package ddingdong.ddingdongBE.domain.form.controller.dto.response;
+
+import ddingdong.ddingdongBE.domain.form.service.dto.query.FormSectionQuery;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+import lombok.Builder;
+
+@Builder
+public record FormSectionResponse (
+    @Schema(description = "폼지 제목", example = "카우 1기 폼지")
+    String title,
+    @Schema(description = "폼지 설명", example = "폼지 설명입니다")
+    String description,
+    @Schema(description = "섹션 리스트", example = "[서버, 웹]")
+    List<String> sections
+) {
+  public static FormSectionResponse from(FormSectionQuery formSectionQuery) {
+    return FormSectionResponse.builder()
+        .title(formSectionQuery.title())
+        .description(formSectionQuery.description())
+        .sections(formSectionQuery.sections())
+        .build();
+  }
+}

--- a/src/main/java/ddingdong/ddingdongBE/domain/form/service/FacadeUserFormService.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/form/service/FacadeUserFormService.java
@@ -1,0 +1,8 @@
+package ddingdong.ddingdongBE.domain.form.service;
+
+import ddingdong.ddingdongBE.domain.form.service.dto.query.FormSectionQuery;
+
+public interface FacadeUserFormService {
+
+  FormSectionQuery getFormSection(Long formId);
+}

--- a/src/main/java/ddingdong/ddingdongBE/domain/form/service/FacadeUserFormServiceImpl.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/form/service/FacadeUserFormServiceImpl.java
@@ -16,6 +16,6 @@ public class FacadeUserFormServiceImpl implements FacadeUserFormService {
   @Override
   public FormSectionQuery getFormSection(Long formId) {
     Form form = formService.getById(formId);
-    return FormSectionQuery.of(form.getTitle(), form.getDescription(), form.getSections());
+    return FormSectionQuery.from(form);
   }
 }

--- a/src/main/java/ddingdong/ddingdongBE/domain/form/service/FacadeUserFormServiceImpl.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/form/service/FacadeUserFormServiceImpl.java
@@ -1,0 +1,21 @@
+package ddingdong.ddingdongBE.domain.form.service;
+
+import ddingdong.ddingdongBE.domain.form.entity.Form;
+import ddingdong.ddingdongBE.domain.form.service.dto.query.FormSectionQuery;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class FacadeUserFormServiceImpl implements FacadeUserFormService {
+
+  private final FormService formService;
+
+  @Override
+  public FormSectionQuery getFormSection(Long formId) {
+    Form form = formService.getById(formId);
+    return FormSectionQuery.of(form.getTitle(), form.getDescription(), form.getSections());
+  }
+}

--- a/src/main/java/ddingdong/ddingdongBE/domain/form/service/dto/query/FormSectionQuery.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/form/service/dto/query/FormSectionQuery.java
@@ -1,0 +1,19 @@
+package ddingdong.ddingdongBE.domain.form.service.dto.query;
+
+import java.util.List;
+import lombok.Builder;
+
+@Builder
+public record FormSectionQuery (
+    String title,
+    String description,
+    List<String> sections
+){
+  public static FormSectionQuery of(String title, String description, List<String> sections) {
+    return FormSectionQuery.builder()
+        .title(title)
+        .description(description)
+        .sections(sections)
+        .build();
+  }
+}

--- a/src/main/java/ddingdong/ddingdongBE/domain/form/service/dto/query/FormSectionQuery.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/form/service/dto/query/FormSectionQuery.java
@@ -1,19 +1,21 @@
 package ddingdong.ddingdongBE.domain.form.service.dto.query;
 
+import ddingdong.ddingdongBE.domain.form.entity.Form;
 import java.util.List;
 import lombok.Builder;
 
 @Builder
-public record FormSectionQuery (
+public record FormSectionQuery(
     String title,
     String description,
     List<String> sections
-){
-  public static FormSectionQuery of(String title, String description, List<String> sections) {
+) {
+
+  public static FormSectionQuery from(Form form) {
     return FormSectionQuery.builder()
-        .title(title)
-        .description(description)
-        .sections(sections)
+        .title(form.getTitle())
+        .description(form.getDescription())
+        .sections(form.getSections())
         .build();
   }
 }

--- a/src/main/java/ddingdong/ddingdongBE/domain/formapplication/controller/UserFormApplicationController.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/formapplication/controller/UserFormApplicationController.java
@@ -2,7 +2,7 @@ package ddingdong.ddingdongBE.domain.formapplication.controller;
 
 import ddingdong.ddingdongBE.domain.formapplication.api.UserFormApplicationApi;
 import ddingdong.ddingdongBE.domain.formapplication.controller.dto.request.CreateFormApplicationRequest;
-import ddingdong.ddingdongBE.domain.formapplication.service.FacadeUserFormService;
+import ddingdong.ddingdongBE.domain.formapplication.service.FacadeUserFormApplicationService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -10,10 +10,10 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 public class UserFormApplicationController implements UserFormApplicationApi {
 
-    private final FacadeUserFormService facadeUserFormService;
+    private final FacadeUserFormApplicationService facadeUserFormApplicationService;
 
     @Override
     public void createFormApplication(Long formId, CreateFormApplicationRequest createFormApplicationRequest) {
-        facadeUserFormService.createFormApplication(createFormApplicationRequest.toCommand(formId));
+        facadeUserFormApplicationService.createFormApplication(createFormApplicationRequest.toCommand(formId));
     }
 }

--- a/src/main/java/ddingdong/ddingdongBE/domain/formapplication/service/FacadeUserFormApplicationService.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/formapplication/service/FacadeUserFormApplicationService.java
@@ -2,7 +2,7 @@ package ddingdong.ddingdongBE.domain.formapplication.service;
 
 import ddingdong.ddingdongBE.domain.formapplication.service.dto.command.CreateFormApplicationCommand;
 
-public interface FacadeUserFormService {
+public interface FacadeUserFormApplicationService {
 
     void createFormApplication(CreateFormApplicationCommand createFormApplicationCommand);
 

--- a/src/main/java/ddingdong/ddingdongBE/domain/formapplication/service/FacadeUserFormApplicationServiceImpl.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/formapplication/service/FacadeUserFormApplicationServiceImpl.java
@@ -15,7 +15,7 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
-public class FacadeUserFormServiceImpl implements FacadeUserFormService {
+public class FacadeUserFormApplicationServiceImpl implements FacadeUserFormApplicationService {
 
     private final FormApplicationService formApplicationService;
     private final FormAnswerService formAnswerService;

--- a/src/test/java/ddingdong/ddingdongBE/domain/form/service/FacadeUserFormApplicationServiceImplTest.java
+++ b/src/test/java/ddingdong/ddingdongBE/domain/form/service/FacadeUserFormApplicationServiceImplTest.java
@@ -16,7 +16,7 @@ import ddingdong.ddingdongBE.domain.formapplication.entity.FormAnswer;
 import ddingdong.ddingdongBE.domain.formapplication.entity.FormApplication;
 import ddingdong.ddingdongBE.domain.formapplication.repository.FormAnswerRepository;
 import ddingdong.ddingdongBE.domain.formapplication.repository.FormApplicationRepository;
-import ddingdong.ddingdongBE.domain.formapplication.service.FacadeUserFormService;
+import ddingdong.ddingdongBE.domain.formapplication.service.FacadeUserFormApplicationService;
 import ddingdong.ddingdongBE.domain.formapplication.service.dto.command.CreateFormApplicationCommand;
 import ddingdong.ddingdongBE.domain.formapplication.service.dto.command.CreateFormApplicationCommand.CreateFormAnswerCommand;
 import ddingdong.ddingdongBE.domain.user.entity.Role;
@@ -30,10 +30,10 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
 @SpringBootTest
-class FacadeUserFormServiceImplTest extends TestContainerSupport {
+class FacadeUserFormApplicationServiceImplTest extends TestContainerSupport {
 
     @Autowired
-    private FacadeUserFormService facadeUserFormService;
+    private FacadeUserFormApplicationService facadeUserFormApplicationService;
 
     @Autowired
     private FormApplicationRepository formApplicationRepository;
@@ -99,7 +99,7 @@ class FacadeUserFormServiceImplTest extends TestContainerSupport {
                 .set("formAnswerCommands", List.of(new CreateFormAnswerCommand(savedFormField.getId(), List.of("답변"))))
                 .sample();
         // when
-        facadeUserFormService.createFormApplication(createFormApplicationCommand);
+        facadeUserFormApplicationService.createFormApplication(createFormApplicationCommand);
         // then
         List<FormApplication> formApplications = formApplicationRepository.findAll();
         List<FormAnswer> formAnswers  = formAnswerRepository.findAll();

--- a/src/test/java/ddingdong/ddingdongBE/domain/form/service/FacadeUserFormServiceImplTest.java
+++ b/src/test/java/ddingdong/ddingdongBE/domain/form/service/FacadeUserFormServiceImplTest.java
@@ -1,0 +1,78 @@
+package ddingdong.ddingdongBE.domain.form.service;
+
+import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
+
+import com.navercorp.fixturemonkey.FixtureMonkey;
+import ddingdong.ddingdongBE.common.support.FixtureMonkeyFactory;
+import ddingdong.ddingdongBE.common.support.TestContainerSupport;
+import ddingdong.ddingdongBE.domain.club.entity.Club;
+import ddingdong.ddingdongBE.domain.club.repository.ClubRepository;
+import ddingdong.ddingdongBE.domain.form.entity.Form;
+import ddingdong.ddingdongBE.domain.form.repository.FormRepository;
+import ddingdong.ddingdongBE.domain.form.service.dto.query.FormSectionQuery;
+import ddingdong.ddingdongBE.domain.user.entity.Role;
+import ddingdong.ddingdongBE.domain.user.entity.User;
+import ddingdong.ddingdongBE.domain.user.repository.UserRepository;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+class FacadeUserFormServiceImplTest extends TestContainerSupport {
+
+  @Autowired
+  private FacadeUserFormService facadeUserFormService;
+
+  @Autowired
+  private FormRepository formRepository;
+
+  @Autowired
+  private ClubRepository clubRepository;
+
+  @Autowired
+  private UserRepository userRepository;
+
+  private static final FixtureMonkey fixtureMonkey = FixtureMonkeyFactory.getNotNullBuilderIntrospectorMonkey();
+
+  @DisplayName("유저는 섹션 목록을 조회할 수 있다.")
+  @Test
+  void getFormSection() {
+    // given
+    User user = fixtureMonkey.giveMeBuilder(User.class)
+        .set("id", 1L)
+        .set("Role", Role.CLUB)
+        .set("deletedAt", null)
+        .sample();
+    User savedUser = userRepository.save(user);
+
+    Club club = fixtureMonkey.giveMeBuilder(Club.class)
+        .set("id", 1L)
+        .set("user", savedUser)
+        .set("score", null)
+        .set("clubMembers", null)
+        .set("deletedAt", null)
+        .sample();
+    clubRepository.save(club);
+
+    List<String> savedSections = new ArrayList<>();
+    savedSections.add("section1");
+    savedSections.add("section2");
+
+    Form form = fixtureMonkey.giveMeBuilder(Form.class)
+        .set("id", 1L)
+        .set("title", "띵동 폼")
+        .set("description", "저희 동아리는 띵동입니다.")
+        .set("hasInterview", false)
+        .set("club", club)
+        .set("sections", savedSections)
+        .sample();
+    Form savedForm = formRepository.save(form);
+
+    FormSectionQuery sectionQuery = facadeUserFormService.getFormSection(savedForm.getId());
+
+    assertThat(sectionQuery.sections()).isEqualTo(savedSections);
+  }
+}


### PR DESCRIPTION
## 🚀 작업 내용

폼지 섹션 조회 API 구현하였습니다.

## 🤔 고민했던 내용


## 💬 리뷰 중점사항


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **새로운 기능**
	- 폼의 제목, 설명 및 섹션 정보를 확인할 수 있는 새로운 API 엔드포인트가 추가되었습니다.
- **리팩터링**
	- 폼 신청 처리 관련 서비스 명칭을 업데이트하여 내부 일관성을 개선하였습니다.
- **테스트**
	- 폼 섹션 조회와 폼 신청 기능에 대한 신규 테스트 케이스가 추가되어 기능의 안정성을 검증하였습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->