### PR TITLE
[DDING-000] FormField 테이블 options 컬럼 default값 설정

### DIFF
--- a/src/main/resources/db/migration/V37__alter_form_field_column_options.sql
+++ b/src/main/resources/db/migration/V37__alter_form_field_column_options.sql
@@ -1,0 +1,2 @@
+ALTER TABLE form_field
+    MODIFY options VARCHAR(255) DEFAULT '[]';


### PR DESCRIPTION
## 🚀 작업 내용
- StringListConverter를 활용하여 저장하고 있는 options column의 값이 Null 이 되면 안되기 때문에, default값 설정하였습니다
