### PR TITLE
[DDING-98] 지원 폼지 통계 객관식 상세조회 API 구현

### DIFF
--- a/src/main/java/ddingdong/ddingdongBE/common/converter/StringListConverter.java
+++ b/src/main/java/ddingdong/ddingdongBE/common/converter/StringListConverter.java
@@ -5,8 +5,10 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.persistence.AttributeConverter;
 import jakarta.persistence.Converter;
 import java.util.List;
+import org.springframework.stereotype.Component;
 
 @Converter
+@Component
 public class StringListConverter implements AttributeConverter<List<String>, String> {
 
     private final ObjectMapper mapper = new ObjectMapper();

--- a/src/main/java/ddingdong/ddingdongBE/common/exception/InvalidatedMappingException.java
+++ b/src/main/java/ddingdong/ddingdongBE/common/exception/InvalidatedMappingException.java
@@ -5,6 +5,7 @@ import static org.springframework.http.HttpStatus.BAD_REQUEST;
 sealed public class InvalidatedMappingException extends CustomException {
 
     private static final String INVALID_FORM_DATE_MESSAGE = "입력한 기간과 겹치는 폼이 존재합니다.";
+    private static final String INVALID_FIELD_TYPE_MESSAGE = "통계를 조회할 질문 유형이 올바르지 않습니다.";
 
     public InvalidatedMappingException(String message, int errorCode) {
         super(message, errorCode);
@@ -23,4 +24,12 @@ sealed public class InvalidatedMappingException extends CustomException {
             super(INVALID_FORM_DATE_MESSAGE, BAD_REQUEST.value());
         }
     }
+
+    public static final class InvalidFieldTypeException extends InvalidatedMappingException {
+
+        public InvalidFieldTypeException() {
+            super(INVALID_FIELD_TYPE_MESSAGE, BAD_REQUEST.value());
+        }
+    }
+
 }

--- a/src/main/java/ddingdong/ddingdongBE/domain/form/api/CentralFormApi.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/form/api/CentralFormApi.java
@@ -94,7 +94,7 @@ public interface CentralFormApi {
 
     @Operation(summary = "동아리 폼지 통계 객관식 상세조회 API")
     @ApiResponse(responseCode = "200", description = "동아리 폼지 통계 객관식 상세조회 성공",
-            content = @Content(schema = @Schema(implementation = FormStatisticsResponse.class)))
+            content = @Content(schema = @Schema(implementation = MultipleFieldStatisticsResponse.class)))
     @ResponseStatus(HttpStatus.OK)
     @SecurityRequirement(name = "AccessToken")
     @GetMapping("/my/forms/statistics/multiple-choice")

--- a/src/main/java/ddingdong/ddingdongBE/domain/form/api/CentralFormApi.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/form/api/CentralFormApi.java
@@ -6,6 +6,7 @@ import ddingdong.ddingdongBE.domain.form.controller.dto.request.UpdateFormReques
 import ddingdong.ddingdongBE.domain.form.controller.dto.response.FormListResponse;
 import ddingdong.ddingdongBE.domain.form.controller.dto.response.FormResponse;
 import ddingdong.ddingdongBE.domain.form.controller.dto.response.FormStatisticsResponse;
+import ddingdong.ddingdongBE.domain.form.controller.dto.response.MultipleFieldStatisticsResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.ArraySchema;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -24,6 +25,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseStatus;
 
 @Tag(name = "Form - Club", description = "Form API")
@@ -89,4 +91,12 @@ public interface CentralFormApi {
             @PathVariable("formId") Long formId,
             @AuthenticationPrincipal PrincipalDetails principalDetails
     );
+
+    @Operation(summary = "동아리 폼지 통계 객관식 상세조회 API")
+    @ApiResponse(responseCode = "200", description = "동아리 폼지 통계 객관식 상세조회 성공",
+            content = @Content(schema = @Schema(implementation = FormStatisticsResponse.class)))
+    @ResponseStatus(HttpStatus.OK)
+    @SecurityRequirement(name = "AccessToken")
+    @GetMapping("/my/forms/statistics/multiple-choice")
+    MultipleFieldStatisticsResponse getMultipleFieldStatistics(@RequestParam Long fieldId);
 }

--- a/src/main/java/ddingdong/ddingdongBE/domain/form/controller/CentralFormController.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/form/controller/CentralFormController.java
@@ -7,10 +7,12 @@ import ddingdong.ddingdongBE.domain.form.controller.dto.request.UpdateFormReques
 import ddingdong.ddingdongBE.domain.form.controller.dto.response.FormListResponse;
 import ddingdong.ddingdongBE.domain.form.controller.dto.response.FormResponse;
 import ddingdong.ddingdongBE.domain.form.controller.dto.response.FormStatisticsResponse;
+import ddingdong.ddingdongBE.domain.form.controller.dto.response.MultipleFieldStatisticsResponse;
 import ddingdong.ddingdongBE.domain.form.service.FacadeCentralFormService;
 import ddingdong.ddingdongBE.domain.form.service.dto.query.FormListQuery;
 import ddingdong.ddingdongBE.domain.form.service.dto.query.FormQuery;
 import ddingdong.ddingdongBE.domain.form.service.dto.query.FormStatisticsQuery;
+import ddingdong.ddingdongBE.domain.form.service.dto.query.MultipleFieldStatisticsQuery;
 import ddingdong.ddingdongBE.domain.user.entity.User;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -70,5 +72,11 @@ public class CentralFormController implements CentralFormApi {
         User user = principalDetails.getUser();
         FormStatisticsQuery query = facadeCentralFormService.getStatisticsByForm(user, formId);
         return FormStatisticsResponse.from(query);
+    }
+
+    @Override
+    public MultipleFieldStatisticsResponse getMultipleFieldStatistics(Long fieldId) {
+        MultipleFieldStatisticsQuery query = facadeCentralFormService.getMultipleFieldStatistics(fieldId);
+        return MultipleFieldStatisticsResponse.from(query);
     }
 }

--- a/src/main/java/ddingdong/ddingdongBE/domain/form/controller/dto/response/MultipleFieldStatisticsResponse.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/form/controller/dto/response/MultipleFieldStatisticsResponse.java
@@ -1,0 +1,36 @@
+package ddingdong.ddingdongBE.domain.form.controller.dto.response;
+
+import ddingdong.ddingdongBE.domain.form.service.dto.query.MultipleFieldStatisticsQuery;
+import ddingdong.ddingdongBE.domain.form.service.dto.query.MultipleFieldStatisticsQuery.OptionStatisticQuery;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+
+public record MultipleFieldStatisticsResponse(
+        @Schema(description = "질문 유형", example = "CHECK_BOX")
+        String type,
+        @ArraySchema(schema = @Schema(implementation = MultipleFieldStatisticsQuery.class))
+        List<OptionStatisticResponse> options
+) {
+
+    record OptionStatisticResponse(
+            @Schema(description = "지문", example = "지문 1입니다.")
+            String label,
+            @Schema(description = "지문 선택 수", example = "10")
+            int count,
+            @Schema(description = "지원자 수 대비 지문 선택 비율", example = "80")
+            int ratio
+    ) {
+
+        public static OptionStatisticResponse from(OptionStatisticQuery query) {
+            return new OptionStatisticResponse(query.label(), query.count(), query.ratio());
+        }
+    }
+
+    public static MultipleFieldStatisticsResponse from(MultipleFieldStatisticsQuery query) {
+        List<OptionStatisticResponse> responses = query.optionsQueries().stream()
+                .map(OptionStatisticResponse::from)
+                .toList();
+        return new MultipleFieldStatisticsResponse(query.type(), responses);
+    }
+}

--- a/src/main/java/ddingdong/ddingdongBE/domain/form/entity/FormField.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/form/entity/FormField.java
@@ -67,4 +67,8 @@ public class FormField extends BaseEntity {
     this.options = options;
     this.form = form;
   }
+
+  public boolean isMultipleChoice() {
+    return this.fieldType == FieldType.CHECK_BOX || this.fieldType == FieldType.RADIO;
+  }
 }

--- a/src/main/java/ddingdong/ddingdongBE/domain/form/service/FacadeCentralFormService.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/form/service/FacadeCentralFormService.java
@@ -5,6 +5,7 @@ import ddingdong.ddingdongBE.domain.form.service.dto.command.UpdateFormCommand;
 import ddingdong.ddingdongBE.domain.form.service.dto.query.FormListQuery;
 import ddingdong.ddingdongBE.domain.form.service.dto.query.FormQuery;
 import ddingdong.ddingdongBE.domain.form.service.dto.query.FormStatisticsQuery;
+import ddingdong.ddingdongBE.domain.form.service.dto.query.MultipleFieldStatisticsQuery;
 import ddingdong.ddingdongBE.domain.user.entity.User;
 import java.util.List;
 
@@ -21,4 +22,6 @@ public interface FacadeCentralFormService {
     FormQuery getForm(Long formId);
 
     FormStatisticsQuery getStatisticsByForm(User user, Long formId);
+
+    MultipleFieldStatisticsQuery getMultipleFieldStatistics(Long fieldId);
 }

--- a/src/main/java/ddingdong/ddingdongBE/domain/form/service/FacadeCentralFormServiceImpl.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/form/service/FacadeCentralFormServiceImpl.java
@@ -17,6 +17,8 @@ import ddingdong.ddingdongBE.domain.form.service.dto.query.FormStatisticsQuery;
 import ddingdong.ddingdongBE.domain.form.service.dto.query.FormStatisticsQuery.ApplicantStatisticQuery;
 import ddingdong.ddingdongBE.domain.form.service.dto.query.FormStatisticsQuery.DepartmentStatisticQuery;
 import ddingdong.ddingdongBE.domain.form.service.dto.query.FormStatisticsQuery.FieldStatisticsQuery;
+import ddingdong.ddingdongBE.domain.form.service.dto.query.MultipleFieldStatisticsQuery;
+import ddingdong.ddingdongBE.domain.form.service.dto.query.MultipleFieldStatisticsQuery.OptionStatisticQuery;
 import ddingdong.ddingdongBE.domain.user.entity.User;
 import java.time.LocalDate;
 import java.util.List;
@@ -100,6 +102,14 @@ public class FacadeCentralFormServiceImpl implements FacadeCentralFormService {
         FieldStatisticsQuery fieldStatisticsQuery = formStatisticService.createFieldStatisticsByForm(form);
 
         return new FormStatisticsQuery(totalCount, departmentStatisticQueries, applicantStatisticQueries, fieldStatisticsQuery);
+    }
+
+    @Override
+    public MultipleFieldStatisticsQuery getMultipleFieldStatistics(Long fieldId) {
+        FormField formField = formFieldService.getById(fieldId);
+        String type = formField.getFieldType().name();
+        List<OptionStatisticQuery> optionStatisticQueries = formStatisticService.createOptionStatistics(formField);
+        return new MultipleFieldStatisticsQuery(type, optionStatisticQueries);
     }
 
     private FormListQuery buildFormListQuery(Form form) {

--- a/src/main/java/ddingdong/ddingdongBE/domain/form/service/FacadeCentralFormServiceImpl.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/form/service/FacadeCentralFormServiceImpl.java
@@ -2,6 +2,7 @@ package ddingdong.ddingdongBE.domain.form.service;
 
 import ddingdong.ddingdongBE.common.exception.AuthenticationException.NonHaveAuthority;
 import ddingdong.ddingdongBE.common.exception.InvalidatedMappingException.InvalidFieldTypeException;
+import ddingdong.ddingdongBE.common.exception.InvalidatedMappingException.InvalidFormPeriodException;
 import ddingdong.ddingdongBE.common.utils.TimeUtils;
 import ddingdong.ddingdongBE.domain.club.entity.Club;
 import ddingdong.ddingdongBE.domain.club.service.ClubService;
@@ -130,7 +131,7 @@ public class FacadeCentralFormServiceImpl implements FacadeCentralFormService {
         List<Form> overlappingForms = formService.findOverlappingForms(club.getId(), startDate, endDate);
 
         if (!overlappingForms.isEmpty()) {
-            throw new InvalidFieldTypeException();
+            throw new InvalidFormPeriodException();
         }
     }
 

--- a/src/main/java/ddingdong/ddingdongBE/domain/form/service/FacadeCentralFormServiceImpl.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/form/service/FacadeCentralFormServiceImpl.java
@@ -1,7 +1,7 @@
 package ddingdong.ddingdongBE.domain.form.service;
 
 import ddingdong.ddingdongBE.common.exception.AuthenticationException.NonHaveAuthority;
-import ddingdong.ddingdongBE.common.exception.InvalidatedMappingException.InvalidFormPeriodException;
+import ddingdong.ddingdongBE.common.exception.InvalidatedMappingException.InvalidFieldTypeException;
 import ddingdong.ddingdongBE.common.utils.TimeUtils;
 import ddingdong.ddingdongBE.domain.club.entity.Club;
 import ddingdong.ddingdongBE.domain.club.service.ClubService;
@@ -107,6 +107,9 @@ public class FacadeCentralFormServiceImpl implements FacadeCentralFormService {
     @Override
     public MultipleFieldStatisticsQuery getMultipleFieldStatistics(Long fieldId) {
         FormField formField = formFieldService.getById(fieldId);
+        if (!formField.isMultipleChoice()) {
+            throw new InvalidFieldTypeException();
+        }
         String type = formField.getFieldType().name();
         List<OptionStatisticQuery> optionStatisticQueries = formStatisticService.createOptionStatistics(formField);
         return new MultipleFieldStatisticsQuery(type, optionStatisticQueries);
@@ -127,7 +130,7 @@ public class FacadeCentralFormServiceImpl implements FacadeCentralFormService {
         List<Form> overlappingForms = formService.findOverlappingForms(club.getId(), startDate, endDate);
 
         if (!overlappingForms.isEmpty()) {
-            throw new InvalidFormPeriodException();
+            throw new InvalidFieldTypeException();
         }
     }
 

--- a/src/main/java/ddingdong/ddingdongBE/domain/form/service/FormStatisticService.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/form/service/FormStatisticService.java
@@ -2,9 +2,11 @@ package ddingdong.ddingdongBE.domain.form.service;
 
 import ddingdong.ddingdongBE.domain.club.entity.Club;
 import ddingdong.ddingdongBE.domain.form.entity.Form;
+import ddingdong.ddingdongBE.domain.form.entity.FormField;
 import ddingdong.ddingdongBE.domain.form.service.dto.query.FormStatisticsQuery.ApplicantStatisticQuery;
 import ddingdong.ddingdongBE.domain.form.service.dto.query.FormStatisticsQuery.DepartmentStatisticQuery;
 import ddingdong.ddingdongBE.domain.form.service.dto.query.FormStatisticsQuery.FieldStatisticsQuery;
+import ddingdong.ddingdongBE.domain.form.service.dto.query.MultipleFieldStatisticsQuery.OptionStatisticQuery;
 import java.util.List;
 
 public interface FormStatisticService {
@@ -17,4 +19,5 @@ public interface FormStatisticService {
 
     FieldStatisticsQuery createFieldStatisticsByForm(Form form);
 
+    List<OptionStatisticQuery> createOptionStatistics(FormField formField);
 }

--- a/src/main/java/ddingdong/ddingdongBE/domain/form/service/FormStatisticServiceImpl.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/form/service/FormStatisticServiceImpl.java
@@ -4,12 +4,14 @@ import ddingdong.ddingdongBE.common.utils.CalculationUtils;
 import ddingdong.ddingdongBE.common.utils.TimeUtils;
 import ddingdong.ddingdongBE.domain.club.entity.Club;
 import ddingdong.ddingdongBE.domain.form.entity.Form;
+import ddingdong.ddingdongBE.domain.form.entity.FormField;
 import ddingdong.ddingdongBE.domain.form.repository.FormFieldRepository;
 import ddingdong.ddingdongBE.domain.form.repository.dto.FieldListInfo;
 import ddingdong.ddingdongBE.domain.form.service.dto.query.FormStatisticsQuery.ApplicantStatisticQuery;
 import ddingdong.ddingdongBE.domain.form.service.dto.query.FormStatisticsQuery.DepartmentStatisticQuery;
 import ddingdong.ddingdongBE.domain.form.service.dto.query.FormStatisticsQuery.FieldStatisticsQuery;
 import ddingdong.ddingdongBE.domain.form.service.dto.query.FormStatisticsQuery.FieldStatisticsQuery.FieldStatisticsListQuery;
+import ddingdong.ddingdongBE.domain.form.service.dto.query.MultipleFieldStatisticsQuery.OptionStatisticQuery;
 import ddingdong.ddingdongBE.domain.formapplication.repository.FormAnswerRepository;
 import ddingdong.ddingdongBE.domain.formapplication.repository.FormApplicationRepository;
 import ddingdong.ddingdongBE.domain.formapplication.repository.dto.DepartmentInfo;
@@ -91,6 +93,18 @@ public class FormStatisticServiceImpl implements FormStatisticService {
         List<FieldListInfo> fieldListInfos = formFieldRepository.findFieldWithAnswerCountByFormId(form.getId());
         List<FieldStatisticsListQuery> fieldStatisticsListQueries = toFieldListQueries(fieldListInfos);
         return new FieldStatisticsQuery(sections, fieldStatisticsListQueries);
+    }
+
+    @Override
+    public List<OptionStatisticQuery> createOptionStatistics(FormField formField) {
+        List<String> options = formField.getOptions();
+        int answerCount = formAnswerRepository.countByFormField(formField);
+        return options.stream().map(option -> {
+                    int count = parseToInt(formAnswerRepository.countAnswerByOption(option));
+                    int ratio = CalculationUtils.calculateRatio(count, answerCount);
+                    return new OptionStatisticQuery(option, count, ratio);
+                })
+                .toList();
     }
 
     private List<FieldStatisticsListQuery> toFieldListQueries(List<FieldListInfo> fieldListInfos) {

--- a/src/main/java/ddingdong/ddingdongBE/domain/form/service/dto/query/MultipleFieldStatisticsQuery.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/form/service/dto/query/MultipleFieldStatisticsQuery.java
@@ -1,0 +1,16 @@
+package ddingdong.ddingdongBE.domain.form.service.dto.query;
+
+import java.util.List;
+
+public record MultipleFieldStatisticsQuery(
+        String type,
+        List<OptionStatisticQuery> optionsQueries
+) {
+    public record OptionStatisticQuery(
+            String label,
+            int count,
+            int ratio
+    ) {
+
+    }
+}

--- a/src/main/java/ddingdong/ddingdongBE/domain/formapplication/repository/FormAnswerRepository.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/formapplication/repository/FormAnswerRepository.java
@@ -6,9 +6,18 @@ import ddingdong.ddingdongBE.domain.formapplication.entity.FormApplication;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
+import org.springframework.data.jpa.repository.Query;
 
 public interface FormAnswerRepository extends JpaRepository<FormAnswer, Long> {
 
     int countByFormField(FormField formField);
+
     List<FormAnswer> findAllByFormApplication(FormApplication formApplication);
+
+    @Query(value = """
+            SELECT COUNT(*)
+            FROM form_answer
+            WHERE value LIKE CONCAT('%"', :option, '"%')
+            """, nativeQuery = true)
+    Integer countAnswerByOption(String option);
 }

--- a/src/main/java/ddingdong/ddingdongBE/domain/formapplication/repository/FormAnswerRepository.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/formapplication/repository/FormAnswerRepository.java
@@ -7,6 +7,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface FormAnswerRepository extends JpaRepository<FormAnswer, Long> {
 
@@ -15,9 +16,9 @@ public interface FormAnswerRepository extends JpaRepository<FormAnswer, Long> {
     List<FormAnswer> findAllByFormApplication(FormApplication formApplication);
 
     @Query(value = """
-            SELECT COUNT(*)
-            FROM form_answer
-            WHERE value LIKE CONCAT('%"', :option, '"%')
+            SELECT fa.value
+            FROM form_answer fa
+            WHERE fa.field_id = :fieldId
             """, nativeQuery = true)
-    Integer countAnswerByOption(String option);
+    List<String> findAllValueByFormField(@Param("fieldId") Long fieldId);
 }

--- a/src/test/java/ddingdong/ddingdongBE/domain/formapplication/repository/FormAnswerRepositoryTest.java
+++ b/src/test/java/ddingdong/ddingdongBE/domain/formapplication/repository/FormAnswerRepositoryTest.java
@@ -1,0 +1,41 @@
+package ddingdong.ddingdongBE.domain.formapplication.repository;
+
+import ddingdong.ddingdongBE.common.support.DataJpaTestSupport;
+import ddingdong.ddingdongBE.domain.formapplication.entity.FormAnswer;
+import java.util.List;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+class FormAnswerRepositoryTest extends DataJpaTestSupport {
+
+    @Autowired
+    FormAnswerRepository formAnswerRepository;
+
+    @DisplayName("해당 option을 선택한 answer의 개수를 반환한다.")
+    @Test
+    void countAnswerByOption() {
+        // given
+        FormAnswer formAnswer = FormAnswer.builder()
+                .value(List.of("서버", "웹입니다."))
+                .build();
+        FormAnswer formAnswer2 = FormAnswer.builder()
+                .value(List.of("서버", "웹입니다."))
+                .build();
+        FormAnswer formAnswer3 = FormAnswer.builder()
+                .value(List.of("서버", "웹입니다."))
+                .build();
+        FormAnswer formAnswer4 = FormAnswer.builder()
+                .value(List.of("서버입니다.", "웹입니다."))
+                .build();
+        FormAnswer formAnswer5 = FormAnswer.builder()
+                .value(List.of("서버입니다.", "웹입니다."))
+                .build();
+        formAnswerRepository.saveAll(List.of(formAnswer, formAnswer2, formAnswer3, formAnswer4, formAnswer5));
+        // when
+        Integer count = formAnswerRepository.countAnswerByOption("서버");
+        // then
+        Assertions.assertThat(count).isEqualTo(3);
+    }
+}

--- a/src/test/java/ddingdong/ddingdongBE/domain/formapplication/repository/FormAnswerRepositoryTest.java
+++ b/src/test/java/ddingdong/ddingdongBE/domain/formapplication/repository/FormAnswerRepositoryTest.java
@@ -1,6 +1,9 @@
 package ddingdong.ddingdongBE.domain.formapplication.repository;
 
 import ddingdong.ddingdongBE.common.support.DataJpaTestSupport;
+import ddingdong.ddingdongBE.domain.form.entity.FieldType;
+import ddingdong.ddingdongBE.domain.form.entity.FormField;
+import ddingdong.ddingdongBE.domain.form.repository.FormFieldRepository;
 import ddingdong.ddingdongBE.domain.formapplication.entity.FormAnswer;
 import java.util.List;
 import org.assertj.core.api.Assertions;
@@ -12,30 +15,36 @@ class FormAnswerRepositoryTest extends DataJpaTestSupport {
 
     @Autowired
     FormAnswerRepository formAnswerRepository;
+    @Autowired
+    FormFieldRepository formFieldRepository;
 
-    @DisplayName("해당 option을 선택한 answer의 개수를 반환한다.")
+    @DisplayName("주어진 FormField와 연관된 FormAnswer의 value를 모두 반환한다.")
     @Test
-    void countAnswerByOption() {
+    void findAllValueByFormField() {
         // given
+        FormField formField = FormField.builder()
+                .question("질문입니다")
+                .required(true)
+                .fieldOrder(1)
+                .section("서버")
+                .options(List.of("지문1", "지문2"))
+                .fieldType(FieldType.CHECK_BOX)
+                .form(null)
+                .build();
+        FormField savedField = formFieldRepository.save(formField);
         FormAnswer formAnswer = FormAnswer.builder()
-                .value(List.of("서버", "웹입니다."))
+                .value(List.of("서버", "웹"))
+                .formField(savedField)
                 .build();
         FormAnswer formAnswer2 = FormAnswer.builder()
-                .value(List.of("서버", "웹입니다."))
+                .value(List.of("서버입니다", "웹입니다."))
+                .formField(savedField)
                 .build();
-        FormAnswer formAnswer3 = FormAnswer.builder()
-                .value(List.of("서버", "웹입니다."))
-                .build();
-        FormAnswer formAnswer4 = FormAnswer.builder()
-                .value(List.of("서버입니다.", "웹입니다."))
-                .build();
-        FormAnswer formAnswer5 = FormAnswer.builder()
-                .value(List.of("서버입니다.", "웹입니다."))
-                .build();
-        formAnswerRepository.saveAll(List.of(formAnswer, formAnswer2, formAnswer3, formAnswer4, formAnswer5));
+        formAnswerRepository.saveAll(List.of(formAnswer, formAnswer2));
         // when
-        Integer count = formAnswerRepository.countAnswerByOption("서버");
+        List<String> allValueByFormField = formAnswerRepository.findAllValueByFormField(savedField.getId());
         // then
-        Assertions.assertThat(count).isEqualTo(3);
+        Assertions.assertThat(allValueByFormField).hasSize(2);
+        Assertions.assertThat(allValueByFormField.get(0)).isEqualTo("[\"서버\",\"웹\"]");
     }
 }


### PR DESCRIPTION
## 🚀 작업 내용
- 지원 폼지 통계 객관식 상세조회 API 구현

## 🤔 고민했던 내용
- 쿼리 작성 부분에 LIKE 연산자를 활용했는데 풀 테이블 스캔을 하게되어 대규모 데이터일 경우 성능 측면에서 좋지 않다고 합니다.
해결 방법으로는 테이블을 따로 분리하여 조인하는 방법이 더 괜찮다고 하는데 어떻게 생각하시나요!?

-> 특수 문자를 사용하면 안된다는 이슈때문에, 쿼리 로직 수정하여 해당 Field와 연관된 Answer의 value값을 가져오고 같은 값을 가진 개수로 카운트 했습니다. 애플리케이션 레벨에서 진행했습니다

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **새로운 기능**
	- 폼의 여러 선택 필드에 대한 통계 정보를 제공하는 새 API 엔드포인트가 추가되었습니다.
	- 응답 결과에는 각 질문 유형 및 선택 옵션의 개수와 비율 정보가 포함되어, 보다 정밀한 통계 확인이 가능해졌습니다.
	- 여러 선택 필드의 통계를 생성하는 기능이 추가되었습니다.
	- 선택 필드가 다중 선택인지 확인하는 메서드가 추가되었습니다.
	- 특정 선택 옵션에 대한 응답 개수를 세는 기능이 추가되었습니다.
	- `FormAnswerRepository`에 선택 필드에 대한 값을 조회하는 메서드가 추가되었습니다.
- **테스트**
	- 선택 옵션 별 응답 개수를 검증하는 단위 테스트가 추가되어 기능의 신뢰성을 향상시켰습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->