### PR TITLE
[DDING-99] 동아리 폼지 통계 주관식 상세조회 API 구현

### DIFF
--- a/src/main/java/ddingdong/ddingdongBE/domain/form/api/CentralFormApi.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/form/api/CentralFormApi.java
@@ -7,6 +7,7 @@ import ddingdong.ddingdongBE.domain.form.controller.dto.response.FormListRespons
 import ddingdong.ddingdongBE.domain.form.controller.dto.response.FormResponse;
 import ddingdong.ddingdongBE.domain.form.controller.dto.response.FormStatisticsResponse;
 import ddingdong.ddingdongBE.domain.form.controller.dto.response.MultipleFieldStatisticsResponse;
+import ddingdong.ddingdongBE.domain.form.controller.dto.response.TextFieldStatisticsResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.ArraySchema;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -99,6 +100,14 @@ public interface CentralFormApi {
     @SecurityRequirement(name = "AccessToken")
     @GetMapping("/my/forms/statistics/multiple-choice")
     MultipleFieldStatisticsResponse getMultipleFieldStatistics(@RequestParam Long fieldId);
+
+    @Operation(summary = "동아리 폼지 통계 주관식 상세조회 API")
+    @ApiResponse(responseCode = "200", description = "동아리 폼지 통계 주관식 상세조회 성공",
+            content = @Content(schema = @Schema(implementation = TextFieldStatisticsResponse.class)))
+    @ResponseStatus(HttpStatus.OK)
+    @SecurityRequirement(name = "AccessToken")
+    @GetMapping("/my/forms/statistics/text")
+    TextFieldStatisticsResponse getTextFieldStatistics(@RequestParam Long fieldId);
 
     @Operation(summary = "동아리 최종 합격 지원자 동아리원 명단 등록API")
     @ApiResponse(responseCode = "201", description = "최종 합격 지원자 동아리원 명단 등록 성공")

--- a/src/main/java/ddingdong/ddingdongBE/domain/form/controller/CentralFormController.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/form/controller/CentralFormController.java
@@ -8,11 +8,13 @@ import ddingdong.ddingdongBE.domain.form.controller.dto.response.FormListRespons
 import ddingdong.ddingdongBE.domain.form.controller.dto.response.FormResponse;
 import ddingdong.ddingdongBE.domain.form.controller.dto.response.FormStatisticsResponse;
 import ddingdong.ddingdongBE.domain.form.controller.dto.response.MultipleFieldStatisticsResponse;
+import ddingdong.ddingdongBE.domain.form.controller.dto.response.TextFieldStatisticsResponse;
 import ddingdong.ddingdongBE.domain.form.service.FacadeCentralFormService;
 import ddingdong.ddingdongBE.domain.form.service.dto.query.FormListQuery;
 import ddingdong.ddingdongBE.domain.form.service.dto.query.FormQuery;
 import ddingdong.ddingdongBE.domain.form.service.dto.query.FormStatisticsQuery;
 import ddingdong.ddingdongBE.domain.form.service.dto.query.MultipleFieldStatisticsQuery;
+import ddingdong.ddingdongBE.domain.form.service.dto.query.TextFieldStatisticsQuery;
 import ddingdong.ddingdongBE.domain.user.entity.User;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -78,6 +80,12 @@ public class CentralFormController implements CentralFormApi {
     public MultipleFieldStatisticsResponse getMultipleFieldStatistics(Long fieldId) {
         MultipleFieldStatisticsQuery query = facadeCentralFormService.getMultipleFieldStatistics(fieldId);
         return MultipleFieldStatisticsResponse.from(query);
+    }
+
+    @Override
+    public TextFieldStatisticsResponse getTextFieldStatistics(Long fieldId) {
+        TextFieldStatisticsQuery query = facadeCentralFormService.getTextFieldStatistics(fieldId);
+        return TextFieldStatisticsResponse.from(query);
     }
 
     @Override

--- a/src/main/java/ddingdong/ddingdongBE/domain/form/controller/dto/response/TextFieldStatisticsResponse.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/form/controller/dto/response/TextFieldStatisticsResponse.java
@@ -2,16 +2,23 @@ package ddingdong.ddingdongBE.domain.form.controller.dto.response;
 
 import ddingdong.ddingdongBE.domain.form.service.dto.query.TextFieldStatisticsQuery;
 import ddingdong.ddingdongBE.domain.form.service.dto.query.TextFieldStatisticsQuery.TextStatisticsQuery;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Schema;
 import java.util.List;
 
 public record TextFieldStatisticsResponse(
+        @Schema(description = "질문 유형", example = "CHECK_BOX")
         String type,
+        @ArraySchema(schema = @Schema(implementation = TextStatisticsResponse.class))
         List<TextStatisticsResponse> answers
 ) {
 
     record TextStatisticsResponse(
+            @Schema(description = "지원자 id", example = "1")
             Long applicationId,
+            @Schema(description = "지원자 이름", example = "고선제")
             String name,
+            @Schema(description = "지원자 답변", example = "답변입니다")
             String answer
     ) {
         public static TextStatisticsResponse from(TextStatisticsQuery query) {

--- a/src/main/java/ddingdong/ddingdongBE/domain/form/controller/dto/response/TextFieldStatisticsResponse.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/form/controller/dto/response/TextFieldStatisticsResponse.java
@@ -1,0 +1,29 @@
+package ddingdong.ddingdongBE.domain.form.controller.dto.response;
+
+import ddingdong.ddingdongBE.domain.form.service.dto.query.TextFieldStatisticsQuery;
+import ddingdong.ddingdongBE.domain.form.service.dto.query.TextFieldStatisticsQuery.TextStatisticsQuery;
+import java.util.List;
+
+public record TextFieldStatisticsResponse(
+        String type,
+        List<TextStatisticsResponse> answers
+) {
+
+    record TextStatisticsResponse(
+            Long applicationId,
+            String name,
+            String answer
+    ) {
+        public static TextStatisticsResponse from(TextStatisticsQuery query) {
+            return new TextStatisticsResponse(query.applicationId(), query.name(), query.answer());
+        }
+
+    }
+
+    public static TextFieldStatisticsResponse from(TextFieldStatisticsQuery query) {
+        List<TextStatisticsResponse> answers = query.answers().stream()
+                .map(TextStatisticsResponse::from)
+                .toList();
+        return new TextFieldStatisticsResponse(query.type(), answers);
+    }
+}

--- a/src/main/java/ddingdong/ddingdongBE/domain/form/entity/FormField.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/form/entity/FormField.java
@@ -71,4 +71,9 @@ public class FormField extends BaseEntity {
   public boolean isMultipleChoice() {
     return this.fieldType == FieldType.CHECK_BOX || this.fieldType == FieldType.RADIO;
   }
+
+  public boolean isTextType() {
+    return this.fieldType == FieldType.TEXT || this.fieldType == FieldType.LONG_TEXT
+            || this.fieldType == FieldType.FILE;
+  }
 }

--- a/src/main/java/ddingdong/ddingdongBE/domain/form/service/FacadeCentralFormService.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/form/service/FacadeCentralFormService.java
@@ -6,6 +6,7 @@ import ddingdong.ddingdongBE.domain.form.service.dto.query.FormListQuery;
 import ddingdong.ddingdongBE.domain.form.service.dto.query.FormQuery;
 import ddingdong.ddingdongBE.domain.form.service.dto.query.FormStatisticsQuery;
 import ddingdong.ddingdongBE.domain.form.service.dto.query.MultipleFieldStatisticsQuery;
+import ddingdong.ddingdongBE.domain.form.service.dto.query.TextFieldStatisticsQuery;
 import ddingdong.ddingdongBE.domain.user.entity.User;
 import java.util.List;
 
@@ -26,4 +27,6 @@ public interface FacadeCentralFormService {
     MultipleFieldStatisticsQuery getMultipleFieldStatistics(Long fieldId);
 
     void registerApplicantAsMember(Long formId);
+
+    TextFieldStatisticsQuery getTextFieldStatistics(Long fieldId);
 }

--- a/src/main/java/ddingdong/ddingdongBE/domain/form/service/FacadeCentralFormServiceImpl.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/form/service/FacadeCentralFormServiceImpl.java
@@ -21,10 +21,12 @@ import ddingdong.ddingdongBE.domain.form.service.dto.query.FormStatisticsQuery;
 import ddingdong.ddingdongBE.domain.form.service.dto.query.FormStatisticsQuery.ApplicantStatisticQuery;
 import ddingdong.ddingdongBE.domain.form.service.dto.query.FormStatisticsQuery.DepartmentStatisticQuery;
 import ddingdong.ddingdongBE.domain.form.service.dto.query.FormStatisticsQuery.FieldStatisticsQuery;
-import ddingdong.ddingdongBE.domain.formapplication.entity.FormApplication;
-import ddingdong.ddingdongBE.domain.formapplication.service.FormApplicationService;
 import ddingdong.ddingdongBE.domain.form.service.dto.query.MultipleFieldStatisticsQuery;
 import ddingdong.ddingdongBE.domain.form.service.dto.query.MultipleFieldStatisticsQuery.OptionStatisticQuery;
+import ddingdong.ddingdongBE.domain.form.service.dto.query.TextFieldStatisticsQuery;
+import ddingdong.ddingdongBE.domain.form.service.dto.query.TextFieldStatisticsQuery.TextStatisticsQuery;
+import ddingdong.ddingdongBE.domain.formapplication.entity.FormApplication;
+import ddingdong.ddingdongBE.domain.formapplication.service.FormApplicationService;
 import ddingdong.ddingdongBE.domain.user.entity.User;
 import java.time.LocalDate;
 import java.util.List;
@@ -137,6 +139,17 @@ public class FacadeCentralFormServiceImpl implements FacadeCentralFormService {
                     .build();
             club.addClubMember(clubMember);
         });
+    }
+
+    @Override
+    public TextFieldStatisticsQuery getTextFieldStatistics(Long fieldId) {
+        FormField formField = formFieldService.getById(fieldId);
+        if (!formField.isTextType()) {
+            throw new InvalidFieldTypeException();
+        }
+        String type = formField.getFieldType().name();
+        List<TextStatisticsQuery> textStatisticsQueries = formStatisticService.createTextStatistics(formField);
+        return new TextFieldStatisticsQuery(type, textStatisticsQueries);
     }
 
     private FormListQuery buildFormListQuery(Form form) {

--- a/src/main/java/ddingdong/ddingdongBE/domain/form/service/FormStatisticService.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/form/service/FormStatisticService.java
@@ -7,6 +7,7 @@ import ddingdong.ddingdongBE.domain.form.service.dto.query.FormStatisticsQuery.A
 import ddingdong.ddingdongBE.domain.form.service.dto.query.FormStatisticsQuery.DepartmentStatisticQuery;
 import ddingdong.ddingdongBE.domain.form.service.dto.query.FormStatisticsQuery.FieldStatisticsQuery;
 import ddingdong.ddingdongBE.domain.form.service.dto.query.MultipleFieldStatisticsQuery.OptionStatisticQuery;
+import ddingdong.ddingdongBE.domain.form.service.dto.query.TextFieldStatisticsQuery.TextStatisticsQuery;
 import java.util.List;
 
 public interface FormStatisticService {
@@ -20,4 +21,6 @@ public interface FormStatisticService {
     FieldStatisticsQuery createFieldStatisticsByForm(Form form);
 
     List<OptionStatisticQuery> createOptionStatistics(FormField formField);
+
+    List<TextStatisticsQuery> createTextStatistics(FormField formField);
 }

--- a/src/main/java/ddingdong/ddingdongBE/domain/form/service/FormStatisticServiceImpl.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/form/service/FormStatisticServiceImpl.java
@@ -4,6 +4,9 @@ import ddingdong.ddingdongBE.common.converter.StringListConverter;
 import ddingdong.ddingdongBE.common.utils.CalculationUtils;
 import ddingdong.ddingdongBE.common.utils.TimeUtils;
 import ddingdong.ddingdongBE.domain.club.entity.Club;
+import ddingdong.ddingdongBE.domain.filemetadata.entity.FileMetaData;
+import ddingdong.ddingdongBE.domain.filemetadata.service.FileMetaDataService;
+import ddingdong.ddingdongBE.domain.form.entity.FieldType;
 import ddingdong.ddingdongBE.domain.form.entity.Form;
 import ddingdong.ddingdongBE.domain.form.entity.FormField;
 import ddingdong.ddingdongBE.domain.form.repository.FormFieldRepository;
@@ -19,6 +22,7 @@ import ddingdong.ddingdongBE.domain.formapplication.repository.FormApplicationRe
 import ddingdong.ddingdongBE.domain.formapplication.repository.dto.DepartmentInfo;
 import ddingdong.ddingdongBE.domain.formapplication.repository.dto.RecentFormInfo;
 import ddingdong.ddingdongBE.domain.formapplication.repository.dto.TextAnswerInfo;
+import ddingdong.ddingdongBE.file.service.S3FileService;
 import java.time.LocalDate;
 import java.util.List;
 import java.util.stream.IntStream;
@@ -38,6 +42,8 @@ public class FormStatisticServiceImpl implements FormStatisticService {
     private final FormFieldRepository formFieldRepository;
     private final FormAnswerRepository formAnswerRepository;
     private final StringListConverter stringListConverter;
+    private final S3FileService s3FileService;
+    private final FileMetaDataService fileMetaDataService;
 
     @Override
     public int getTotalApplicationCountByForm(Form form) {
@@ -121,16 +127,22 @@ public class FormStatisticServiceImpl implements FormStatisticService {
                 .map(textAnswerInfo -> {
                     Long id = textAnswerInfo.getId();
                     String name = textAnswerInfo.getName();
-                    String answer = getAnswer(textAnswerInfo.getValue());
+                    String answer = getAnswer(textAnswerInfo.getValue(), formField.getFieldType());
                     return new TextStatisticsQuery(id, name, answer);
                 })
                 .toList();
     }
 
-    private String getAnswer(String value) {
+    private String getAnswer(String value, FieldType fieldType) {
         List<String> answer = stringListConverter.convertToEntityAttribute(value);
         if(answer.isEmpty()) {
             return null;
+        }
+        if(fieldType == FieldType.FILE) {
+            String fileKey = answer.get(0);
+            String fileMetDataId = s3FileService.getUploadedFileUrl(fileKey).id();
+            FileMetaData fileMetaData = fileMetaDataService.getById(fileMetDataId);
+            return fileMetaData.getFileName();
         }
         return answer.get(0);
     }

--- a/src/main/java/ddingdong/ddingdongBE/domain/form/service/FormStatisticServiceImpl.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/form/service/FormStatisticServiceImpl.java
@@ -139,9 +139,8 @@ public class FormStatisticServiceImpl implements FormStatisticService {
             return null;
         }
         if(fieldType == FieldType.FILE) {
-            String fileKey = answer.get(0);
-            String fileMetDataId = s3FileService.getUploadedFileUrl(fileKey).id();
-            FileMetaData fileMetaData = fileMetaDataService.getById(fileMetDataId);
+            String fileId = answer.get(0);
+            FileMetaData fileMetaData = fileMetaDataService.getById(fileId);
             return fileMetaData.getFileName();
         }
         return answer.get(0);

--- a/src/main/java/ddingdong/ddingdongBE/domain/form/service/dto/query/TextFieldStatisticsQuery.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/form/service/dto/query/TextFieldStatisticsQuery.java
@@ -1,0 +1,16 @@
+package ddingdong.ddingdongBE.domain.form.service.dto.query;
+
+import java.util.List;
+
+public record TextFieldStatisticsQuery(
+        String type,
+        List<TextStatisticsQuery> answers
+) {
+
+    public record TextStatisticsQuery(
+            Long applicationId,
+            String name,
+            String answer
+    ) {
+    }
+}

--- a/src/main/java/ddingdong/ddingdongBE/domain/formapplication/repository/FormAnswerRepository.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/formapplication/repository/FormAnswerRepository.java
@@ -3,6 +3,7 @@ package ddingdong.ddingdongBE.domain.formapplication.repository;
 import ddingdong.ddingdongBE.domain.form.entity.FormField;
 import ddingdong.ddingdongBE.domain.formapplication.entity.FormAnswer;
 import ddingdong.ddingdongBE.domain.formapplication.entity.FormApplication;
+import ddingdong.ddingdongBE.domain.formapplication.repository.dto.TextAnswerInfo;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
@@ -20,5 +21,18 @@ public interface FormAnswerRepository extends JpaRepository<FormAnswer, Long> {
             FROM form_answer fa
             WHERE fa.field_id = :fieldId
             """, nativeQuery = true)
-    List<String> findAllValueByFormField(@Param("fieldId") Long fieldId);
+    List<String> findAllValueByFormFieldId(@Param("fieldId") Long fieldId);
+
+    @Query(value = """
+            SELECT fap.id as id, fap.name as name, field_answer.value as value
+            FROM (
+                SELECT *
+                FROM form_answer fa
+                WHERE fa.field_id = :fieldId
+                ) field_answer
+            JOIN form_application fap
+            ON fap.id = field_answer.application_id
+            ORDER BY fap.id
+            """, nativeQuery = true)
+    List<TextAnswerInfo> getTextAnswerInfosByFormFieldId(Long fieldId);
 }

--- a/src/main/java/ddingdong/ddingdongBE/domain/formapplication/repository/dto/TextAnswerInfo.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/formapplication/repository/dto/TextAnswerInfo.java
@@ -1,0 +1,8 @@
+package ddingdong.ddingdongBE.domain.formapplication.repository.dto;
+
+public interface TextAnswerInfo {
+
+    Long getId();
+    String getName();
+    String getValue();
+}

--- a/src/test/java/ddingdong/ddingdongBE/domain/formapplication/repository/FormAnswerRepositoryTest.java
+++ b/src/test/java/ddingdong/ddingdongBE/domain/formapplication/repository/FormAnswerRepositoryTest.java
@@ -20,7 +20,7 @@ class FormAnswerRepositoryTest extends DataJpaTestSupport {
 
     @DisplayName("주어진 FormField와 연관된 FormAnswer의 value를 모두 반환한다.")
     @Test
-    void findAllValueByFormField() {
+    void findAllValueByFormFieldId() {
         // given
         FormField formField = FormField.builder()
                 .question("질문입니다")
@@ -42,7 +42,7 @@ class FormAnswerRepositoryTest extends DataJpaTestSupport {
                 .build();
         formAnswerRepository.saveAll(List.of(formAnswer, formAnswer2));
         // when
-        List<String> allValueByFormField = formAnswerRepository.findAllValueByFormField(savedField.getId());
+        List<String> allValueByFormField = formAnswerRepository.findAllValueByFormFieldId(savedField.getId());
         // then
         Assertions.assertThat(allValueByFormField).hasSize(2);
         Assertions.assertThat(allValueByFormField.get(0)).isEqualTo("[\"서버\",\"웹\"]");


### PR DESCRIPTION
## 🚀 작업 내용
- 동아리 폼지 통계 주관식 상세조회 API 구현했습니다.

## 🤔 고민했던 내용
현재 지원하기 API에서 파일을 저장할 때, FormAnswer 엔터티의 value값에 어떤 값을 저장할 지 정해지지 않아, 제외하고 구현했습니다.


## 💬 리뷰 중점사항
query및 statisticService중점으로 봐주시면 감사하겠습니다

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - 폼에 입력된 텍스트 필드에 대한 통계 데이터를 조회할 수 있는 새로운 API 엔드포인트가 추가되었습니다.
  - 클럽 폼의 주관식 질문에 대해 상세한 텍스트 응답 정보(응용 ID, 이름, 답변 등)를 포함한 통계 결과를 제공합니다.
  - 텍스트 타입 필드를 자동으로 감지하여 적절한 통계 처리가 이뤄지도록 개선하였습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->