### PR TITLE
[DDING-113] 지원자 수 조회 API 구현

### DIFF
--- a/src/main/java/ddingdong/ddingdongBE/domain/formapplication/api/UserFormApplicationApi.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/formapplication/api/UserFormApplicationApi.java
@@ -1,11 +1,16 @@
 package ddingdong.ddingdongBE.domain.formapplication.api;
 
+import ddingdong.ddingdongBE.auth.PrincipalDetails;
 import ddingdong.ddingdongBE.domain.formapplication.controller.dto.request.CreateFormApplicationRequest;
+import ddingdong.ddingdongBE.domain.formapplication.controller.dto.response.FormApplicationCountResponse;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import org.springframework.http.HttpStatus;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 @Tag(name = "Form - User", description = "User Form API")
@@ -19,6 +24,16 @@ public interface UserFormApplicationApi {
     void createFormApplication(
             @PathVariable Long formId,
             @Valid @RequestBody CreateFormApplicationRequest request
+    );
+
+    @Operation(summary = "지원자 수 조회 API")
+    @ApiResponse(responseCode = "200", description = "지원자 수 조회 성공",
+            content = @Content(schema = @Schema(implementation = FormApplicationCountResponse.class)))
+    @ResponseStatus(HttpStatus.OK)
+    @GetMapping("/forms/{formId}/applications")
+    FormApplicationCountResponse getNumberOfFormApplication(
+            @PathVariable("formId") Long formId,
+            @AuthenticationPrincipal PrincipalDetails principalDetails
     );
 
 }

--- a/src/main/java/ddingdong/ddingdongBE/domain/formapplication/api/UserFormApplicationApi.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/formapplication/api/UserFormApplicationApi.java
@@ -30,7 +30,7 @@ public interface UserFormApplicationApi {
     @ApiResponse(responseCode = "200", description = "지원자 수 조회 성공",
             content = @Content(schema = @Schema(implementation = FormApplicationCountResponse.class)))
     @ResponseStatus(HttpStatus.OK)
-    @GetMapping("/forms/{formId}/applications")
+    @GetMapping("/forms/{formId}/applications/count")
     FormApplicationCountResponse getNumberOfFormApplication(
             @PathVariable("formId") Long formId,
             @AuthenticationPrincipal PrincipalDetails principalDetails

--- a/src/main/java/ddingdong/ddingdongBE/domain/formapplication/controller/UserFormApplicationController.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/formapplication/controller/UserFormApplicationController.java
@@ -1,8 +1,11 @@
 package ddingdong.ddingdongBE.domain.formapplication.controller;
 
+import ddingdong.ddingdongBE.auth.PrincipalDetails;
 import ddingdong.ddingdongBE.domain.formapplication.api.UserFormApplicationApi;
 import ddingdong.ddingdongBE.domain.formapplication.controller.dto.request.CreateFormApplicationRequest;
+import ddingdong.ddingdongBE.domain.formapplication.controller.dto.response.FormApplicationCountResponse;
 import ddingdong.ddingdongBE.domain.formapplication.service.FacadeUserFormApplicationService;
+import ddingdong.ddingdongBE.domain.formapplication.service.dto.query.FormApplicationCountQuery;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -17,5 +20,12 @@ public class UserFormApplicationController implements UserFormApplicationApi {
             CreateFormApplicationRequest createFormApplicationRequest) {
         facadeUserFormApplicationService.createFormApplication(
                 createFormApplicationRequest.toCommand(formId));
+    }
+
+    @Override
+    public FormApplicationCountResponse getNumberOfFormApplication(Long formId,
+            PrincipalDetails principalDetails) {
+        FormApplicationCountQuery query = facadeUserFormApplicationService.getFormApplicationCount(formId);
+        return FormApplicationCountResponse.from(query);
     }
 }

--- a/src/main/java/ddingdong/ddingdongBE/domain/formapplication/controller/dto/response/FormApplicationCountResponse.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/formapplication/controller/dto/response/FormApplicationCountResponse.java
@@ -1,0 +1,16 @@
+package ddingdong.ddingdongBE.domain.formapplication.controller.dto.response;
+
+import ddingdong.ddingdongBE.domain.formapplication.service.dto.query.FormApplicationCountQuery;
+import lombok.Builder;
+
+@Builder
+public record FormApplicationCountResponse(
+        int formApplicationCount
+) {
+
+    public static FormApplicationCountResponse from(FormApplicationCountQuery query) {
+        return FormApplicationCountResponse.builder()
+                .formApplicationCount(query.formApplicationCount())
+                .build();
+    }
+}

--- a/src/main/java/ddingdong/ddingdongBE/domain/formapplication/service/FacadeUserFormApplicationService.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/formapplication/service/FacadeUserFormApplicationService.java
@@ -1,9 +1,11 @@
 package ddingdong.ddingdongBE.domain.formapplication.service;
 
 import ddingdong.ddingdongBE.domain.formapplication.service.dto.command.CreateFormApplicationCommand;
+import ddingdong.ddingdongBE.domain.formapplication.service.dto.query.FormApplicationCountQuery;
 
 public interface FacadeUserFormApplicationService {
 
     void createFormApplication(CreateFormApplicationCommand createFormApplicationCommand);
 
+    FormApplicationCountQuery getFormApplicationCount(Long formId);
 }

--- a/src/main/java/ddingdong/ddingdongBE/domain/formapplication/service/FacadeUserFormApplicationServiceImpl.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/formapplication/service/FacadeUserFormApplicationServiceImpl.java
@@ -45,7 +45,7 @@ public class FacadeUserFormApplicationServiceImpl implements FacadeUserFormAppli
     @Override
     public FormApplicationCountQuery getFormApplicationCount(Long formId) {
         Form form = formService.getById(formId);
-        return FormApplicationCountQuery.of(formStatisticService.getTotalApplicationCountByForm(form));
+        return FormApplicationCountQuery.from(formStatisticService.getTotalApplicationCountByForm(form));
     }
 
     private void updateFileMetaDataStatusToCoupled(List<FormAnswer> formAnswers, Form form) {

--- a/src/main/java/ddingdong/ddingdongBE/domain/formapplication/service/FacadeUserFormApplicationServiceImpl.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/formapplication/service/FacadeUserFormApplicationServiceImpl.java
@@ -6,10 +6,12 @@ import ddingdong.ddingdongBE.domain.filemetadata.service.FileMetaDataService;
 import ddingdong.ddingdongBE.domain.form.entity.Form;
 import ddingdong.ddingdongBE.domain.form.service.FormFieldService;
 import ddingdong.ddingdongBE.domain.form.service.FormService;
+import ddingdong.ddingdongBE.domain.form.service.FormStatisticService;
 import ddingdong.ddingdongBE.domain.formapplication.entity.FormAnswer;
 import ddingdong.ddingdongBE.domain.formapplication.entity.FormApplication;
 import ddingdong.ddingdongBE.domain.formapplication.service.dto.command.CreateFormApplicationCommand;
 import ddingdong.ddingdongBE.domain.formapplication.service.dto.command.CreateFormApplicationCommand.CreateFormAnswerCommand;
+import ddingdong.ddingdongBE.domain.formapplication.service.dto.query.FormApplicationCountQuery;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -25,6 +27,7 @@ public class FacadeUserFormApplicationServiceImpl implements FacadeUserFormAppli
     private final FormService formService;
     private final FormFieldService formFieldService;
     private final FileMetaDataService fileMetaDataService;
+    private final FormStatisticService formStatisticService;
 
     @Transactional
     @Override
@@ -37,6 +40,12 @@ public class FacadeUserFormApplicationServiceImpl implements FacadeUserFormAppli
                 createFormApplicationCommand.formAnswerCommands());
         updateFileMetaDataStatusToCoupled(formAnswers, form);
         formAnswerService.createAll(formAnswers);
+    }
+
+    @Override
+    public FormApplicationCountQuery getFormApplicationCount(Long formId) {
+        Form form = formService.getById(formId);
+        return FormApplicationCountQuery.of(formStatisticService.getTotalApplicationCountByForm(form));
     }
 
     private void updateFileMetaDataStatusToCoupled(List<FormAnswer> formAnswers, Form form) {

--- a/src/main/java/ddingdong/ddingdongBE/domain/formapplication/service/dto/query/FormApplicationCountQuery.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/formapplication/service/dto/query/FormApplicationCountQuery.java
@@ -1,0 +1,14 @@
+package ddingdong.ddingdongBE.domain.formapplication.service.dto.query;
+
+import lombok.Builder;
+
+@Builder
+public record FormApplicationCountQuery(
+        int formApplicationCount
+) {
+    public static FormApplicationCountQuery of(int formApplicationCount) {
+        return FormApplicationCountQuery.builder()
+                .formApplicationCount(formApplicationCount)
+                .build();
+    }
+}

--- a/src/main/java/ddingdong/ddingdongBE/domain/formapplication/service/dto/query/FormApplicationCountQuery.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/formapplication/service/dto/query/FormApplicationCountQuery.java
@@ -6,7 +6,7 @@ import lombok.Builder;
 public record FormApplicationCountQuery(
         int formApplicationCount
 ) {
-    public static FormApplicationCountQuery of(int formApplicationCount) {
+    public static FormApplicationCountQuery from(int formApplicationCount) {
         return FormApplicationCountQuery.builder()
                 .formApplicationCount(formApplicationCount)
                 .build();


### PR DESCRIPTION
## 🚀 작업 내용

지원자 수 조회 API 구현하였습니다.

## 🤔 고민했던 내용


## 💬 리뷰 중점사항

FormStatisticService의 getTotalApplicationCountByForm() 메서드 사용하였습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
	- 특정 양식에 대한 응모 건수를 조회할 수 있는 기능이 추가되었습니다.
	- 사용자 인증 정보를 활용하여 요청 시 최신 통계 데이터를 정확하게 제공하며, 응모 현황을 손쉽게 확인할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->