### PR TITLE
[DDING-114] 폼지 진행상태 응답 상태 수정

### DIFF
--- a/src/main/java/ddingdong/ddingdongBE/common/utils/TimeUtils.java
+++ b/src/main/java/ddingdong/ddingdongBE/common/utils/TimeUtils.java
@@ -28,13 +28,6 @@ public class TimeUtils {
         return parseToLocalDateTime(dateString);
     }
 
-    public static boolean isDateInRange(LocalDate nowDate, LocalDate startDate, LocalDate endDate) {
-        if (nowDate == null || startDate == null || endDate == null) {
-            return false;
-        }
-        return !nowDate.isBefore(startDate) && !nowDate.isAfter(endDate);
-    }
-
     public static String getYearAndMonth(LocalDate date) {
         return date.getYear() + "-" + date.getMonthValue();
     }

--- a/src/main/java/ddingdong/ddingdongBE/domain/form/controller/dto/response/FormListResponse.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/form/controller/dto/response/FormListResponse.java
@@ -15,8 +15,8 @@ public record FormListResponse(
         LocalDate startDate,
         @Schema(description = "지원 폼지 종료일", example = "2001-01-02")
         LocalDate endDate,
-        @Schema(description = "활성화 여부", example = "true")
-        boolean isActive
+        @Schema(description = "폼 현재 진행상태", example = "진행 중")
+        String formStatus
 ) {
 
     public static FormListResponse from(FormListQuery query) {
@@ -25,7 +25,7 @@ public record FormListResponse(
                 .title(query.title())
                 .startDate(query.startDate())
                 .endDate(query.endDate())
-                .isActive(query.isActive())
+                .formStatus(query.formStatus())
                 .build();
     }
 }

--- a/src/main/java/ddingdong/ddingdongBE/domain/form/entity/FormStatus.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/form/entity/FormStatus.java
@@ -1,0 +1,28 @@
+package ddingdong.ddingdongBE.domain.form.entity;
+
+import java.time.LocalDate;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Getter
+public enum FormStatus {
+    UPCOMING("진행 전"),
+    ONGOING("진행 중"),
+    CLOSED("마감");
+
+    private final String description;
+
+
+    public static FormStatus getDescription(LocalDate now, LocalDate startDate, LocalDate endDate) {
+        if (now.isBefore(startDate)) {
+            return FormStatus.UPCOMING;
+        }
+
+        if (!now.isAfter(endDate)) {
+            return FormStatus.ONGOING;
+        }
+
+        return FormStatus.CLOSED;
+    }
+}

--- a/src/main/java/ddingdong/ddingdongBE/domain/form/service/FacadeCentralFormServiceImpl.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/form/service/FacadeCentralFormServiceImpl.java
@@ -5,7 +5,6 @@ import static ddingdong.ddingdongBE.domain.club.entity.Position.MEMBER;
 import ddingdong.ddingdongBE.common.exception.AuthenticationException.NonHaveAuthority;
 import ddingdong.ddingdongBE.common.exception.InvalidatedMappingException.InvalidFieldTypeException;
 import ddingdong.ddingdongBE.common.exception.InvalidatedMappingException.InvalidFormPeriodException;
-import ddingdong.ddingdongBE.common.utils.TimeUtils;
 import ddingdong.ddingdongBE.domain.club.entity.Club;
 import ddingdong.ddingdongBE.domain.club.service.ClubService;
 import ddingdong.ddingdongBE.domain.clubmember.entity.ClubMember;
@@ -13,6 +12,7 @@ import ddingdong.ddingdongBE.domain.filemetadata.entity.DomainType;
 import ddingdong.ddingdongBE.domain.filemetadata.service.FileMetaDataService;
 import ddingdong.ddingdongBE.domain.form.entity.Form;
 import ddingdong.ddingdongBE.domain.form.entity.FormField;
+import ddingdong.ddingdongBE.domain.form.entity.FormStatus;
 import ddingdong.ddingdongBE.domain.form.service.dto.command.CreateFormCommand;
 import ddingdong.ddingdongBE.domain.form.service.dto.command.CreateFormCommand.CreateFormFieldCommand;
 import ddingdong.ddingdongBE.domain.form.service.dto.command.UpdateFormCommand;
@@ -95,7 +95,9 @@ public class FacadeCentralFormServiceImpl implements FacadeCentralFormService {
     public List<FormListQuery> getAllMyForm(User user) {
         Club club = clubService.getByUserId(user.getId());
         List<Form> forms = formService.getAllByClub(club);
-        return forms.stream().map(this::buildFormListQuery).toList();
+        return forms.stream()
+                .map(this::buildFormListQuery)
+                .toList();
     }
 
     @Override
@@ -160,9 +162,9 @@ public class FacadeCentralFormServiceImpl implements FacadeCentralFormService {
     }
 
     private FormListQuery buildFormListQuery(Form form) {
-        boolean isActive = TimeUtils.isDateInRange(LocalDate.now(), form.getStartDate(),
+        FormStatus formStatus = FormStatus.getDescription(LocalDate.now(), form.getStartDate(),
                 form.getEndDate());
-        return FormListQuery.from(form, isActive);
+        return FormListQuery.from(form, formStatus);
     }
 
     private void validateEqualsClub(Club club, Form form) {

--- a/src/main/java/ddingdong/ddingdongBE/domain/form/service/dto/query/FormListQuery.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/form/service/dto/query/FormListQuery.java
@@ -1,6 +1,7 @@
 package ddingdong.ddingdongBE.domain.form.service.dto.query;
 
 import ddingdong.ddingdongBE.domain.form.entity.Form;
+import ddingdong.ddingdongBE.domain.form.entity.FormStatus;
 import java.time.LocalDate;
 import lombok.Builder;
 
@@ -10,16 +11,16 @@ public record FormListQuery(
     String title,
     LocalDate startDate,
     LocalDate endDate,
-    boolean isActive
+    String formStatus
 ) {
 
-  public static FormListQuery from(Form form, boolean isActive) {
+  public static FormListQuery from(Form form, FormStatus formStatus) {
     return FormListQuery.builder()
         .formId(form.getId())
         .title(form.getTitle())
         .startDate(form.getStartDate())
         .endDate(form.getEndDate())
-        .isActive(isActive)
+        .formStatus(formStatus.getDescription())
         .build();
   }
 

--- a/src/main/java/ddingdong/ddingdongBE/domain/formapplication/controller/dto/response/MyAllFormApplicationsResponse.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/formapplication/controller/dto/response/MyAllFormApplicationsResponse.java
@@ -20,12 +20,13 @@ public record MyAllFormApplicationsResponse(
         LocalDate endDate,
         @Schema(description = "면접 여부", example = "true")
         boolean hasInterview,
+        @Schema(description = "폼 현재 진행상태", example = "진행 중")
+        String formStatus,
         @ArraySchema(schema = @Schema(name = "지원자 전체 조회 페이지", implementation = MyAllFormApplicationsResponse.MyFormApplicationListResponse.class))
         List<MyFormApplicationListResponse> formApplications
 ) {
 
-    public static MyAllFormApplicationsResponse from(
-            MyAllFormApplicationsQuery myAllFormApplicationsQuery) {
+    public static MyAllFormApplicationsResponse from(MyAllFormApplicationsQuery myAllFormApplicationsQuery) {
         List<MyFormApplicationListResponse> formApplications = myAllFormApplicationsQuery.formApplicationListQueries()
                 .stream()
                 .map(MyFormApplicationListResponse::from)
@@ -35,6 +36,7 @@ public record MyAllFormApplicationsResponse(
                 .startDate(myAllFormApplicationsQuery.startDate())
                 .endDate(myAllFormApplicationsQuery.endDate())
                 .hasInterview(myAllFormApplicationsQuery.hasInterview())
+                .formStatus(myAllFormApplicationsQuery.formStatus())
                 .formApplications(formApplications)
                 .build();
     }

--- a/src/main/java/ddingdong/ddingdongBE/domain/formapplication/service/FacadeCentralFormApplicationServiceImpl.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/formapplication/service/FacadeCentralFormApplicationServiceImpl.java
@@ -3,6 +3,7 @@ package ddingdong.ddingdongBE.domain.formapplication.service;
 import ddingdong.ddingdongBE.domain.filemetadata.entity.FileMetaData;
 import ddingdong.ddingdongBE.domain.filemetadata.service.FileMetaDataService;
 import ddingdong.ddingdongBE.domain.form.entity.Form;
+import ddingdong.ddingdongBE.domain.form.entity.FormStatus;
 import ddingdong.ddingdongBE.domain.form.service.FormService;
 import ddingdong.ddingdongBE.domain.formapplication.entity.FormAnswer;
 import ddingdong.ddingdongBE.domain.formapplication.entity.FormApplication;
@@ -13,6 +14,7 @@ import ddingdong.ddingdongBE.domain.formapplication.service.dto.query.MyAllFormA
 import ddingdong.ddingdongBE.domain.formapplication.service.dto.query.FormApplicationQuery.FormFieldAnswerListQuery;
 import ddingdong.ddingdongBE.domain.user.entity.User;
 import ddingdong.ddingdongBE.file.service.S3FileService;
+import java.time.LocalDate;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -34,14 +36,15 @@ public class FacadeCentralFormApplicationServiceImpl implements
     public MyAllFormApplicationsQuery getAllFormApplication(Long formId, User user) {
         Form form = formService.getById(formId);
         List<FormApplication> formApplications = formApplicationService.getAllByForm(form);
+        FormStatus formStatus = FormStatus.getDescription(LocalDate.now(), form.getStartDate(), form.getEndDate());
         if (formApplications == null) {
-            return MyAllFormApplicationsQuery.createEmpty(form);
+            return MyAllFormApplicationsQuery.createEmpty(form, formStatus.getDescription());
         }
         List<FormApplicationListQuery> formApplicationListQueries = formApplications.stream()
                 .map(FormApplicationListQuery::of)
                 .toList();
 
-        return MyAllFormApplicationsQuery.of(form, formApplicationListQueries);
+        return MyAllFormApplicationsQuery.of(form, formApplicationListQueries, formStatus.getDescription());
     }
 
     @Override

--- a/src/main/java/ddingdong/ddingdongBE/domain/formapplication/service/dto/query/MyAllFormApplicationsQuery.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/formapplication/service/dto/query/MyAllFormApplicationsQuery.java
@@ -14,26 +14,29 @@ public record MyAllFormApplicationsQuery(
         LocalDate startDate,
         LocalDate endDate,
         boolean hasInterview,
+        String formStatus,
         List<FormApplicationListQuery> formApplicationListQueries
 ) {
 
     public static MyAllFormApplicationsQuery of(Form form,
-            List<FormApplicationListQuery> formApplicationListQueries) {
+            List<FormApplicationListQuery> formApplicationListQueries, String formStatus) {
         return new MyAllFormApplicationsQuery(
                 form.getTitle(),
                 form.getStartDate(),
                 form.getEndDate(),
                 form.isHasInterview(),
+                formStatus,
                 formApplicationListQueries
         );
     }
 
-    public static MyAllFormApplicationsQuery createEmpty(Form form) {
+    public static MyAllFormApplicationsQuery createEmpty(Form form, String formStatus) {
         return new MyAllFormApplicationsQuery(
                 form.getTitle(), // title
                 form.getStartDate(), // startDate
                 form.getEndDate(), // endDate
                 form.isHasInterview(), // hasInterview
+                formStatus,
                 Collections.emptyList() // formApplicationListQueries
         );
     }

--- a/src/test/java/ddingdong/ddingdongBE/domain/form/entity/FormStatusTest.java
+++ b/src/test/java/ddingdong/ddingdongBE/domain/form/entity/FormStatusTest.java
@@ -1,13 +1,14 @@
-package ddingdong.ddingdongBE.common.utils;
+package ddingdong.ddingdongBE.domain.form.entity;
 
 import java.time.LocalDate;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
-class TimeUtilsTest {
+class FormStatusTest {
 
-    @DisplayName("현재 날짜가 기간 내 포함된다면 true를 반환한다.")
+
+    @DisplayName("현재 날짜가 기간 내 포함된다면 알맞는 FormStatus를 반환한다.")
     @Test
     void isDateInRange() {
         // given
@@ -15,8 +16,8 @@ class TimeUtilsTest {
         LocalDate startDate = now.minusDays(1);
         LocalDate endDate = now.plusDays(1);
         // when
-        boolean isActive = TimeUtils.isDateInRange(now, startDate, endDate);
+        FormStatus formStatus = FormStatus.getDescription(now, startDate, endDate);
         // then
-        Assertions.assertThat(isActive).isTrue();
+        Assertions.assertThat(formStatus).isEqualTo(FormStatus.ONGOING);
     }
 }


### PR DESCRIPTION
## 🚀 작업 내용
현재 isActive(true, false)로 응답되었던 폼지 상태를
FormStatus를 생성하여 진행 전, 진행 중, 마감 세가지 상태로 변경한 뒤 응답하였습니다.

## 🤔 고민했던 내용


## 💬 리뷰 중점사항


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**  
  - 이제 폼의 진행 상태가 단순 활성/비활성 플래그 대신 “예정”, “진행 중”, “종료” 등 구체적인 상태 설명으로 제공됩니다.

- **Refactor**  
  - 폼 관련 데이터 구조와 처리 로직이 업데이트되어, 상태 정보가 보다 명확하고 일관되게 전달됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->