### PR TITLE
[DDING-000] 폼지 수정내 기간 검증로직 오류 수정

### DIFF
--- a/src/main/java/ddingdong/ddingdongBE/domain/form/entity/Form.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/form/entity/Form.java
@@ -75,4 +75,8 @@ public class Form extends BaseEntity {
         this.sections = updateForm.getSections();
         this.hasInterview = updateForm.isHasInterview();
     }
+
+    public boolean isEqualsById(Long formId) {
+        return this.id.equals(formId);
+    }
 }


### PR DESCRIPTION
## 🚀 작업 내용
- 이전 폼지 수정시 기존 폼지와 중복되는 날짜는 수정하지 못하게 검증하는 로직 구현
- 위 로직에서 자기 자신을 포함하여 검증하는 오류가 발생하여 자기자신을 제외시키도록 수정

## 🤔 고민했던 내용


## 💬 리뷰 중점사항


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
  - 폼 고유 식별 기능이 추가되어, 사용자가 폼의 일관성을 보다 쉽게 확인할 수 있습니다.
- **리팩터링**
  - 폼 업데이트 시 중복 날짜 검증 로직이 개선되어, 현재 폼은 검증 과정에서 올바르게 제외되도록 조정되었습니다.
  - 업데이트 관련 내부 처리 프로세스가 단순화되어, 전체 폼 관리의 안정성이 향상되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->