### PR TITLE
[DDING-000] 파일 폼지 응답 presignedUrl 발급 API 구현

### DIFF
--- a/src/main/java/ddingdong/ddingdongBE/file/api/S3FileAPi.java
+++ b/src/main/java/ddingdong/ddingdongBE/file/api/S3FileAPi.java
@@ -56,6 +56,39 @@ public interface S3FileAPi {
     @SecurityRequirement(name = "AccessToken")
     @GetMapping("/upload-url")
     UploadUrlResponse getPreSignedUrl(@AuthenticationPrincipal PrincipalDetails principalDetails,
-                                      @RequestParam("fileName") String fileName);
+                                                     @RequestParam("fileName") String fileName);
+
+    @Operation(summary = "폼 응답 - AWS S3 presignedUrl 발급 API")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "폼 응답 presignedUrl 발급 성공"),
+            @ApiResponse(responseCode = "400",
+                    description = "AWS 오류(서버 오류)",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            schema = @Schema(implementation = ErrorResponse.class),
+                            examples = {
+                                    @ExampleObject(name = "AWS 서비스 오류(서버 오류)",
+                                            value = """
+                                                    {
+                                                      "status": 500,
+                                                      "message": "AWS 서비스 오류로 인해 Presigned URL 생성에 실패했습니다.",
+                                                      "timestamp": "2024-08-22T00:08:46.990585"
+                                                    }
+                                                    """
+                                    ),
+                                    @ExampleObject(name = "AWS 클라이언트 오류(서버 오류)",
+                                            value = """
+                                                    {
+                                                      "status": 500,
+                                                      "message": "AWS 클라이언트 오류로 인해 Presigned URL 생성에 실패했습니다.",
+                                                      "timestamp": "2024-08-22T00:08:46.990585"
+                                                    }
+                                                    """
+                                    )
+                            })
+            )
+    })
+    @ResponseStatus(HttpStatus.OK)
+    @GetMapping("/upload-url/form-application")
+    UploadUrlResponse getFormApplicationPreSignedUrl(@RequestParam("fileName") String fileName);
 
 }

--- a/src/main/java/ddingdong/ddingdongBE/file/controller/S3FileController.java
+++ b/src/main/java/ddingdong/ddingdongBE/file/controller/S3FileController.java
@@ -31,4 +31,15 @@ public class S3FileController implements S3FileAPi {
         URL presingedUrl = s3FileService.getPresignedUrl(query.generatePresignedUrlRequest());
         return UploadUrlResponse.of(query, presingedUrl);
     }
+
+    @Override
+    public UploadUrlResponse getFormApplicationPreSignedUrl(String fileName) {
+        LocalDateTime now = LocalDateTime.now();
+        String decodedFileName = URLDecoder.decode(fileName, StandardCharsets.UTF_8);
+        GeneratePreSignedUrlRequestQuery query =
+                s3FileService.generatePresignedUrlRequest(
+                        new GeneratePreSignedUrlRequestCommand(now, 9999L, decodedFileName));
+        URL presingedUrl = s3FileService.getPresignedUrl(query.generatePresignedUrlRequest());
+        return UploadUrlResponse.of(query, presingedUrl);
+    }
 }


### PR DESCRIPTION
## 🚀 작업 내용
- 파일 타입 폼지 응답을 위한 presignedUrl 발급 API 구현

## 🤔 고민했던 내용
- s3 path를 위한 userId가 포함되지 않기 때문에 우선 임시로 9999를 사용했습니다.
## 💬 리뷰 중점사항

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
  - 파일 업로드를 위한 프리사인 URL 생성에 폼 애플리케이션 전용 옵션이 추가되었습니다. 새로운 API 엔드포인트를 통해 별도의 요청으로 프리사인 URL을 제공하며, 기존 방식은 그대로 유지되면서 내부 파라미터 포맷이 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->