### PR TITLE
[DDING-000] 폼지 조회 및 섹션 조회 응답 dto에 응답 기간 필드 추가

### DIFF
--- a/src/main/java/ddingdong/ddingdongBE/domain/form/controller/dto/response/FormSectionResponse.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/form/controller/dto/response/FormSectionResponse.java
@@ -2,6 +2,7 @@ package ddingdong.ddingdongBE.domain.form.controller.dto.response;
 
 import ddingdong.ddingdongBE.domain.form.service.dto.query.FormSectionQuery;
 import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.LocalDate;
 import java.util.List;
 import lombok.Builder;
 
@@ -11,6 +12,10 @@ public record FormSectionResponse(
         String title,
         @Schema(description = "폼지 설명", example = "폼지 설명입니다")
         String description,
+        @Schema(description = "폼지 시작일", example = "2001-01-01")
+        LocalDate startDate,
+        @Schema(description = "폼지 종료일", example = "2001-01-02")
+        LocalDate endDate,
         @Schema(description = "섹션 리스트", example = "[서버, 웹]")
         List<String> sections
 ) {
@@ -19,6 +24,8 @@ public record FormSectionResponse(
         return FormSectionResponse.builder()
                 .title(formSectionQuery.title())
                 .description(formSectionQuery.description())
+                .startDate(formSectionQuery.startDate())
+                .endDate(formSectionQuery.endDate())
                 .sections(formSectionQuery.sections())
                 .build();
     }

--- a/src/main/java/ddingdong/ddingdongBE/domain/form/controller/dto/response/UserFormResponse.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/form/controller/dto/response/UserFormResponse.java
@@ -5,6 +5,7 @@ import ddingdong.ddingdongBE.domain.form.service.dto.query.UserFormQuery;
 import ddingdong.ddingdongBE.domain.form.service.dto.query.UserFormQuery.UserFormFieldListQuery;
 import io.swagger.v3.oas.annotations.media.ArraySchema;
 import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.LocalDate;
 import java.util.List;
 import lombok.Builder;
 
@@ -18,6 +19,10 @@ public record UserFormResponse(
         String description,
         @Schema(description = "폼지 지원자 수", example = "20")
         int applicationCount,
+        @Schema(description = "폼지 시작일", example = "2001-01-01")
+        LocalDate startDate,
+        @Schema(description = "폼지 종료일", example = "2001-01-02")
+        LocalDate endDate,
         @ArraySchema(schema = @Schema(implementation = UserFormFieldListResponse.class))
         List<UserFormFieldListResponse> formFields
 ) {
@@ -62,6 +67,8 @@ public record UserFormResponse(
                 .title(userFormQuery.title())
                 .description(userFormQuery.description())
                 .applicationCount(userFormQuery.applicationCount())
+                .startDate(userFormQuery.startDate())
+                .endDate(userFormQuery.endDate())
                 .formFields(responses)
                 .build();
     }

--- a/src/main/java/ddingdong/ddingdongBE/domain/form/service/dto/query/FormSectionQuery.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/form/service/dto/query/FormSectionQuery.java
@@ -1,21 +1,26 @@
 package ddingdong.ddingdongBE.domain.form.service.dto.query;
 
 import ddingdong.ddingdongBE.domain.form.entity.Form;
+import java.time.LocalDate;
 import java.util.List;
 import lombok.Builder;
 
 @Builder
 public record FormSectionQuery(
-    String title,
-    String description,
-    List<String> sections
+        String title,
+        String description,
+        LocalDate startDate,
+        LocalDate endDate,
+        List<String> sections
 ) {
 
-  public static FormSectionQuery from(Form form) {
-    return FormSectionQuery.builder()
-        .title(form.getTitle())
-        .description(form.getDescription())
-        .sections(form.getSections())
-        .build();
-  }
+    public static FormSectionQuery from(Form form) {
+        return FormSectionQuery.builder()
+                .title(form.getTitle())
+                .description(form.getDescription())
+                .sections(form.getSections())
+                .startDate(form.getStartDate())
+                .endDate(form.getEndDate())
+                .build();
+    }
 }

--- a/src/main/java/ddingdong/ddingdongBE/domain/form/service/dto/query/UserFormQuery.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/form/service/dto/query/UserFormQuery.java
@@ -4,6 +4,7 @@ import ddingdong.ddingdongBE.domain.club.entity.Club;
 import ddingdong.ddingdongBE.domain.form.entity.FieldType;
 import ddingdong.ddingdongBE.domain.form.entity.Form;
 import ddingdong.ddingdongBE.domain.form.entity.FormField;
+import java.time.LocalDate;
 import java.util.List;
 import lombok.Builder;
 
@@ -13,6 +14,8 @@ public record UserFormQuery(
         String title,
         String description,
         int applicationCount,
+        LocalDate startDate,
+        LocalDate endDate,
         List<UserFormFieldListQuery> formFields
 ) {
 
@@ -26,6 +29,8 @@ public record UserFormQuery(
                 .title(form.getTitle())
                 .description(form.getDescription())
                 .applicationCount(applicationCount)
+                .startDate(form.getStartDate())
+                .endDate(form.getEndDate())
                 .formFields(formFieldListQueries)
                 .build();
     }


### PR DESCRIPTION
## 🚀 작업 내용
 
응답 기간이 지난 폼지 접근을 프론트에서 제한할 수 있도록 폼지 조회 및 섹션 조회 응답 dto에 응답 기간 필드 추가하였습니다.

## 🤔 고민했던 내용


## 💬 리뷰 중점사항


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- 폼 섹션 및 사용자 폼 응답에 시작일과 종료일 필드가 추가되어, 폼의 날짜 정보를 보다 명확하게 확인할 수 있습니다.
	- 폼 조회 기능이 개선되어, 날짜 기준으로 폼의 운영 기간 및 일정 정보를 손쉽게 파악할 수 있게 되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->