### PR TITLE
[DDING-000] 지원서 상세조회시 파일 다운로드 수정

### DIFF
--- a/src/main/java/ddingdong/ddingdongBE/file/api/S3FileAPi.java
+++ b/src/main/java/ddingdong/ddingdongBE/file/api/S3FileAPi.java
@@ -90,5 +90,4 @@ public interface S3FileAPi {
     @ResponseStatus(HttpStatus.OK)
     @GetMapping("/upload-url/form-application")
     UploadUrlResponse getFormApplicationPreSignedUrl(@RequestParam("fileName") String fileName);
-
 }

--- a/src/main/java/ddingdong/ddingdongBE/file/controller/S3FileController.java
+++ b/src/main/java/ddingdong/ddingdongBE/file/controller/S3FileController.java
@@ -37,7 +37,7 @@ public class S3FileController implements S3FileAPi {
         LocalDateTime now = LocalDateTime.now();
         String decodedFileName = URLDecoder.decode(fileName, StandardCharsets.UTF_8);
         GeneratePreSignedUrlRequestQuery query =
-                s3FileService.generatePresignedUrlRequest(
+                s3FileService.generateDownloadPresignedUrlRequest(
                         new GeneratePreSignedUrlRequestCommand(now, 9999L, decodedFileName));
         URL presingedUrl = s3FileService.getPresignedUrl(query.generatePresignedUrlRequest());
         return UploadUrlResponse.of(query, presingedUrl);


### PR DESCRIPTION
## 🚀 작업 내용
- 기존 지원서 상세조회시 파일이 조회되었던 로직을 다운로드되도록 수정하였습니다.

## 🤔 고민했던 내용
- 로직이 중복되어 private메소드로 분리했는데 괜찮은지 봐주세요!

## 💬 리뷰 중점사항


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
	- 파일 다운로드용 미리 서명 URL 생성 기능을 도입하여 파일 접근 방식을 개선했습니다.
- **리팩토링**
	- 기존 파일 URL 생성 로직을 재구성하여 코드의 명확성과 유지보수성을 향상시켰으며, 불필요한 기능을 제거하여 처리 과정을 단순화했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->