### PR TITLE
[DDING-000] 지원서 상세조회시 파일정보 명세 추가

### DIFF
--- a/src/main/java/ddingdong/ddingdongBE/domain/filemetadata/service/FileMetaDataService.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/filemetadata/service/FileMetaDataService.java
@@ -12,6 +12,8 @@ public interface FileMetaDataService {
 
     FileMetaData getById(String id);
 
+    List<FileMetaData> getAllByIds(List<String> ids);
+
     List<FileMetaData> getCoupledAllByDomainTypeAndEntityId(DomainType domainType, Long entityId);
 
     List<FileMetaData> getCoupledAllByEntityId(Long entityId);

--- a/src/main/java/ddingdong/ddingdongBE/domain/filemetadata/service/FileMetaDataServiceImpl.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/filemetadata/service/FileMetaDataServiceImpl.java
@@ -40,6 +40,12 @@ public class FileMetaDataServiceImpl implements FileMetaDataService {
     }
 
     @Override
+    public List<FileMetaData> getAllByIds(List<String> ids) {
+        List<UUID> uuids = toUUIDs(ids);
+        return fileMetaDataRepository.findByIdIn(uuids);
+    }
+
+    @Override
     public List<FileMetaData> getCoupledAllByDomainTypeAndEntityId(DomainType domainType, Long entityId) {
         return fileMetaDataRepository.findAllByDomainTypeAndEntityIdWithFileStatus(domainType, entityId, COUPLED);
     }

--- a/src/main/java/ddingdong/ddingdongBE/domain/formapplication/controller/dto/response/FormApplicationResponse.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/formapplication/controller/dto/response/FormApplicationResponse.java
@@ -4,13 +4,11 @@ import ddingdong.ddingdongBE.domain.form.entity.FieldType;
 import ddingdong.ddingdongBE.domain.formapplication.entity.FormApplicationStatus;
 import ddingdong.ddingdongBE.domain.formapplication.service.dto.query.FormApplicationQuery;
 import ddingdong.ddingdongBE.domain.formapplication.service.dto.query.FormApplicationQuery.FormFieldAnswerListQuery;
-
 import io.swagger.v3.oas.annotations.media.ArraySchema;
 import io.swagger.v3.oas.annotations.media.Schema;
-import lombok.Builder;
-
 import java.time.LocalDateTime;
 import java.util.List;
+import lombok.Builder;
 
 @Builder
 public record FormApplicationResponse(
@@ -55,11 +53,24 @@ public record FormApplicationResponse(
             @Schema(description = "섹션", example = "공통")
             String section,
             @Schema(description = "질문 답변 값", example = "[\"지문1\"]")
-            List<String> value
+            List<String> value,
+            @ArraySchema(schema = @Schema(implementation = FileResponse.class))
+            List<FileResponse> files
     ) {
+
+        record FileResponse(
+                @Schema(description = "파일 이름", example = "제출용 파일.zip")
+                String name,
+                @Schema(description = "파일 다운로드 cdn url", example = "url")
+                String cdnUrl
+        ) {
+        }
 
         public static FormFieldAnswerListResponse from(
                 FormFieldAnswerListQuery formFieldAnswerListQuery) {
+            List<FileResponse> fileResponses = formFieldAnswerListQuery.fileQueries().stream()
+                    .map(fileQuery -> new FileResponse(fileQuery.name(), fileQuery.cdnUrl()))
+                    .toList();
             return FormFieldAnswerListResponse.builder()
                     .fieldId(formFieldAnswerListQuery.fieldId())
                     .question(formFieldAnswerListQuery.question())
@@ -69,6 +80,7 @@ public record FormApplicationResponse(
                     .order(formFieldAnswerListQuery.order())
                     .section(formFieldAnswerListQuery.section())
                     .value(formFieldAnswerListQuery.value())
+                    .files(fileResponses)
                     .build();
         }
     }

--- a/src/main/java/ddingdong/ddingdongBE/domain/formapplication/service/dto/query/FormApplicationQuery.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/formapplication/service/dto/query/FormApplicationQuery.java
@@ -1,16 +1,13 @@
 package ddingdong.ddingdongBE.domain.formapplication.service.dto.query;
 
 import ddingdong.ddingdongBE.domain.form.entity.FieldType;
-
 import ddingdong.ddingdongBE.domain.form.entity.Form;
 import ddingdong.ddingdongBE.domain.formapplication.entity.FormAnswer;
 import ddingdong.ddingdongBE.domain.formapplication.entity.FormApplication;
 import ddingdong.ddingdongBE.domain.formapplication.entity.FormApplicationStatus;
-
-import lombok.Builder;
-
 import java.time.LocalDateTime;
 import java.util.List;
+import lombok.Builder;
 
 @Builder
 public record FormApplicationQuery(
@@ -35,10 +32,18 @@ public record FormApplicationQuery(
             Boolean required,
             Integer order,
             String section,
-            List<String> value
+            List<String> value,
+            List<FileQuery> fileQueries
     ) {
 
-        public static FormFieldAnswerListQuery from(FormAnswer formAnswer) {
+        public record FileQuery(
+                String name,
+                String cdnUrl
+        ) {
+
+        }
+
+        public static FormFieldAnswerListQuery of(FormAnswer formAnswer, List<FileQuery> fieldQueries) {
             return FormFieldAnswerListQuery.builder()
                     .fieldId(formAnswer.getFormField().getId())
                     .question(formAnswer.getFormField().getQuestion())
@@ -48,19 +53,7 @@ public record FormApplicationQuery(
                     .order(formAnswer.getFormField().getFieldOrder())
                     .section(formAnswer.getFormField().getSection())
                     .value(formAnswer.getValue())
-                    .build();
-        }
-
-        public static FormFieldAnswerListQuery of(FormAnswer formAnswer, List<String> value) {
-            return FormFieldAnswerListQuery.builder()
-                    .fieldId(formAnswer.getFormField().getId())
-                    .question(formAnswer.getFormField().getQuestion())
-                    .type(formAnswer.getFormField().getFieldType())
-                    .options(formAnswer.getFormField().getOptions())
-                    .required(formAnswer.getFormField().isRequired())
-                    .order(formAnswer.getFormField().getFieldOrder())
-                    .section(formAnswer.getFormField().getSection())
-                    .value(value)
+                    .fileQueries(fieldQueries)
                     .build();
         }
     }


### PR DESCRIPTION
## 🚀 작업 내용
- 기존 파일 Url만 반환하면 되는 줄 알고, values에 값을 포함시켰다가 프론트에서 파일 이름도 요청하여 파일 필드 명세를 추가했습니다!

## 🤔 고민했던 내용
- 새로운 API를 생성하여 파일 조회 API를 호출하려 했는데, 그래도 하나의 API에 모든 정보가 있으면 좋을 것 같아서 포함시켰습니다.!
두 가지 방법이 서로 장단점이 있는 것 같습니다


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
  - 여러 파일의 메타데이터를 한 번에 조회할 수 있는 기능이 추가되었습니다.
  - 양식 응답에 파일 이름과 CDN URL 등의 파일 정보가 포함되어, 보다 풍부한 데이터를 제공합니다.

- **리팩토링**
  - 양식 응답 처리 로직을 개선하여, 파일 관련 데이터 조회 및 처리 과정을 모듈화하였습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->