### PR TITLE
[DDING-120] 활동 보고서 테이블 내 회차(term), 생성일자(created_at) 인덱스 추가

### DIFF
--- a/src/main/resources/db/migration/V41__alter_table_add_index_activity_report.sql
+++ b/src/main/resources/db/migration/V41__alter_table_add_index_activity_report.sql
@@ -1,0 +1,7 @@
+CREATE INDEX activity_report_term_index
+    ON ddingdong_dev.activity_report (term)
+    COMMENT '활동 보고서 회차(term) 인덱스';
+
+CREATE INDEX activity_report_created_at_index
+    ON ddingdong_dev.activity_report (created_at)
+    COMMENT '활동보고서 생성 일자(created_at) 인덱스';

--- a/src/main/resources/db/migration/V42__alter_table_add_index_activity_report.sql
+++ b/src/main/resources/db/migration/V42__alter_table_add_index_activity_report.sql
@@ -5,3 +5,7 @@ CREATE INDEX activity_report_term_index
 CREATE INDEX activity_report_created_at_index
     ON ddingdong_dev.activity_report (created_at)
     COMMENT '활동보고서 생성 일자(created_at) 인덱스';
+
+CREATE INDEX activity_report_start_date_index
+    ON ddingdong_dev.activity_report (start_date)
+    COMMENT '활동보고서 시작 일자(start_date) 인덱스';


### PR DESCRIPTION
## 🚀 작업 내용
* 활동 보고서 테이블 내 회차(term), 생성일자(created_at) 필드에 인덱스를 추가합니다.

### 세부 작업 내용

현재 조회 쿼리 내에서 where 조건에 사용되는 컬럼에 대해 secondary index를 추가합니다.


```java
@Repository
public interface ActivityReportRepository extends JpaRepository<ActivityReport, Long> {

    List<ActivityReport> findByClubNameAndTerm(String clubName, String term);

    List<ActivityReport> findByClubName(String clubName);
}
```

```java
public interface ActivityReportTermInfoRepository extends JpaRepository<ActivityReportTermInfo, Long> {

    Optional<ActivityReportTermInfo> findFirstByOrderByStartDateAsc();
}
```

### 추가 확인 필요한 사항
* club_name 필드로 조회하는 쿼리가 존재하나, 해당 테이블에는 관련 필드 정보가 존재하지 않습니다. 해당 로직에 대한 파악이 필요하며, 필요 시에는 club_id로 대체하는 등 추가 조치가 필요합니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - 활동 보고서 관련 데이터 조회 성능이 개선되어, 보다 빠른 결과 확인이 가능합니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->