### PR TITLE
[DDING-121] 활동보고서 현재 회차 조회 로직 수정

### DIFF
--- a/src/main/java/ddingdong/ddingdongBE/domain/activityreport/controller/ClubActivityReportApiController.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/activityreport/controller/ClubActivityReportApiController.java
@@ -17,6 +17,7 @@ import ddingdong.ddingdongBE.domain.activityreport.service.dto.query.ActivityRep
 import ddingdong.ddingdongBE.domain.activityreport.service.dto.query.ActivityReportQuery;
 import ddingdong.ddingdongBE.domain.activityreport.service.dto.query.ActivityReportTermInfoQuery;
 import ddingdong.ddingdongBE.domain.user.entity.User;
+import java.time.LocalDateTime;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.RestController;
@@ -29,7 +30,8 @@ public class ClubActivityReportApiController implements ClubActivityReportApi {
 
     @Override
     public CurrentTermResponse getCurrentTerm() {
-        String currentTerm = facadeClubActivityReportService.getCurrentTerm();
+        LocalDateTime now = LocalDateTime.now();
+        String currentTerm = facadeClubActivityReportService.getCurrentTerm(now);
         return CurrentTermResponse.from(currentTerm);
     }
 

--- a/src/main/java/ddingdong/ddingdongBE/domain/activityreport/service/ActivityReportTermInfoService.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/activityreport/service/ActivityReportTermInfoService.java
@@ -2,6 +2,7 @@ package ddingdong.ddingdongBE.domain.activityreport.service;
 
 import ddingdong.ddingdongBE.domain.activityreport.domain.ActivityReportTermInfo;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 
 public interface ActivityReportTermInfoService {
@@ -10,5 +11,5 @@ public interface ActivityReportTermInfoService {
 
     void create(LocalDate startDate, int totalTermCount);
 
-    String getCurrentTerm();
+    String getCurrentTerm(LocalDateTime now);
 }

--- a/src/main/java/ddingdong/ddingdongBE/domain/activityreport/service/FacadeClubActivityReportService.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/activityreport/service/FacadeClubActivityReportService.java
@@ -6,6 +6,7 @@ import ddingdong.ddingdongBE.domain.activityreport.service.dto.query.ActivityRep
 import ddingdong.ddingdongBE.domain.activityreport.service.dto.query.ActivityReportQuery;
 import ddingdong.ddingdongBE.domain.activityreport.service.dto.query.ActivityReportTermInfoQuery;
 import ddingdong.ddingdongBE.domain.user.entity.User;
+import java.time.LocalDateTime;
 import java.util.List;
 
 public interface FacadeClubActivityReportService {
@@ -16,7 +17,7 @@ public interface FacadeClubActivityReportService {
 
     List<ActivityReportTermInfoQuery> getActivityReportTermInfos();
 
-    String getCurrentTerm();
+    String getCurrentTerm(LocalDateTime now);
 
     void create(User user, List<CreateActivityReportCommand> commands);
 


### PR DESCRIPTION
## 🚀 작업 내용
- 활동보고서 현재 회차 조회 로직 수정
	- `as-is`: 첫번째 활동보고서 기간을 바탕으로 현재 회차 계산
	- `to-be`: 현재 날짜에 해당하는 활동보고서 회자 정보 활용

## 🤔 고민했던 내용
- 현재 날짜에 해당하는 활동보고서 회차 정보를 활용 시 데이터베이스 조회 단계에서 날짜로 필터링하여 조회하는 방법과 전체 조회 후 어플리케이션 레벨에서 필터링 하는 방법을 고민하였는데 다음과 같은 후자를 선택했습니다.
	- 활동보고서 회차 정보 데이터 로우 수가 적어(8개) 전체 조회에 부담 없음
	- 활동보고서 회차 정보에 해당하는 날짜가 아닐 경우 기본 값 적용 용이

## 💬 리뷰 중점사항


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - 현재 시간을 입력받아 학기를 계산하는 기능이 추가되어, 보다 정밀한 활동 보고서 확인이 가능합니다.
- **Refactor**
  - 활동 보고서의 현재 학기 판단 로직이 개선되어, 기존 단일 항목 기반 계산에서 기간 내 여부 확인 방식으로 전환되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->