### PR TITLE
[DDING-122] 활동보고서 조회 API 수정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -99,8 +99,6 @@ sonar {
         property "sonar.coverage.jacoco.xmlReportPaths", "${layout.buildDirectory}/reports/jacoco/test/jacocoTestReport.xml"
         property "sonar.junit.reportPaths", "${layout.buildDirectory}/test-results/test"
 
-        property "sonar.coverage.minimum", "0"
-
         property "sonar.exclusions", "**/common/**"
         property "sonar.coverage.exclusions", """
             **/common/**,

--- a/build.gradle
+++ b/build.gradle
@@ -99,6 +99,8 @@ sonar {
         property "sonar.coverage.jacoco.xmlReportPaths", "${layout.buildDirectory}/reports/jacoco/test/jacocoTestReport.xml"
         property "sonar.junit.reportPaths", "${layout.buildDirectory}/test-results/test"
 
+        property "sonar.coverage.minimum", "0"
+
         property "sonar.exclusions", "**/common/**"
         property "sonar.coverage.exclusions", """
             **/common/**,

--- a/src/main/java/ddingdong/ddingdongBE/domain/activityreport/api/AdminActivityReportApi.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/activityreport/api/AdminActivityReportApi.java
@@ -1,7 +1,7 @@
 package ddingdong.ddingdongBE.domain.activityreport.api;
 
 import ddingdong.ddingdongBE.domain.activityreport.controller.dto.request.CreateActivityTermInfoRequest;
-import ddingdong.ddingdongBE.domain.activityreport.controller.dto.response.ActivityReportListResponse;
+import ddingdong.ddingdongBE.domain.activityreport.controller.dto.response.AdminActivityReportListResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -11,6 +11,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import java.util.List;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -22,11 +23,11 @@ public interface AdminActivityReportApi {
 
     @Operation(summary = "활동 보고서 전체 조회")
     @ApiResponse(responseCode = "200", description = "활동 보고서 전체 조회 성공",
-        content = @Content(schema = @Schema(implementation = ActivityReportListResponse.class)))
+        content = @Content(schema = @Schema(implementation = AdminActivityReportListResponse.class)))
     @ResponseStatus(HttpStatus.OK)
     @SecurityRequirement(name = "AccessToken")
-    @GetMapping
-    List<ActivityReportListResponse> getActivityReports();
+    @GetMapping("/{term}")
+    List<AdminActivityReportListResponse> getActivityReports(@PathVariable("term") int term);
 
     @Operation(summary = "활동 보고서 회차별 기간 설정 API")
     @ApiResponse(responseCode = "201", description = "활동 보고서 회차 생성 성공")

--- a/src/main/java/ddingdong/ddingdongBE/domain/activityreport/api/ClubActivityReportApi.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/activityreport/api/ClubActivityReportApi.java
@@ -56,7 +56,7 @@ public interface ClubActivityReportApi {
     @GetMapping("/activity-reports")
     List<ActivityReportResponse> getActivityReport(
             @AuthenticationPrincipal PrincipalDetails principalDetails,
-            @RequestParam("term") String term
+            @RequestParam("term") int term
     );
 
     @Operation(summary = "활동보고서 등록")
@@ -76,7 +76,7 @@ public interface ClubActivityReportApi {
     @PatchMapping(value = "/my/activity-reports")
     void updateActivityReport(
             @AuthenticationPrincipal PrincipalDetails principalDetails,
-            @RequestParam(value = "term") String term,
+            @RequestParam(value = "term") int term,
             @RequestBody UpdateActivityReportRequests requests
     );
 
@@ -87,7 +87,7 @@ public interface ClubActivityReportApi {
     @DeleteMapping("/my/activity-reports")
     void deleteActivityReport(
             @AuthenticationPrincipal PrincipalDetails principalDetails,
-            @RequestParam(value = "term") String term
+            @RequestParam(value = "term") int term
     );
 
     @Operation(summary = "활동 보고서 회차별 기간 조회 API")

--- a/src/main/java/ddingdong/ddingdongBE/domain/activityreport/api/ClubActivityReportApi.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/activityreport/api/ClubActivityReportApi.java
@@ -3,9 +3,10 @@ package ddingdong.ddingdongBE.domain.activityreport.api;
 import ddingdong.ddingdongBE.auth.PrincipalDetails;
 import ddingdong.ddingdongBE.domain.activityreport.controller.dto.request.CreateActivityReportRequests;
 import ddingdong.ddingdongBE.domain.activityreport.controller.dto.request.UpdateActivityReportRequests;
-import ddingdong.ddingdongBE.domain.activityreport.controller.dto.response.ActivityReportListResponse;
+import ddingdong.ddingdongBE.domain.activityreport.controller.dto.response.AdminActivityReportListResponse;
 import ddingdong.ddingdongBE.domain.activityreport.controller.dto.response.ActivityReportResponse;
 import ddingdong.ddingdongBE.domain.activityreport.controller.dto.response.ActivityReportTermInfoResponse;
+import ddingdong.ddingdongBE.domain.activityreport.controller.dto.response.CentralActivityReportListResponse;
 import ddingdong.ddingdongBE.domain.activityreport.controller.dto.response.CurrentTermResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -31,7 +32,7 @@ public interface ClubActivityReportApi {
 
     @Operation(summary = "현재 활동보고서 회차 조회")
     @ApiResponse(responseCode = "200", description = "현재 활동보고서 회차 조회 성공",
-        content = @Content(schema = @Schema(implementation = CurrentTermResponse.class)))
+            content = @Content(schema = @Schema(implementation = CurrentTermResponse.class)))
     @ResponseStatus(HttpStatus.OK)
     @SecurityRequirement(name = "AccessToken")
     @GetMapping("/activity-reports/current-term")
@@ -39,23 +40,23 @@ public interface ClubActivityReportApi {
 
     @Operation(summary = "본인 동아리 활동보고서 전체 조회")
     @ApiResponse(responseCode = "200", description = "본인 동아리 활동보고서 전체 조회 성공",
-        content = @Content(schema = @Schema(implementation = ActivityReportListResponse.class)))
+            content = @Content(schema = @Schema(implementation = AdminActivityReportListResponse.class)))
     @ResponseStatus(HttpStatus.OK)
     @SecurityRequirement(name = "AccessToken")
     @GetMapping("/my/activity-reports")
-    List<ActivityReportListResponse> getMyActivityReports(
-        @AuthenticationPrincipal PrincipalDetails principalDetails
+    List<CentralActivityReportListResponse> getMyActivityReports(
+            @AuthenticationPrincipal PrincipalDetails principalDetails
     );
 
     @Operation(summary = "활동보고서 상세 조회")
     @ApiResponse(responseCode = "200", description = "활동보고서 상세 조회 성공",
-        content = @Content(schema = @Schema(implementation = ActivityReportResponse.class)))
+            content = @Content(schema = @Schema(implementation = ActivityReportResponse.class)))
     @ResponseStatus(HttpStatus.OK)
     @SecurityRequirement(name = "AccessToken")
     @GetMapping("/activity-reports")
     List<ActivityReportResponse> getActivityReport(
-        @RequestParam("term") String term,
-        @RequestParam("club_name") String clubName
+            @AuthenticationPrincipal PrincipalDetails principalDetails,
+            @RequestParam("term") String term
     );
 
     @Operation(summary = "활동보고서 등록")
@@ -64,8 +65,8 @@ public interface ClubActivityReportApi {
     @SecurityRequirement(name = "AccessToken")
     @PostMapping(value = "/my/activity-reports")
     void createActivityReport(
-        @AuthenticationPrincipal PrincipalDetails principalDetails,
-        @RequestBody CreateActivityReportRequests requests
+            @AuthenticationPrincipal PrincipalDetails principalDetails,
+            @RequestBody CreateActivityReportRequests requests
     );
 
     @Operation(summary = "활동보고서 수정")
@@ -74,9 +75,9 @@ public interface ClubActivityReportApi {
     @SecurityRequirement(name = "AccessToken")
     @PatchMapping(value = "/my/activity-reports")
     void updateActivityReport(
-        @AuthenticationPrincipal PrincipalDetails principalDetails,
-        @RequestParam(value = "term") String term,
-        @RequestBody UpdateActivityReportRequests requests
+            @AuthenticationPrincipal PrincipalDetails principalDetails,
+            @RequestParam(value = "term") String term,
+            @RequestBody UpdateActivityReportRequests requests
     );
 
     @Operation(summary = "활동보고서 삭제")
@@ -85,13 +86,13 @@ public interface ClubActivityReportApi {
     @SecurityRequirement(name = "AccessToken")
     @DeleteMapping("/my/activity-reports")
     void deleteActivityReport(
-        @AuthenticationPrincipal PrincipalDetails principalDetails,
-        @RequestParam(value = "term") String term
+            @AuthenticationPrincipal PrincipalDetails principalDetails,
+            @RequestParam(value = "term") String term
     );
 
     @Operation(summary = "활동 보고서 회차별 기간 조회 API")
     @ApiResponse(responseCode = "200", description = "활동 보고서 회차별 기간 조회 성공",
-        content = @Content(schema = @Schema(implementation = ActivityReportTermInfoResponse.class)))
+            content = @Content(schema = @Schema(implementation = ActivityReportTermInfoResponse.class)))
     @ResponseStatus(HttpStatus.OK)
     @SecurityRequirement(name = "AccessToken")
     @GetMapping("/activity-reports/term")

--- a/src/main/java/ddingdong/ddingdongBE/domain/activityreport/controller/AdminActivityReportApiController.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/activityreport/controller/AdminActivityReportApiController.java
@@ -2,9 +2,10 @@ package ddingdong.ddingdongBE.domain.activityreport.controller;
 
 import ddingdong.ddingdongBE.domain.activityreport.api.AdminActivityReportApi;
 import ddingdong.ddingdongBE.domain.activityreport.controller.dto.request.CreateActivityTermInfoRequest;
-import ddingdong.ddingdongBE.domain.activityreport.controller.dto.response.ActivityReportListResponse;
+import ddingdong.ddingdongBE.domain.activityreport.controller.dto.response.AdminActivityReportListResponse;
 import ddingdong.ddingdongBE.domain.activityreport.service.FacadeAdminActivityReportService;
-import ddingdong.ddingdongBE.domain.activityreport.service.dto.query.ActivityReportListQuery;
+import ddingdong.ddingdongBE.domain.activityreport.service.dto.query.AdminActivityReportListQuery;
+import java.time.LocalDateTime;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.RestController;
@@ -16,11 +17,12 @@ public class AdminActivityReportApiController implements AdminActivityReportApi 
     private final FacadeAdminActivityReportService facadeAdminActivityReportService;
 
     @Override
-    public List<ActivityReportListResponse> getActivityReports() {
-        List<ActivityReportListQuery> queries = facadeAdminActivityReportService.getActivityReports();
+    public List<AdminActivityReportListResponse> getActivityReports(int term) {
+        LocalDateTime now = LocalDateTime.now();
+        List<AdminActivityReportListQuery> queries = facadeAdminActivityReportService.getActivityReports(now, term);
         return queries.stream()
-            .map(ActivityReportListResponse::from)
-            .toList();
+                .map(AdminActivityReportListResponse::from)
+                .toList();
     }
 
     @Override

--- a/src/main/java/ddingdong/ddingdongBE/domain/activityreport/controller/ClubActivityReportApiController.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/activityreport/controller/ClubActivityReportApiController.java
@@ -47,7 +47,7 @@ public class ClubActivityReportApiController implements ClubActivityReportApi {
     }
 
     @Override
-    public List<ActivityReportResponse> getActivityReport(PrincipalDetails principalDetails, String term) {
+    public List<ActivityReportResponse> getActivityReport(PrincipalDetails principalDetails, int term) {
         User user = principalDetails.getUser();
         LocalDateTime now = LocalDateTime.now();
         List<ActivityReportQuery> queries = facadeClubActivityReportService.getActivityReport(user, now, term);
@@ -71,25 +71,22 @@ public class ClubActivityReportApiController implements ClubActivityReportApi {
     @Override
     public void updateActivityReport(
             PrincipalDetails principalDetails,
-            String term,
+            int term,
             UpdateActivityReportRequests requests
     ) {
         User user = principalDetails.getUser();
         LocalDateTime now = LocalDateTime.now();
         List<UpdateActivityReportCommand> commands = requests.activityReportRequests().stream()
-            .map(UpdateActivityReportRequest::toCommand)
-            .toList();
-        facadeClubActivityReportService.update(user, term, now, commands);
+                .map(UpdateActivityReportRequest::toCommand)
+                .toList();
+        facadeClubActivityReportService.update(user, now, term, commands);
     }
 
     @Override
-    public void deleteActivityReport(
-            PrincipalDetails principalDetails,
-            String term
-    ) {
+    public void deleteActivityReport(PrincipalDetails principalDetails, int term) {
         User user = principalDetails.getUser();
         LocalDateTime now = LocalDateTime.now();
-        facadeClubActivityReportService.delete(user, term, now);
+        facadeClubActivityReportService.delete(user, now, term);
     }
 
     @Override

--- a/src/main/java/ddingdong/ddingdongBE/domain/activityreport/controller/ClubActivityReportApiController.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/activityreport/controller/ClubActivityReportApiController.java
@@ -6,16 +6,17 @@ import ddingdong.ddingdongBE.domain.activityreport.controller.dto.request.Create
 import ddingdong.ddingdongBE.domain.activityreport.controller.dto.request.CreateActivityReportRequests;
 import ddingdong.ddingdongBE.domain.activityreport.controller.dto.request.UpdateActivityReportRequest;
 import ddingdong.ddingdongBE.domain.activityreport.controller.dto.request.UpdateActivityReportRequests;
-import ddingdong.ddingdongBE.domain.activityreport.controller.dto.response.ActivityReportListResponse;
+import ddingdong.ddingdongBE.domain.activityreport.controller.dto.response.AdminActivityReportListResponse;
 import ddingdong.ddingdongBE.domain.activityreport.controller.dto.response.ActivityReportResponse;
 import ddingdong.ddingdongBE.domain.activityreport.controller.dto.response.ActivityReportTermInfoResponse;
+import ddingdong.ddingdongBE.domain.activityreport.controller.dto.response.CentralActivityReportListResponse;
 import ddingdong.ddingdongBE.domain.activityreport.controller.dto.response.CurrentTermResponse;
 import ddingdong.ddingdongBE.domain.activityreport.service.FacadeClubActivityReportService;
 import ddingdong.ddingdongBE.domain.activityreport.service.dto.command.CreateActivityReportCommand;
 import ddingdong.ddingdongBE.domain.activityreport.service.dto.command.UpdateActivityReportCommand;
-import ddingdong.ddingdongBE.domain.activityreport.service.dto.query.ActivityReportListQuery;
 import ddingdong.ddingdongBE.domain.activityreport.service.dto.query.ActivityReportQuery;
 import ddingdong.ddingdongBE.domain.activityreport.service.dto.query.ActivityReportTermInfoQuery;
+import ddingdong.ddingdongBE.domain.activityreport.service.dto.query.CentralActivityReportListQuery;
 import ddingdong.ddingdongBE.domain.user.entity.User;
 import java.time.LocalDateTime;
 import java.util.List;
@@ -36,66 +37,66 @@ public class ClubActivityReportApiController implements ClubActivityReportApi {
     }
 
     @Override
-    public List<ActivityReportListResponse> getMyActivityReports(PrincipalDetails principalDetails) {
+    public List<CentralActivityReportListResponse> getMyActivityReports(PrincipalDetails principalDetails) {
         User user = principalDetails.getUser();
-        List<ActivityReportListQuery> queries = facadeClubActivityReportService.getMyActivityReports(
-            user);
+        LocalDateTime now = LocalDateTime.now();
+        List<CentralActivityReportListQuery> queries = facadeClubActivityReportService.getMyActivityReports(user, now);
         return queries.stream()
-            .map(ActivityReportListResponse::from)
-            .toList();
+                .map(CentralActivityReportListResponse::from)
+                .toList();
     }
 
     @Override
-    public List<ActivityReportResponse> getActivityReport(
-        String term,
-        String clubName
-    ) {
-        List<ActivityReportQuery> queries = facadeClubActivityReportService.getActivityReport(term,
-            clubName);
+    public List<ActivityReportResponse> getActivityReport(PrincipalDetails principalDetails, String term) {
+        User user = principalDetails.getUser();
+        LocalDateTime now = LocalDateTime.now();
+        List<ActivityReportQuery> queries = facadeClubActivityReportService.getActivityReport(user, now, term);
         return queries.stream()
-            .map(ActivityReportResponse::from)
-            .toList();
+                .map(ActivityReportResponse::from)
+                .toList();
     }
 
     @Override
     public void createActivityReport(
-        PrincipalDetails principalDetails,
-        CreateActivityReportRequests requests
+            PrincipalDetails principalDetails,
+            CreateActivityReportRequests requests
     ) {
         User user = principalDetails.getUser();
         List<CreateActivityReportCommand> commands = requests.activityReportRequests().stream()
-            .map(CreateActivityReportRequest::toCommand)
-            .toList();
+                .map(CreateActivityReportRequest::toCommand)
+                .toList();
         facadeClubActivityReportService.create(user, commands);
     }
 
     @Override
     public void updateActivityReport(
-        PrincipalDetails principalDetails,
-        String term,
-        UpdateActivityReportRequests requests
+            PrincipalDetails principalDetails,
+            String term,
+            UpdateActivityReportRequests requests
     ) {
         User user = principalDetails.getUser();
+        LocalDateTime now = LocalDateTime.now();
         List<UpdateActivityReportCommand> commands = requests.activityReportRequests().stream()
             .map(UpdateActivityReportRequest::toCommand)
             .toList();
-        facadeClubActivityReportService.update(user, term, commands);
+        facadeClubActivityReportService.update(user, term, now, commands);
     }
 
     @Override
     public void deleteActivityReport(
-        PrincipalDetails principalDetails,
-        String term
+            PrincipalDetails principalDetails,
+            String term
     ) {
         User user = principalDetails.getUser();
-        facadeClubActivityReportService.delete(user, term);
+        LocalDateTime now = LocalDateTime.now();
+        facadeClubActivityReportService.delete(user, term, now);
     }
 
     @Override
     public List<ActivityReportTermInfoResponse> getActivityTermInfos() {
         List<ActivityReportTermInfoQuery> queries = facadeClubActivityReportService.getActivityReportTermInfos();
         return queries.stream()
-            .map(ActivityReportTermInfoResponse::from)
-            .toList();
+                .map(ActivityReportTermInfoResponse::from)
+                .toList();
     }
 }

--- a/src/main/java/ddingdong/ddingdongBE/domain/activityreport/controller/dto/request/CreateActivityReportRequest.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/activityreport/controller/dto/request/CreateActivityReportRequest.java
@@ -1,6 +1,6 @@
 package ddingdong.ddingdongBE.domain.activityreport.controller.dto.request;
 
-import ddingdong.ddingdongBE.domain.activityreport.domain.Participant;
+import ddingdong.ddingdongBE.domain.activityreport.entity.Participant;
 import ddingdong.ddingdongBE.domain.activityreport.service.dto.command.CreateActivityReportCommand;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.util.List;

--- a/src/main/java/ddingdong/ddingdongBE/domain/activityreport/controller/dto/request/UpdateActivityReportRequest.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/activityreport/controller/dto/request/UpdateActivityReportRequest.java
@@ -1,6 +1,6 @@
 package ddingdong.ddingdongBE.domain.activityreport.controller.dto.request;
 
-import ddingdong.ddingdongBE.domain.activityreport.domain.Participant;
+import ddingdong.ddingdongBE.domain.activityreport.entity.Participant;
 import ddingdong.ddingdongBE.domain.activityreport.service.dto.command.UpdateActivityReportCommand;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.util.List;

--- a/src/main/java/ddingdong/ddingdongBE/domain/activityreport/controller/dto/request/UpdateActivityReportRequest.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/activityreport/controller/dto/request/UpdateActivityReportRequest.java
@@ -3,46 +3,47 @@ package ddingdong.ddingdongBE.domain.activityreport.controller.dto.request;
 import ddingdong.ddingdongBE.domain.activityreport.entity.Participant;
 import ddingdong.ddingdongBE.domain.activityreport.service.dto.command.UpdateActivityReportCommand;
 import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.LocalDateTime;
 import java.util.List;
 import org.springframework.format.annotation.DateTimeFormat;
 
 public record UpdateActivityReportRequest(
-    @Schema(description = "내용", example = "활동보고서 내용입니다")
-    String content,
+        @Schema(description = "내용", example = "활동보고서 내용입니다")
+        String content,
 
-    @Schema(description = "활동 장소", example = "S1353")
-    String place,
+        @Schema(description = "활동 장소", example = "S1353")
+        String place,
 
-    @DateTimeFormat(pattern = "yyyy-MM-dd HH:mm")
-    @Schema(description = "활동 시작 일자", example = "2024-01-02 11:11")
-    String startDate,
+        @DateTimeFormat(pattern = "yyyy-MM-dd HH:mm")
+        @Schema(description = "활동 시작 일자", example = "2024-01-02 11:11")
+        String startDate,
 
-    @DateTimeFormat(pattern = "yyyy-MM-dd HH:mm")
-    @Schema(description = "활동 종료 일자", example = "2024-01-04 11:11")
-    String endDate,
+        @DateTimeFormat(pattern = "yyyy-MM-dd HH:mm")
+        @Schema(description = "활동 종료 일자", example = "2024-01-04 11:11")
+        String endDate,
 
-    @Schema(description = "활동보고서 이미지 key", example = "{serverProfile}/{contentType}/2024-01-01/{authId}/{uuid}")
-    String imageId,
+        @Schema(description = "활동보고서 이미지 key", example = "{serverProfile}/{contentType}/2024-01-01/{authId}/{uuid}")
+        String imageId,
 
-    @Schema(description = "활동 참여자 목록",
-        example = """
-             [{
-             "name" : "홍길동",
-             "studentId" : "1",
-             "department" : "서부서"
-             }]
-            """)
-    List<Participant> participants
+        @Schema(description = "활동 참여자 목록",
+                example = """
+                         [{
+                         "name" : "홍길동",
+                         "studentId" : "1",
+                         "department" : "서부서"
+                         }]
+                        """)
+        List<Participant> participants
 ) {
 
     public UpdateActivityReportCommand toCommand() {
         return UpdateActivityReportCommand.builder()
-            .content(content)
-            .place(place)
-            .imageId(imageId)
-            .startDate(startDate)
-            .endDate(endDate)
-            .participants(participants)
-            .build();
+                .content(content)
+                .place(place)
+                .imageId(imageId)
+                .startDate(startDate)
+                .endDate(endDate)
+                .participants(participants)
+                .build();
     }
 }

--- a/src/main/java/ddingdong/ddingdongBE/domain/activityreport/controller/dto/response/ActivityReportResponse.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/activityreport/controller/dto/response/ActivityReportResponse.java
@@ -1,7 +1,7 @@
 package ddingdong.ddingdongBE.domain.activityreport.controller.dto.response;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
-import ddingdong.ddingdongBE.domain.activityreport.domain.Participant;
+import ddingdong.ddingdongBE.domain.activityreport.entity.Participant;
 import ddingdong.ddingdongBE.domain.activityreport.service.dto.query.ActivityReportQuery;
 import ddingdong.ddingdongBE.file.service.dto.query.UploadedFileUrlQuery;
 import io.swagger.v3.oas.annotations.media.Schema;

--- a/src/main/java/ddingdong/ddingdongBE/domain/activityreport/controller/dto/response/AdminActivityReportListResponse.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/activityreport/controller/dto/response/AdminActivityReportListResponse.java
@@ -1,30 +1,26 @@
 package ddingdong.ddingdongBE.domain.activityreport.controller.dto.response;
 
-import ddingdong.ddingdongBE.domain.activityreport.service.dto.query.ActivityReportListQuery;
+import ddingdong.ddingdongBE.domain.activityreport.service.dto.query.AdminActivityReportListQuery;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.util.List;
 import lombok.Builder;
 
 @Builder
-public record ActivityReportListResponse(
+public record AdminActivityReportListResponse(
     @Schema(description = "동아리 이름", example = "카우")
     String name,
-
-    @Schema(description = "회차", example = "1")
-    String term,
 
     @Schema(description = "활동보고서 정보")
     List<ActivityReportDto> activityReports
 ) {
 
-    public static ActivityReportListResponse from(ActivityReportListQuery query) {
+    public static AdminActivityReportListResponse from(AdminActivityReportListQuery query) {
         List<ActivityReportDto> activityReports = query.activityReports().stream()
             .map(ActivityReportDto::from)
             .toList();
 
-        return ActivityReportListResponse.builder()
+        return AdminActivityReportListResponse.builder()
             .name(query.name())
-            .term(query.term())
             .activityReports(activityReports)
             .build();
     }

--- a/src/main/java/ddingdong/ddingdongBE/domain/activityreport/controller/dto/response/CentralActivityReportListResponse.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/activityreport/controller/dto/response/CentralActivityReportListResponse.java
@@ -1,0 +1,31 @@
+package ddingdong.ddingdongBE.domain.activityreport.controller.dto.response;
+
+import ddingdong.ddingdongBE.domain.activityreport.service.dto.query.CentralActivityReportListQuery;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+import lombok.Builder;
+
+@Builder
+public record CentralActivityReportListResponse(
+        @Schema(description = "동아리 이름", example = "카우")
+        String name,
+
+        @Schema(description = "회차", example = "1")
+        String term,
+
+        @Schema(description = "활동보고서 정보")
+        List<ActivityReportDto> activityReports
+) {
+
+    public static CentralActivityReportListResponse from(CentralActivityReportListQuery query) {
+        List<ActivityReportDto> activityReports = query.activityReports().stream()
+                .map(ActivityReportDto::from)
+                .toList();
+
+        return CentralActivityReportListResponse.builder()
+                .name(query.name())
+                .term(query.term())
+                .activityReports(activityReports)
+                .build();
+    }
+}

--- a/src/main/java/ddingdong/ddingdongBE/domain/activityreport/entity/ActivityReport.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/activityreport/entity/ActivityReport.java
@@ -1,4 +1,4 @@
-package ddingdong.ddingdongBE.domain.activityreport.domain;
+package ddingdong.ddingdongBE.domain.activityreport.entity;
 
 import ddingdong.ddingdongBE.common.BaseEntity;
 import ddingdong.ddingdongBE.domain.club.entity.Club;

--- a/src/main/java/ddingdong/ddingdongBE/domain/activityreport/entity/ActivityReportTermInfo.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/activityreport/entity/ActivityReportTermInfo.java
@@ -1,4 +1,4 @@
-package ddingdong.ddingdongBE.domain.activityreport.domain;
+package ddingdong.ddingdongBE.domain.activityreport.entity;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;

--- a/src/main/java/ddingdong/ddingdongBE/domain/activityreport/entity/Participant.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/activityreport/entity/Participant.java
@@ -1,4 +1,4 @@
-package ddingdong.ddingdongBE.domain.activityreport.domain;
+package ddingdong.ddingdongBE.domain.activityreport.entity;
 
 import jakarta.persistence.Embeddable;
 

--- a/src/main/java/ddingdong/ddingdongBE/domain/activityreport/repository/ActivityReportRepository.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/activityreport/repository/ActivityReportRepository.java
@@ -1,6 +1,6 @@
 package ddingdong.ddingdongBE.domain.activityreport.repository;
 
-import ddingdong.ddingdongBE.domain.activityreport.domain.ActivityReport;
+import ddingdong.ddingdongBE.domain.activityreport.entity.ActivityReport;
 
 import java.util.List;
 

--- a/src/main/java/ddingdong/ddingdongBE/domain/activityreport/repository/ActivityReportRepository.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/activityreport/repository/ActivityReportRepository.java
@@ -5,10 +5,21 @@ import ddingdong.ddingdongBE.domain.activityreport.entity.ActivityReport;
 import java.util.List;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface ActivityReportRepository extends JpaRepository<ActivityReport, Long> {
+
+    @Query(value = """
+        select ac from ActivityReport ac
+        join fetch ac.club c
+        where YEAR(ac.createdAt) = :currentYear
+        and ac.term = :term
+        and c.deletedAt is null
+        """)
+    List<ActivityReport> findAllByCurrentYearAndTerm(@Param("currentYear") int currentYear, @Param("term") int term);
 
     List<ActivityReport> findByClubNameAndTerm(String clubName, String term);
 

--- a/src/main/java/ddingdong/ddingdongBE/domain/activityreport/repository/ActivityReportRepository.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/activityreport/repository/ActivityReportRepository.java
@@ -2,6 +2,7 @@ package ddingdong.ddingdongBE.domain.activityreport.repository;
 
 import ddingdong.ddingdongBE.domain.activityreport.entity.ActivityReport;
 
+import ddingdong.ddingdongBE.domain.club.entity.Club;
 import java.util.List;
 
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -13,15 +14,33 @@ import org.springframework.stereotype.Repository;
 public interface ActivityReportRepository extends JpaRepository<ActivityReport, Long> {
 
     @Query(value = """
-        select ac from ActivityReport ac
-        join fetch ac.club c
-        where YEAR(ac.createdAt) = :currentYear
-        and ac.term = :term
-        and c.deletedAt is null
-        """)
+            select ac from ActivityReport ac
+            join fetch ac.club c
+            where YEAR(ac.createdAt) = :currentYear
+            and ac.term = :term
+            and c.deletedAt is null
+            """)
     List<ActivityReport> findAllByCurrentYearAndTerm(@Param("currentYear") int currentYear, @Param("term") int term);
 
-    List<ActivityReport> findByClubNameAndTerm(String clubName, String term);
+    @Query(value = """
+            select ac from ActivityReport ac
+            join fetch ac.club c
+            where YEAR(ac.createdAt) = :currentYear
+            and ac.term = :term
+            and c = :club
+            """)
+    List<ActivityReport> findByClubAndTerm(
+            @Param("club") Club club,
+            @Param("currentYear") int currentYear,
+            @Param("term") String term
+    );
 
-    List<ActivityReport> findByClubName(String clubName);
+    @Query(value = """
+            select ac from ActivityReport ac
+            join fetch ac.club c
+            where YEAR(ac.createdAt) = :currentYear
+            and c = :club
+            """)
+    List<ActivityReport> findAllByClub(@Param("club") Club club, @Param("currentYear") int currentYear);
+
 }

--- a/src/main/java/ddingdong/ddingdongBE/domain/activityreport/repository/ActivityReportRepository.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/activityreport/repository/ActivityReportRepository.java
@@ -32,7 +32,7 @@ public interface ActivityReportRepository extends JpaRepository<ActivityReport, 
     List<ActivityReport> findByClubAndTerm(
             @Param("club") Club club,
             @Param("currentYear") int currentYear,
-            @Param("term") String term
+            @Param("term") int term
     );
 
     @Query(value = """

--- a/src/main/java/ddingdong/ddingdongBE/domain/activityreport/repository/ActivityReportTermInfoRepository.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/activityreport/repository/ActivityReportTermInfoRepository.java
@@ -1,6 +1,6 @@
 package ddingdong.ddingdongBE.domain.activityreport.repository;
 
-import ddingdong.ddingdongBE.domain.activityreport.domain.ActivityReportTermInfo;
+import ddingdong.ddingdongBE.domain.activityreport.entity.ActivityReportTermInfo;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 

--- a/src/main/java/ddingdong/ddingdongBE/domain/activityreport/service/ActivityReportService.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/activityreport/service/ActivityReportService.java
@@ -6,7 +6,7 @@ import java.util.List;
 
 public interface ActivityReportService {
 
-    List<ActivityReport> getActivityReports();
+    List<ActivityReport> getActivityReports(int year, int term);
 
     List<ActivityReport> getActivityReportsByClub(final Club club);
 

--- a/src/main/java/ddingdong/ddingdongBE/domain/activityreport/service/ActivityReportService.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/activityreport/service/ActivityReportService.java
@@ -10,7 +10,7 @@ public interface ActivityReportService {
 
     List<ActivityReport> getActivityReportsByClub(Club club, int year);
 
-    List<ActivityReport> getActivityReport(Club club, int year, String term);
+    List<ActivityReport> getActivityReport(Club club, int year, int term);
 
     Long create(final ActivityReport activityReport);
 
@@ -18,5 +18,5 @@ public interface ActivityReportService {
 
     void deleteAll(List<ActivityReport> activityReports);
 
-    List<ActivityReport> getActivityReportOrThrow(Club club, int year, String term);
+    List<ActivityReport> getActivityReportOrThrow(Club club, int year, int term);
 }

--- a/src/main/java/ddingdong/ddingdongBE/domain/activityreport/service/ActivityReportService.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/activityreport/service/ActivityReportService.java
@@ -8,9 +8,9 @@ public interface ActivityReportService {
 
     List<ActivityReport> getActivityReports(int year, int term);
 
-    List<ActivityReport> getActivityReportsByClub(final Club club);
+    List<ActivityReport> getActivityReportsByClub(Club club, int year);
 
-    List<ActivityReport> getActivityReport(String clubName, String term);
+    List<ActivityReport> getActivityReport(Club club, int year, String term);
 
     Long create(final ActivityReport activityReport);
 
@@ -18,5 +18,5 @@ public interface ActivityReportService {
 
     void deleteAll(List<ActivityReport> activityReports);
 
-    List<ActivityReport> getActivityReportOrThrow(String clubName, String term);
+    List<ActivityReport> getActivityReportOrThrow(Club club, int year, String term);
 }

--- a/src/main/java/ddingdong/ddingdongBE/domain/activityreport/service/ActivityReportService.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/activityreport/service/ActivityReportService.java
@@ -1,6 +1,6 @@
 package ddingdong.ddingdongBE.domain.activityreport.service;
 
-import ddingdong.ddingdongBE.domain.activityreport.domain.ActivityReport;
+import ddingdong.ddingdongBE.domain.activityreport.entity.ActivityReport;
 import ddingdong.ddingdongBE.domain.club.entity.Club;
 import java.util.List;
 

--- a/src/main/java/ddingdong/ddingdongBE/domain/activityreport/service/ActivityReportServiceImpl.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/activityreport/service/ActivityReportServiceImpl.java
@@ -28,7 +28,7 @@ public class ActivityReportServiceImpl implements ActivityReportService {
     }
 
     @Override
-    public List<ActivityReport> getActivityReport(Club club, int year, String term) {
+    public List<ActivityReport> getActivityReport(Club club, int year, int term) {
         return activityReportRepository.findByClubAndTerm(club, year, term);
     }
 
@@ -55,7 +55,7 @@ public class ActivityReportServiceImpl implements ActivityReportService {
     }
 
     @Override
-    public List<ActivityReport> getActivityReportOrThrow(Club club, int year, String term) {
+    public List<ActivityReport> getActivityReportOrThrow(Club club, int year, int term) {
         List<ActivityReport> activityReports = getActivityReport(club, year, term);
         if (activityReports.isEmpty()) {
             throw new ResourceNotFound("해당 ActivityReports(clubName: " + club.getName() + ", term: " + term + ")"

--- a/src/main/java/ddingdong/ddingdongBE/domain/activityreport/service/ActivityReportServiceImpl.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/activityreport/service/ActivityReportServiceImpl.java
@@ -17,8 +17,8 @@ public class ActivityReportServiceImpl implements ActivityReportService{
     private final ActivityReportRepository activityReportRepository;
 
     @Override
-    public List<ActivityReport> getActivityReports() {
-        return activityReportRepository.findAll();
+    public List<ActivityReport> getActivityReports(int year, int term) {
+        return activityReportRepository.findAllByCurrentYearAndTerm(year, term);
     }
 
     @Override

--- a/src/main/java/ddingdong/ddingdongBE/domain/activityreport/service/ActivityReportServiceImpl.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/activityreport/service/ActivityReportServiceImpl.java
@@ -1,7 +1,7 @@
 package ddingdong.ddingdongBE.domain.activityreport.service;
 
 import ddingdong.ddingdongBE.common.exception.PersistenceException.ResourceNotFound;
-import ddingdong.ddingdongBE.domain.activityreport.domain.ActivityReport;
+import ddingdong.ddingdongBE.domain.activityreport.entity.ActivityReport;
 import ddingdong.ddingdongBE.domain.activityreport.repository.ActivityReportRepository;
 import ddingdong.ddingdongBE.domain.club.entity.Club;
 import java.util.List;

--- a/src/main/java/ddingdong/ddingdongBE/domain/activityreport/service/ActivityReportServiceImpl.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/activityreport/service/ActivityReportServiceImpl.java
@@ -4,7 +4,6 @@ import ddingdong.ddingdongBE.common.exception.PersistenceException.ResourceNotFo
 import ddingdong.ddingdongBE.domain.activityreport.entity.ActivityReport;
 import ddingdong.ddingdongBE.domain.activityreport.repository.ActivityReportRepository;
 import ddingdong.ddingdongBE.domain.club.entity.Club;
-import java.time.LocalDateTime;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;

--- a/src/main/java/ddingdong/ddingdongBE/domain/activityreport/service/ActivityReportServiceImpl.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/activityreport/service/ActivityReportServiceImpl.java
@@ -4,6 +4,7 @@ import ddingdong.ddingdongBE.common.exception.PersistenceException.ResourceNotFo
 import ddingdong.ddingdongBE.domain.activityreport.entity.ActivityReport;
 import ddingdong.ddingdongBE.domain.activityreport.repository.ActivityReportRepository;
 import ddingdong.ddingdongBE.domain.club.entity.Club;
+import java.time.LocalDateTime;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -12,7 +13,7 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 @Transactional(readOnly = true)
 @RequiredArgsConstructor
-public class ActivityReportServiceImpl implements ActivityReportService{
+public class ActivityReportServiceImpl implements ActivityReportService {
 
     private final ActivityReportRepository activityReportRepository;
 
@@ -22,16 +23,13 @@ public class ActivityReportServiceImpl implements ActivityReportService{
     }
 
     @Override
-    public List<ActivityReport> getActivityReportsByClub(final Club club) {
-        return activityReportRepository.findByClubName(club.getName());
+    public List<ActivityReport> getActivityReportsByClub(Club club, int year) {
+        return activityReportRepository.findAllByClub(club, year);
     }
 
     @Override
-    public List<ActivityReport> getActivityReport(
-        final String clubName,
-        final String term
-    ) {
-        return activityReportRepository.findByClubNameAndTerm(clubName, term);
+    public List<ActivityReport> getActivityReport(Club club, int year, String term) {
+        return activityReportRepository.findByClubAndTerm(club, year, term);
     }
 
     @Transactional
@@ -44,8 +42,8 @@ public class ActivityReportServiceImpl implements ActivityReportService{
     @Transactional
     @Override
     public void update(
-        final ActivityReport activityReport,
-        final ActivityReport updateActivityReport
+            final ActivityReport activityReport,
+            final ActivityReport updateActivityReport
     ) {
         activityReport.update(updateActivityReport);
     }
@@ -57,11 +55,11 @@ public class ActivityReportServiceImpl implements ActivityReportService{
     }
 
     @Override
-    public List<ActivityReport> getActivityReportOrThrow(String clubName, String term) {
-        List<ActivityReport> activityReports = getActivityReport(clubName, term);
+    public List<ActivityReport> getActivityReportOrThrow(Club club, int year, String term) {
+        List<ActivityReport> activityReports = getActivityReport(club, year, term);
         if (activityReports.isEmpty()) {
-            throw new ResourceNotFound("해당 ActivityReports(clubName: " + clubName + ", term: " + term + ")"
-                + "를 찾을 수 없습니다.");
+            throw new ResourceNotFound("해당 ActivityReports(clubName: " + club.getName() + ", term: " + term + ")"
+                    + "를 찾을 수 없습니다.");
         }
         return activityReports;
     }

--- a/src/main/java/ddingdong/ddingdongBE/domain/activityreport/service/ActivityReportTermInfoService.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/activityreport/service/ActivityReportTermInfoService.java
@@ -1,6 +1,6 @@
 package ddingdong.ddingdongBE.domain.activityreport.service;
 
-import ddingdong.ddingdongBE.domain.activityreport.domain.ActivityReportTermInfo;
+import ddingdong.ddingdongBE.domain.activityreport.entity.ActivityReportTermInfo;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;

--- a/src/main/java/ddingdong/ddingdongBE/domain/activityreport/service/ActivityReportTermInfoServiceImpl.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/activityreport/service/ActivityReportTermInfoServiceImpl.java
@@ -1,6 +1,6 @@
 package ddingdong.ddingdongBE.domain.activityreport.service;
 
-import ddingdong.ddingdongBE.domain.activityreport.domain.ActivityReportTermInfo;
+import ddingdong.ddingdongBE.domain.activityreport.entity.ActivityReportTermInfo;
 import ddingdong.ddingdongBE.domain.activityreport.repository.ActivityReportTermInfoRepository;
 import java.time.LocalDate;
 import java.time.LocalDateTime;

--- a/src/main/java/ddingdong/ddingdongBE/domain/activityreport/service/FacadeAdminActivityReportService.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/activityreport/service/FacadeAdminActivityReportService.java
@@ -1,12 +1,13 @@
 package ddingdong.ddingdongBE.domain.activityreport.service;
 
 import ddingdong.ddingdongBE.domain.activityreport.service.dto.command.CreateActivityTermInfoCommand;
-import ddingdong.ddingdongBE.domain.activityreport.service.dto.query.ActivityReportListQuery;
+import ddingdong.ddingdongBE.domain.activityreport.service.dto.query.AdminActivityReportListQuery;
+import java.time.LocalDateTime;
 import java.util.List;
 
 public interface FacadeAdminActivityReportService {
 
-    List<ActivityReportListQuery> getActivityReports();
+    List<AdminActivityReportListQuery> getActivityReports(LocalDateTime now, int term);
 
     void createActivityTermInfo(CreateActivityTermInfoCommand command);
 }

--- a/src/main/java/ddingdong/ddingdongBE/domain/activityreport/service/FacadeAdminActivityReportServiceImpl.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/activityreport/service/FacadeAdminActivityReportServiceImpl.java
@@ -3,7 +3,8 @@ package ddingdong.ddingdongBE.domain.activityreport.service;
 import ddingdong.ddingdongBE.domain.activityreport.entity.ActivityReport;
 import ddingdong.ddingdongBE.domain.activityreport.service.dto.command.CreateActivityTermInfoCommand;
 import ddingdong.ddingdongBE.domain.activityreport.service.dto.query.ActivityReportInfo;
-import ddingdong.ddingdongBE.domain.activityreport.service.dto.query.ActivityReportListQuery;
+import ddingdong.ddingdongBE.domain.activityreport.service.dto.query.AdminActivityReportListQuery;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -14,14 +15,15 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
-public class FacadeAdminActivityReportServiceImpl implements FacadeAdminActivityReportService{
+public class FacadeAdminActivityReportServiceImpl implements FacadeAdminActivityReportService {
 
     private final ActivityReportTermInfoService activityReportTermInfoService;
     private final ActivityReportService activityReportService;
 
     @Override
-    public List<ActivityReportListQuery> getActivityReports() {
-        List<ActivityReport> activityReports = activityReportService.getActivityReports();
+    public List<AdminActivityReportListQuery> getActivityReports(LocalDateTime now, int term) {
+        int currentYear = now.getYear();
+        List<ActivityReport> activityReports = activityReportService.getActivityReports(currentYear, term);
         return parseToListQuery(activityReports);
     }
 
@@ -31,23 +33,17 @@ public class FacadeAdminActivityReportServiceImpl implements FacadeAdminActivity
         activityReportTermInfoService.create(command.startDate(), command.totalTermCount());
     }
 
-    private List<ActivityReportListQuery> parseToListQuery(final List<ActivityReport> activityReports) {
-        Map<String, Map<String, List<Long>>> groupedData = activityReports.stream().collect(
-            Collectors.groupingBy(activityReport -> activityReport.getClub().getName(),
-                Collectors.groupingBy(ActivityReport::getTerm,
-                    Collectors.mapping(ActivityReport::getId, Collectors.toList()))));
+    private List<AdminActivityReportListQuery> parseToListQuery(final List<ActivityReport> activityReports) {
+        Map<String, List<ActivityReport>> activityReportsGroupedByClubName = activityReports.stream()
+                .collect(Collectors.groupingBy(report -> report.getClub().getName()));
 
-        return groupedData.entrySet().stream().flatMap(entry -> {
-            String clubName = entry.getKey();
-            Map<String, List<Long>> termMap = entry.getValue();
-
-            return termMap.entrySet().stream().map(termEntry -> {
-                String term = termEntry.getKey();
-                List<ActivityReportInfo> activityReportInfos = termEntry.getValue().stream()
-                    .map(ActivityReportInfo::new)
-                    .toList();
-                return ActivityReportListQuery.of(clubName, term, activityReportInfos);
-            });
-        }).toList();
+        return activityReportsGroupedByClubName.entrySet().stream()
+                .map(entry -> {
+                    List<ActivityReportInfo> activityReportInfos = entry.getValue().stream()
+                            .map(ActivityReportInfo::from)
+                            .toList();
+                    return new AdminActivityReportListQuery(entry.getKey(), activityReportInfos);
+                })
+                .toList();
     }
 }

--- a/src/main/java/ddingdong/ddingdongBE/domain/activityreport/service/FacadeAdminActivityReportServiceImpl.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/activityreport/service/FacadeAdminActivityReportServiceImpl.java
@@ -1,6 +1,6 @@
 package ddingdong.ddingdongBE.domain.activityreport.service;
 
-import ddingdong.ddingdongBE.domain.activityreport.domain.ActivityReport;
+import ddingdong.ddingdongBE.domain.activityreport.entity.ActivityReport;
 import ddingdong.ddingdongBE.domain.activityreport.service.dto.command.CreateActivityTermInfoCommand;
 import ddingdong.ddingdongBE.domain.activityreport.service.dto.query.ActivityReportInfo;
 import ddingdong.ddingdongBE.domain.activityreport.service.dto.query.ActivityReportListQuery;

--- a/src/main/java/ddingdong/ddingdongBE/domain/activityreport/service/FacadeClubActivityReportService.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/activityreport/service/FacadeClubActivityReportService.java
@@ -2,18 +2,16 @@ package ddingdong.ddingdongBE.domain.activityreport.service;
 
 import ddingdong.ddingdongBE.domain.activityreport.service.dto.command.CreateActivityReportCommand;
 import ddingdong.ddingdongBE.domain.activityreport.service.dto.command.UpdateActivityReportCommand;
-import ddingdong.ddingdongBE.domain.activityreport.service.dto.query.AdminActivityReportListQuery;
 import ddingdong.ddingdongBE.domain.activityreport.service.dto.query.ActivityReportQuery;
 import ddingdong.ddingdongBE.domain.activityreport.service.dto.query.ActivityReportTermInfoQuery;
 import ddingdong.ddingdongBE.domain.activityreport.service.dto.query.CentralActivityReportListQuery;
-import ddingdong.ddingdongBE.domain.club.entity.Club;
 import ddingdong.ddingdongBE.domain.user.entity.User;
 import java.time.LocalDateTime;
 import java.util.List;
 
 public interface FacadeClubActivityReportService {
 
-    List<ActivityReportQuery> getActivityReport(User user,  LocalDateTime now, String term);
+    List<ActivityReportQuery> getActivityReport(User user, LocalDateTime now, int term);
 
     List<CentralActivityReportListQuery> getMyActivityReports(User user, LocalDateTime now);
 
@@ -23,8 +21,8 @@ public interface FacadeClubActivityReportService {
 
     void create(User user, List<CreateActivityReportCommand> commands);
 
-    void update(User user, String term, LocalDateTime now, List<UpdateActivityReportCommand> commands);
+    void update(User user, LocalDateTime now, int term, List<UpdateActivityReportCommand> commands);
 
-    void delete(User user, String term, LocalDateTime now);
+    void delete(User user, LocalDateTime now, int term);
 
 }

--- a/src/main/java/ddingdong/ddingdongBE/domain/activityreport/service/FacadeClubActivityReportService.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/activityreport/service/FacadeClubActivityReportService.java
@@ -2,18 +2,20 @@ package ddingdong.ddingdongBE.domain.activityreport.service;
 
 import ddingdong.ddingdongBE.domain.activityreport.service.dto.command.CreateActivityReportCommand;
 import ddingdong.ddingdongBE.domain.activityreport.service.dto.command.UpdateActivityReportCommand;
-import ddingdong.ddingdongBE.domain.activityreport.service.dto.query.ActivityReportListQuery;
+import ddingdong.ddingdongBE.domain.activityreport.service.dto.query.AdminActivityReportListQuery;
 import ddingdong.ddingdongBE.domain.activityreport.service.dto.query.ActivityReportQuery;
 import ddingdong.ddingdongBE.domain.activityreport.service.dto.query.ActivityReportTermInfoQuery;
+import ddingdong.ddingdongBE.domain.activityreport.service.dto.query.CentralActivityReportListQuery;
+import ddingdong.ddingdongBE.domain.club.entity.Club;
 import ddingdong.ddingdongBE.domain.user.entity.User;
 import java.time.LocalDateTime;
 import java.util.List;
 
 public interface FacadeClubActivityReportService {
 
-    List<ActivityReportQuery> getActivityReport(String term, String clubName);
+    List<ActivityReportQuery> getActivityReport(User user,  LocalDateTime now, String term);
 
-    List<ActivityReportListQuery> getMyActivityReports(User user);
+    List<CentralActivityReportListQuery> getMyActivityReports(User user, LocalDateTime now);
 
     List<ActivityReportTermInfoQuery> getActivityReportTermInfos();
 
@@ -21,8 +23,8 @@ public interface FacadeClubActivityReportService {
 
     void create(User user, List<CreateActivityReportCommand> commands);
 
-    void update(User user, String term, List<UpdateActivityReportCommand> commands);
+    void update(User user, String term, LocalDateTime now, List<UpdateActivityReportCommand> commands);
 
-    void delete(User user, String term);
+    void delete(User user, String term, LocalDateTime now);
 
 }

--- a/src/main/java/ddingdong/ddingdongBE/domain/activityreport/service/FacadeClubActivityReportServiceImpl.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/activityreport/service/FacadeClubActivityReportServiceImpl.java
@@ -1,7 +1,7 @@
 package ddingdong.ddingdongBE.domain.activityreport.service;
 
-import ddingdong.ddingdongBE.domain.activityreport.domain.ActivityReport;
-import ddingdong.ddingdongBE.domain.activityreport.domain.ActivityReportTermInfo;
+import ddingdong.ddingdongBE.domain.activityreport.entity.ActivityReport;
+import ddingdong.ddingdongBE.domain.activityreport.entity.ActivityReportTermInfo;
 import ddingdong.ddingdongBE.domain.activityreport.service.dto.command.CreateActivityReportCommand;
 import ddingdong.ddingdongBE.domain.activityreport.service.dto.command.UpdateActivityReportCommand;
 import ddingdong.ddingdongBE.domain.activityreport.service.dto.query.ActivityReportInfo;

--- a/src/main/java/ddingdong/ddingdongBE/domain/activityreport/service/FacadeClubActivityReportServiceImpl.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/activityreport/service/FacadeClubActivityReportServiceImpl.java
@@ -37,7 +37,7 @@ public class FacadeClubActivityReportServiceImpl implements FacadeClubActivityRe
     private final S3FileService s3FileService;
 
     @Override
-    public List<ActivityReportQuery> getActivityReport(User user, LocalDateTime now, String term) {
+    public List<ActivityReportQuery> getActivityReport(User user, LocalDateTime now, int term) {
         Club club = clubService.getByUserId(user.getId());
         int currentYear = now.getYear();
         List<ActivityReport> activityReports = activityReportService.getActivityReport(club, currentYear, term);
@@ -87,8 +87,8 @@ public class FacadeClubActivityReportServiceImpl implements FacadeClubActivityRe
     @Override
     public void update(
             User user,
-            String term,
             LocalDateTime now,
+            int term,
             List<UpdateActivityReportCommand> commands
     ) {
         Club club = clubService.getByUserId(user.getId());
@@ -111,7 +111,7 @@ public class FacadeClubActivityReportServiceImpl implements FacadeClubActivityRe
 
     @Transactional
     @Override
-    public void delete(User user, String term, LocalDateTime now) {
+    public void delete(User user, LocalDateTime now, int term) {
         Club club = clubService.getByUserId(user.getId());
         int currentYear = now.getYear();
         List<ActivityReport> activityReports = activityReportService.getActivityReportOrThrow(club, currentYear, term);
@@ -131,7 +131,8 @@ public class FacadeClubActivityReportServiceImpl implements FacadeClubActivityRe
         return ActivityReportQuery.of(activityReport, image);
     }
 
-    private List<CentralActivityReportListQuery> parseToListQuery(String clubName, List<ActivityReport> activityReports) {
+    private List<CentralActivityReportListQuery> parseToListQuery(String clubName,
+            List<ActivityReport> activityReports) {
         Map<String, List<ActivityReport>> activityReportsGroupedByTerm = activityReports.stream()
                 .collect(Collectors.groupingBy(ActivityReport::getTerm));
 

--- a/src/main/java/ddingdong/ddingdongBE/domain/activityreport/service/dto/command/CreateActivityReportCommand.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/activityreport/service/dto/command/CreateActivityReportCommand.java
@@ -1,8 +1,8 @@
 package ddingdong.ddingdongBE.domain.activityreport.service.dto.command;
 
 import ddingdong.ddingdongBE.common.utils.TimeUtils;
-import ddingdong.ddingdongBE.domain.activityreport.domain.ActivityReport;
-import ddingdong.ddingdongBE.domain.activityreport.domain.Participant;
+import ddingdong.ddingdongBE.domain.activityreport.entity.ActivityReport;
+import ddingdong.ddingdongBE.domain.activityreport.entity.Participant;
 import ddingdong.ddingdongBE.domain.club.entity.Club;
 import java.util.List;
 import lombok.Builder;

--- a/src/main/java/ddingdong/ddingdongBE/domain/activityreport/service/dto/command/UpdateActivityReportCommand.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/activityreport/service/dto/command/UpdateActivityReportCommand.java
@@ -23,8 +23,8 @@ public record UpdateActivityReportCommand(
         return ActivityReport.builder()
                 .content(content)
                 .place(place)
-                .startDate(TimeUtils.processDate(startDate, LocalDateTime.now()))
-                .endDate(TimeUtils.processDate(endDate, LocalDateTime.now()))
+                .startDate(TimeUtils.processDate(startDate, now))
+                .endDate(TimeUtils.processDate(endDate, now))
                 .participants(participants)
                 .build();
     }

--- a/src/main/java/ddingdong/ddingdongBE/domain/activityreport/service/dto/command/UpdateActivityReportCommand.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/activityreport/service/dto/command/UpdateActivityReportCommand.java
@@ -1,8 +1,8 @@
 package ddingdong.ddingdongBE.domain.activityreport.service.dto.command;
 
 import ddingdong.ddingdongBE.common.utils.TimeUtils;
-import ddingdong.ddingdongBE.domain.activityreport.domain.ActivityReport;
-import ddingdong.ddingdongBE.domain.activityreport.domain.Participant;
+import ddingdong.ddingdongBE.domain.activityreport.entity.ActivityReport;
+import ddingdong.ddingdongBE.domain.activityreport.entity.Participant;
 import java.time.LocalDateTime;
 import java.util.List;
 import lombok.Builder;

--- a/src/main/java/ddingdong/ddingdongBE/domain/activityreport/service/dto/command/UpdateActivityReportCommand.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/activityreport/service/dto/command/UpdateActivityReportCommand.java
@@ -9,22 +9,23 @@ import lombok.Builder;
 
 @Builder
 public record UpdateActivityReportCommand(
-    String content,
-    String place,
-    String startDate,
-    String endDate,
-    String imageId,
-    List<Participant> participants
+        LocalDateTime now,
+        String content,
+        String place,
+        String startDate,
+        String endDate,
+        String imageId,
+        List<Participant> participants
 ) {
 
 
     public ActivityReport toEntity() {
         return ActivityReport.builder()
-            .content(content)
-            .place(place)
-            .startDate(TimeUtils.processDate(startDate, LocalDateTime.now()))
-            .endDate(TimeUtils.processDate(endDate, LocalDateTime.now()))
-            .participants(participants)
-            .build();
+                .content(content)
+                .place(place)
+                .startDate(TimeUtils.processDate(startDate, LocalDateTime.now()))
+                .endDate(TimeUtils.processDate(endDate, LocalDateTime.now()))
+                .participants(participants)
+                .build();
     }
 }

--- a/src/main/java/ddingdong/ddingdongBE/domain/activityreport/service/dto/query/ActivityReportInfo.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/activityreport/service/dto/query/ActivityReportInfo.java
@@ -1,6 +1,6 @@
 package ddingdong.ddingdongBE.domain.activityreport.service.dto.query;
 
-import ddingdong.ddingdongBE.domain.activityreport.domain.ActivityReport;
+import ddingdong.ddingdongBE.domain.activityreport.entity.ActivityReport;
 import lombok.Builder;
 
 @Builder

--- a/src/main/java/ddingdong/ddingdongBE/domain/activityreport/service/dto/query/ActivityReportQuery.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/activityreport/service/dto/query/ActivityReportQuery.java
@@ -1,7 +1,7 @@
 package ddingdong.ddingdongBE.domain.activityreport.service.dto.query;
 
-import ddingdong.ddingdongBE.domain.activityreport.domain.ActivityReport;
-import ddingdong.ddingdongBE.domain.activityreport.domain.Participant;
+import ddingdong.ddingdongBE.domain.activityreport.entity.ActivityReport;
+import ddingdong.ddingdongBE.domain.activityreport.entity.Participant;
 import ddingdong.ddingdongBE.file.service.dto.query.UploadedFileUrlQuery;
 import java.time.LocalDateTime;
 import java.util.List;

--- a/src/main/java/ddingdong/ddingdongBE/domain/activityreport/service/dto/query/ActivityReportTermInfoQuery.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/activityreport/service/dto/query/ActivityReportTermInfoQuery.java
@@ -1,6 +1,6 @@
 package ddingdong.ddingdongBE.domain.activityreport.service.dto.query;
 
-import ddingdong.ddingdongBE.domain.activityreport.domain.ActivityReportTermInfo;
+import ddingdong.ddingdongBE.domain.activityreport.entity.ActivityReportTermInfo;
 import java.time.LocalDate;
 import lombok.Builder;
 

--- a/src/main/java/ddingdong/ddingdongBE/domain/activityreport/service/dto/query/AdminActivityReportListQuery.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/activityreport/service/dto/query/AdminActivityReportListQuery.java
@@ -4,16 +4,14 @@ import java.util.List;
 import lombok.Builder;
 
 @Builder
-public record ActivityReportListQuery(
+public record AdminActivityReportListQuery(
     String name,
-    String term,
     List<ActivityReportInfo> activityReports
 ) {
 
-  public static ActivityReportListQuery of(String name, String term, List<ActivityReportInfo> activityReportInfos) {
-    return ActivityReportListQuery.builder()
+  public static AdminActivityReportListQuery of(String name, List<ActivityReportInfo> activityReportInfos) {
+    return AdminActivityReportListQuery.builder()
         .name(name)
-        .term(term)
         .activityReports(activityReportInfos)
         .build();
   }

--- a/src/main/java/ddingdong/ddingdongBE/domain/activityreport/service/dto/query/CentralActivityReportListQuery.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/activityreport/service/dto/query/CentralActivityReportListQuery.java
@@ -1,0 +1,24 @@
+package ddingdong.ddingdongBE.domain.activityreport.service.dto.query;
+
+import java.util.List;
+import lombok.Builder;
+
+@Builder
+public record CentralActivityReportListQuery(
+        String name,
+        String term,
+        List<ActivityReportInfo> activityReports
+) {
+
+    public static CentralActivityReportListQuery of(
+            String name,
+            String term,
+            List<ActivityReportInfo> activityReportInfos
+    ) {
+        return CentralActivityReportListQuery.builder()
+                .name(name)
+                .term(term)
+                .activityReports(activityReportInfos)
+                .build();
+    }
+}

--- a/src/test/java/ddingdong/ddingdongBE/domain/activityreport/entity/ActivityReportTest.java
+++ b/src/test/java/ddingdong/ddingdongBE/domain/activityreport/entity/ActivityReportTest.java
@@ -1,4 +1,4 @@
-package ddingdong.ddingdongBE.domain.activityreport.domain;
+package ddingdong.ddingdongBE.domain.activityreport.entity;
 
 import ddingdong.ddingdongBE.common.support.DataJpaTestSupport;
 import ddingdong.ddingdongBE.domain.activityreport.repository.ActivityReportRepository;


### PR DESCRIPTION
## 🚀 작업 내용
- 활동보고서 조회 API 수정
	- `as-is` : 모든 활동보고서 전체조회 
	- `to-be`: 해당 년도 회차에 맞는 활동보고서 조회
	- 올바르지 않은 조건 조회 수정
		- clubName 

## 🤔 고민했던 내용


## 💬 리뷰 중점사항
- 파일 체인지가 많습니다. 다음의 사항을 위주로 리뷰 부탁드립니다
	- `ActivityReportRepository`의 활동보고서 조회하는 쿼리
	- `FacadeClubActivityReportServiceImpl`, `FacadeAdminActivityReportServiceImpl`의 parseToListQuery 메서드
		- 기존에는 모든 활동보고서를 그룹핑하는 코드였지만 조회하는 활동보고서의 범위가 작아진 만큼 그룹핑 코드를 수정했습니다. 	

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - 관리자와 동아리 활동 보고서를 조회할 때, 정수형 기간 및 현재 시각 기반의 세밀한 필터링 기능이 도입되었습니다.
  - 응답 데이터가 보다 구체적인 정보로 제공되어 보고서 확인이 개선되었습니다.

- **Refactor**
  - API 엔드포인트와 서비스의 파라미터, 응답 구조가 일관성 있게 재정의되었습니다.
  - 전반적인 코드 구조 재조정을 통해 기능 구현이 보다 명확해졌습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->