### PR TITLE
[DDING-000] 사용자 동아리 전체 목록 조회시 쿼리 대량 발생 수정

### DIFF
--- a/src/main/java/ddingdong/ddingdongBE/domain/club/repository/ClubRepository.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/club/repository/ClubRepository.java
@@ -1,9 +1,14 @@
 package ddingdong.ddingdongBE.domain.club.repository;
 
 import ddingdong.ddingdongBE.domain.club.entity.Club;
+import ddingdong.ddingdongBE.domain.club.repository.dto.UserClubListInfo;
+import java.time.LocalDate;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
@@ -13,4 +18,24 @@ public interface ClubRepository extends JpaRepository<Club, Long> {
 
     @EntityGraph(attributePaths = {"clubMembers"})
     Optional<Club> findEntityGraphByUserId(Long userId);
+
+    @Query(value = """
+            SELECT c.id, c.name, c.category, c.tag, f.start_date AS start, f.end_date AS end
+                FROM club c
+                LEFT JOIN (
+                    SELECT f1.id, f1.club_id, f1.start_date, f1.end_date
+                    FROM form f1
+                    WHERE f1.id = (
+                            SELECT f2.id
+                            FROM form f2
+                            WHERE f2.club_id = f1.club_id
+                            ORDER BY LEAST(
+                                COALESCE(ABS(DATEDIFF(f2.start_date, :now)), 99999),
+                                COALESCE(ABS(DATEDIFF(f2.end_date, :now)), 99999)
+                            )
+                            LIMIT 1
+                    )
+                ) f ON c.id = f.club_id;
+            """, nativeQuery = true)
+    List<UserClubListInfo> findAllClubListInfo(@Param("now") LocalDate now);
 }

--- a/src/main/java/ddingdong/ddingdongBE/domain/club/repository/dto/UserClubListInfo.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/club/repository/dto/UserClubListInfo.java
@@ -1,0 +1,19 @@
+package ddingdong.ddingdongBE.domain.club.repository.dto;
+
+
+import java.time.LocalDate;
+
+public interface UserClubListInfo {
+
+    Long getId();
+
+    String getName();
+
+    String getCategory();
+
+    String getTag();
+
+    LocalDate getStart();
+
+    LocalDate getEnd();
+}

--- a/src/main/java/ddingdong/ddingdongBE/domain/club/service/ClubService.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/club/service/ClubService.java
@@ -1,6 +1,7 @@
 package ddingdong.ddingdongBE.domain.club.service;
 
 import ddingdong.ddingdongBE.domain.club.entity.Club;
+import ddingdong.ddingdongBE.domain.club.repository.dto.UserClubListInfo;
 import java.util.List;
 
 public interface ClubService {
@@ -18,4 +19,6 @@ public interface ClubService {
     void delete(Long clubId);
 
     Club getByUserIdWithFetch(Long userId);
+
+    List<UserClubListInfo> findAllClubListInfo();
 }

--- a/src/main/java/ddingdong/ddingdongBE/domain/club/service/FacadeUserClubServiceImpl.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/club/service/FacadeUserClubServiceImpl.java
@@ -36,10 +36,7 @@ public class FacadeUserClubServiceImpl implements FacadeUserClubService {
 
         List<UserClubListInfo> userClubListInfos = clubService.findAllClubListInfo();
         return userClubListInfos.stream()
-                .map(info -> {
-                    System.out.println("날짜 : " + info.getStart() + " " + info.getEnd());
-                    return UserClubListQuery.of(info, checkRecruit(now, info.getStart(), info.getEnd()).getText());
-                })
+                .map(info -> UserClubListQuery.of(info, checkRecruit(now, info.getStart(), info.getEnd()).getText()))
                 .toList();
     }
 

--- a/src/main/java/ddingdong/ddingdongBE/domain/club/service/FacadeUserClubServiceImpl.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/club/service/FacadeUserClubServiceImpl.java
@@ -6,6 +6,7 @@ import static ddingdong.ddingdongBE.domain.club.entity.RecruitmentStatus.RECRUIT
 
 import ddingdong.ddingdongBE.domain.club.entity.Club;
 import ddingdong.ddingdongBE.domain.club.entity.RecruitmentStatus;
+import ddingdong.ddingdongBE.domain.club.repository.dto.UserClubListInfo;
 import ddingdong.ddingdongBE.domain.club.service.dto.query.UserClubListQuery;
 import ddingdong.ddingdongBE.domain.club.service.dto.query.UserClubQuery;
 import ddingdong.ddingdongBE.domain.filemetadata.entity.DomainType;
@@ -32,13 +33,12 @@ public class FacadeUserClubServiceImpl implements FacadeUserClubService {
 
     @Override
     public List<UserClubListQuery> findAllWithRecruitTimeCheckPoint(LocalDate now) {
-        return clubService.findAll().stream()
-                .map(club -> {
-                    List<Form> forms = formService.getAllByClub(club);
-                    Form form = formService.findActiveForm(forms) != null
-                            ? formService.findActiveForm(forms)
-                            : formService.getNewestForm(forms);
-                    return UserClubListQuery.of(club, checkRecruit(now, form).getText());
+
+        List<UserClubListInfo> userClubListInfos = clubService.findAllClubListInfo();
+        return userClubListInfos.stream()
+                .map(info -> {
+                    System.out.println("날짜 : " + info.getStart() + " " + info.getEnd());
+                    return UserClubListQuery.of(info, checkRecruit(now, info.getStart(), info.getEnd()).getText());
                 })
                 .toList();
     }
@@ -58,11 +58,11 @@ public class FacadeUserClubServiceImpl implements FacadeUserClubService {
         );
     }
 
-    private RecruitmentStatus checkRecruit(LocalDate now, Form form) {
-        if (form == null || form.getStartDate().isAfter(now)) {
+    private RecruitmentStatus checkRecruit(LocalDate now, LocalDate startDate, LocalDate endDate) {
+        if (startDate == null || startDate.isAfter(now)) {
             return BEFORE_RECRUIT;
         }
-        return form.getEndDate().isAfter(now) || form.getEndDate().isEqual(now) ? RECRUITING : END_RECRUIT;
+        return endDate.isAfter(now) || endDate.isEqual(now) ? RECRUITING : END_RECRUIT;
     }
 
     private UploadedFileUrlQuery getFileKey(DomainType domainType, Long clubId) {

--- a/src/main/java/ddingdong/ddingdongBE/domain/club/service/GeneralClubService.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/club/service/GeneralClubService.java
@@ -3,6 +3,8 @@ package ddingdong.ddingdongBE.domain.club.service;
 import ddingdong.ddingdongBE.common.exception.PersistenceException.ResourceNotFound;
 import ddingdong.ddingdongBE.domain.club.entity.Club;
 import ddingdong.ddingdongBE.domain.club.repository.ClubRepository;
+import ddingdong.ddingdongBE.domain.club.repository.dto.UserClubListInfo;
+import java.time.LocalDate;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -40,6 +42,11 @@ public class GeneralClubService implements ClubService {
     public Club getByUserIdWithFetch(Long userId) {
         return clubRepository.findEntityGraphByUserId(userId)
                 .orElseThrow(() -> new ResourceNotFound("Club(userId=" + userId + ")를 찾을 수 없습니다."));
+    }
+
+    @Override
+    public List<UserClubListInfo> findAllClubListInfo() {
+        return clubRepository.findAllClubListInfo(LocalDate.now());
     }
 
     @Override

--- a/src/main/java/ddingdong/ddingdongBE/domain/club/service/dto/query/UserClubListQuery.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/club/service/dto/query/UserClubListQuery.java
@@ -1,6 +1,6 @@
 package ddingdong.ddingdongBE.domain.club.service.dto.query;
 
-import ddingdong.ddingdongBE.domain.club.entity.Club;
+import ddingdong.ddingdongBE.domain.club.repository.dto.UserClubListInfo;
 
 public record UserClubListQuery(
         Long id,
@@ -10,12 +10,12 @@ public record UserClubListQuery(
         String recruitStatus
 ) {
 
-    public static UserClubListQuery of(Club club, String recruitStatus) {
+    public static UserClubListQuery of(UserClubListInfo userClubListInfo, String recruitStatus) {
         return new UserClubListQuery(
-                club.getId(),
-                club.getName(),
-                club.getCategory(),
-                club.getTag(),
+                userClubListInfo.getId(),
+                userClubListInfo.getName(),
+                userClubListInfo.getCategory(),
+                userClubListInfo.getTag(),
                 recruitStatus
         );
     }

--- a/src/test/java/ddingdong/ddingdongBE/domain/club/repository/ClubRepositoryTest.java
+++ b/src/test/java/ddingdong/ddingdongBE/domain/club/repository/ClubRepositoryTest.java
@@ -1,0 +1,67 @@
+package ddingdong.ddingdongBE.domain.club.repository;
+
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
+
+import ddingdong.ddingdongBE.common.support.DataJpaTestSupport;
+import ddingdong.ddingdongBE.domain.club.entity.Club;
+import ddingdong.ddingdongBE.domain.club.repository.dto.UserClubListInfo;
+import ddingdong.ddingdongBE.domain.form.entity.Form;
+import ddingdong.ddingdongBE.domain.form.repository.FormRepository;
+import java.time.LocalDate;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+class ClubRepositoryTest extends DataJpaTestSupport {
+
+    @Autowired
+    private ClubRepository clubRepository;
+
+    @Autowired
+    private FormRepository formRepository;
+
+
+    @DisplayName("클럽 목록 전체조회에 필요한 모든 클럽 및 폼지 정보를 조회한다. 입력 날짜와 가장 가까운 폼지를 조회한다.")
+    @Test
+    void test() {
+        // given
+        Club club = Club.builder()
+                .user(null)
+                .name("이름1")
+                .build();
+        Club club2 = Club.builder()
+                .user(null)
+                .name("이름2")
+                .build();
+        clubRepository.saveAll(List.of(club, club2));
+        Form form = Form.builder()
+                .title("제목 1")
+                .startDate(LocalDate.of(2024, 12, 13))
+                .endDate(LocalDate.of(2024, 12, 20))
+                .hasInterview(false)
+                .sections(List.of())
+                .club(club)
+                .build();
+        Form form2 = Form.builder()
+                .title("제목 2")
+                .startDate(LocalDate.of(2024, 12, 7))
+                .endDate(LocalDate.of(2024, 12, 12))
+                .hasInterview(false)
+                .sections(List.of())
+                .club(club)
+                .build();
+        formRepository.saveAll(List.of(form, form2));
+        // when
+        List<UserClubListInfo> infos = clubRepository.findAllClubListInfo(LocalDate.of(2024, 12, 30));
+        // then
+
+        assertSoftly(softly -> {
+            softly.assertThat(infos.size()).isEqualTo(2);
+            softly.assertThat(infos.get(0).getName()).isEqualTo("이름1");
+            softly.assertThat(infos.get(1).getName()).isEqualTo("이름2");
+            softly.assertThat(infos.get(0).getStart()).isEqualTo(LocalDate.of(2024, 12, 13));
+            softly.assertThat(infos.get(0).getEnd()).isEqualTo(LocalDate.of(2024, 12, 20));
+        });
+    }
+}


### PR DESCRIPTION
## 🚀 작업 내용
메인페이지 내 클럽 전체 목록 조회 시 쿼리 대량발생하여 서버에 큰 무리가 있었습니다.
이를 조인과 서브쿼리를 활용하여 해결하였습니다.

쿼리 142 -> 1번으로 줄였습니다

## 🤔 고민했던 내용
쿼리 가독성이 많이 떨어져요,, ㅎㅎ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
  - 클럽 목록 조회 기능이 개선되어, 사용자에게 클럽 모집 기간(시작일 및 종료일 포함)을 비롯한 보다 상세한 정보가 제공됩니다.
  - 클럽 서비스에서 사용자 클럽 목록 정보를 조회하는 새로운 메소드가 추가되었습니다.
- **버그 수정**
  - 클럽 정보 처리 로직이 업데이트되어, 모집 일정 관련 데이터의 정확성이 향상되었습니다.
- **테스트**
  - 클럽 레포지토리에 대한 새로운 테스트 클래스가 추가되어, 클럽 및 폼 정보를 올바르게 조회하는지 검증합니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->