### PR TITLE
[DDING-000] 어드민 - 활동보고서 상세 조회 API 구현

### DIFF
--- a/src/main/java/ddingdong/ddingdongBE/domain/activityreport/api/AdminActivityReportApi.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/activityreport/api/AdminActivityReportApi.java
@@ -1,6 +1,7 @@
 package ddingdong.ddingdongBE.domain.activityreport.api;
 
 import ddingdong.ddingdongBE.domain.activityreport.controller.dto.request.CreateActivityTermInfoRequest;
+import ddingdong.ddingdongBE.domain.activityreport.controller.dto.response.ActivityReportResponse;
 import ddingdong.ddingdongBE.domain.activityreport.controller.dto.response.AdminActivityReportListResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -15,21 +16,33 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseStatus;
 
 @Tag(name = "Activity Report - Admin", description = "Activity Report Admin API")
 @RequestMapping("/server/admin/activity-reports")
 public interface AdminActivityReportApi {
 
-    @Operation(summary = "활동 보고서 전체 조회")
+    @Operation(summary = "어드민 - 활동 보고서 전체 조회")
     @ApiResponse(responseCode = "200", description = "활동 보고서 전체 조회 성공",
         content = @Content(schema = @Schema(implementation = AdminActivityReportListResponse.class)))
     @ResponseStatus(HttpStatus.OK)
     @SecurityRequirement(name = "AccessToken")
-    @GetMapping("/{term}")
-    List<AdminActivityReportListResponse> getActivityReports(@PathVariable("term") int term);
+    @GetMapping()
+    List<AdminActivityReportListResponse> getActivityReports(@RequestParam("term") int term);
 
-    @Operation(summary = "활동 보고서 회차별 기간 설정 API")
+    @Operation(summary = "어드민 - 활동보고서 상세 조회")
+    @ApiResponse(responseCode = "200", description = "활동보고서 상세 조회 성공",
+            content = @Content(schema = @Schema(implementation = ActivityReportResponse.class)))
+    @ResponseStatus(HttpStatus.OK)
+    @SecurityRequirement(name = "AccessToken")
+    @GetMapping("/clubs/{clubId}")
+    List<ActivityReportResponse> getActivityReport(
+            @PathVariable("clubId") Long clubId,
+            @RequestParam("term") int term
+    );
+
+    @Operation(summary = "어드민 - 활동 보고서 회차별 기간 설정 API")
     @ApiResponse(responseCode = "201", description = "활동 보고서 회차 생성 성공")
     @ResponseStatus(HttpStatus.CREATED)
     @SecurityRequirement(name = "AccessToken")

--- a/src/main/java/ddingdong/ddingdongBE/domain/activityreport/controller/AdminActivityReportApiController.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/activityreport/controller/AdminActivityReportApiController.java
@@ -2,8 +2,10 @@ package ddingdong.ddingdongBE.domain.activityreport.controller;
 
 import ddingdong.ddingdongBE.domain.activityreport.api.AdminActivityReportApi;
 import ddingdong.ddingdongBE.domain.activityreport.controller.dto.request.CreateActivityTermInfoRequest;
+import ddingdong.ddingdongBE.domain.activityreport.controller.dto.response.ActivityReportResponse;
 import ddingdong.ddingdongBE.domain.activityreport.controller.dto.response.AdminActivityReportListResponse;
 import ddingdong.ddingdongBE.domain.activityreport.service.FacadeAdminActivityReportService;
+import ddingdong.ddingdongBE.domain.activityreport.service.dto.query.ActivityReportQuery;
 import ddingdong.ddingdongBE.domain.activityreport.service.dto.query.AdminActivityReportListQuery;
 import java.time.LocalDateTime;
 import java.util.List;
@@ -22,6 +24,15 @@ public class AdminActivityReportApiController implements AdminActivityReportApi 
         List<AdminActivityReportListQuery> queries = facadeAdminActivityReportService.getActivityReports(now, term);
         return queries.stream()
                 .map(AdminActivityReportListResponse::from)
+                .toList();
+    }
+
+    @Override
+    public List<ActivityReportResponse> getActivityReport(Long clubId, int term) {
+        LocalDateTime now = LocalDateTime.now();
+        List<ActivityReportQuery> queries = facadeAdminActivityReportService.getActivityReport(clubId, now, term);
+        return queries.stream()
+                .map(ActivityReportResponse::from)
                 .toList();
     }
 

--- a/src/main/java/ddingdong/ddingdongBE/domain/activityreport/controller/dto/response/AdminActivityReportListResponse.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/activityreport/controller/dto/response/AdminActivityReportListResponse.java
@@ -7,21 +7,29 @@ import lombok.Builder;
 
 @Builder
 public record AdminActivityReportListResponse(
-    @Schema(description = "동아리 이름", example = "카우")
-    String name,
+        AdminActivityReportListClubResponse club,
 
-    @Schema(description = "활동보고서 정보")
-    List<ActivityReportDto> activityReports
+        @Schema(description = "활동보고서 정보")
+        List<ActivityReportDto> activityReports
 ) {
 
     public static AdminActivityReportListResponse from(AdminActivityReportListQuery query) {
         List<ActivityReportDto> activityReports = query.activityReports().stream()
-            .map(ActivityReportDto::from)
-            .toList();
+                .map(ActivityReportDto::from)
+                .toList();
 
         return AdminActivityReportListResponse.builder()
-            .name(query.name())
-            .activityReports(activityReports)
-            .build();
+                .club(new AdminActivityReportListClubResponse(query.clubId(), query.clubName()))
+                .activityReports(activityReports)
+                .build();
+    }
+
+    public record AdminActivityReportListClubResponse(
+            @Schema(description = "동아리 식별자", example = "1")
+            Long id,
+            @Schema(description = "동아리 이름", example = "카우")
+            String name
+    ) {
+
     }
 }

--- a/src/main/java/ddingdong/ddingdongBE/domain/activityreport/service/FacadeAdminActivityReportService.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/activityreport/service/FacadeAdminActivityReportService.java
@@ -1,6 +1,7 @@
 package ddingdong.ddingdongBE.domain.activityreport.service;
 
 import ddingdong.ddingdongBE.domain.activityreport.service.dto.command.CreateActivityTermInfoCommand;
+import ddingdong.ddingdongBE.domain.activityreport.service.dto.query.ActivityReportQuery;
 import ddingdong.ddingdongBE.domain.activityreport.service.dto.query.AdminActivityReportListQuery;
 import java.time.LocalDateTime;
 import java.util.List;
@@ -8,6 +9,8 @@ import java.util.List;
 public interface FacadeAdminActivityReportService {
 
     List<AdminActivityReportListQuery> getActivityReports(LocalDateTime now, int term);
+
+    List<ActivityReportQuery> getActivityReport(Long clubId, LocalDateTime now, int term);
 
     void createActivityTermInfo(CreateActivityTermInfoCommand command);
 }

--- a/src/main/java/ddingdong/ddingdongBE/domain/activityreport/service/FacadeAdminActivityReportServiceImpl.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/activityreport/service/FacadeAdminActivityReportServiceImpl.java
@@ -34,15 +34,15 @@ public class FacadeAdminActivityReportServiceImpl implements FacadeAdminActivity
     }
 
     private List<AdminActivityReportListQuery> parseToListQuery(final List<ActivityReport> activityReports) {
-        Map<String, List<ActivityReport>> activityReportsGroupedByClubName = activityReports.stream()
-                .collect(Collectors.groupingBy(report -> report.getClub().getName()));
+        Map<Club, List<ActivityReport>> activityReportsGroupedByClubName = activityReports.stream()
+                .collect(Collectors.groupingBy(ActivityReport::getClub));
 
         return activityReportsGroupedByClubName.entrySet().stream()
                 .map(entry -> {
                     List<ActivityReportInfo> activityReportInfos = entry.getValue().stream()
                             .map(ActivityReportInfo::from)
                             .toList();
-                    return new AdminActivityReportListQuery(entry.getKey(), activityReportInfos);
+                    return AdminActivityReportListQuery.of(entry.getKey(), activityReportInfos);
                 })
                 .toList();
     }

--- a/src/main/java/ddingdong/ddingdongBE/domain/activityreport/service/FacadeAdminActivityReportServiceImpl.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/activityreport/service/FacadeAdminActivityReportServiceImpl.java
@@ -3,7 +3,14 @@ package ddingdong.ddingdongBE.domain.activityreport.service;
 import ddingdong.ddingdongBE.domain.activityreport.entity.ActivityReport;
 import ddingdong.ddingdongBE.domain.activityreport.service.dto.command.CreateActivityTermInfoCommand;
 import ddingdong.ddingdongBE.domain.activityreport.service.dto.query.ActivityReportInfo;
+import ddingdong.ddingdongBE.domain.activityreport.service.dto.query.ActivityReportQuery;
 import ddingdong.ddingdongBE.domain.activityreport.service.dto.query.AdminActivityReportListQuery;
+import ddingdong.ddingdongBE.domain.club.entity.Club;
+import ddingdong.ddingdongBE.domain.club.service.ClubService;
+import ddingdong.ddingdongBE.domain.filemetadata.entity.DomainType;
+import ddingdong.ddingdongBE.domain.filemetadata.service.FileMetaDataService;
+import ddingdong.ddingdongBE.file.service.S3FileService;
+import ddingdong.ddingdongBE.file.service.dto.query.UploadedFileUrlQuery;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
@@ -17,8 +24,11 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional(readOnly = true)
 public class FacadeAdminActivityReportServiceImpl implements FacadeAdminActivityReportService {
 
+    private final ClubService clubService;
     private final ActivityReportTermInfoService activityReportTermInfoService;
     private final ActivityReportService activityReportService;
+    private final FileMetaDataService fileMetaDataService;
+    private final S3FileService s3FileService;
 
     @Override
     public List<AdminActivityReportListQuery> getActivityReports(LocalDateTime now, int term) {
@@ -27,10 +37,31 @@ public class FacadeAdminActivityReportServiceImpl implements FacadeAdminActivity
         return parseToListQuery(activityReports);
     }
 
+    @Override
+    public List<ActivityReportQuery> getActivityReport(Long clubId, LocalDateTime now, int term) {
+        Club club = clubService.getById(clubId);
+        int currentYear = now.getYear();
+        List<ActivityReport> activityReports = activityReportService.getActivityReport(club, currentYear, term);
+
+        return activityReports.stream()
+                .map(this::parseToQuery)
+                .toList();
+    }
+
     @Transactional
     @Override
     public void createActivityTermInfo(CreateActivityTermInfoCommand command) {
         activityReportTermInfoService.create(command.startDate(), command.totalTermCount());
+    }
+
+    private ActivityReportQuery parseToQuery(ActivityReport activityReport) {
+        UploadedFileUrlQuery image = fileMetaDataService
+                .getCoupledAllByDomainTypeAndEntityId(DomainType.ACTIVITY_REPORT_IMAGE, activityReport.getId())
+                .stream()
+                .map(fileMetaData -> s3FileService.getUploadedFileUrl(fileMetaData.getFileKey()))
+                .findFirst()
+                .orElse(null);
+        return ActivityReportQuery.of(activityReport, image);
     }
 
     private List<AdminActivityReportListQuery> parseToListQuery(final List<ActivityReport> activityReports) {

--- a/src/main/java/ddingdong/ddingdongBE/domain/activityreport/service/dto/query/AdminActivityReportListQuery.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/activityreport/service/dto/query/AdminActivityReportListQuery.java
@@ -1,18 +1,21 @@
 package ddingdong.ddingdongBE.domain.activityreport.service.dto.query;
 
+import ddingdong.ddingdongBE.domain.club.entity.Club;
 import java.util.List;
 import lombok.Builder;
 
 @Builder
 public record AdminActivityReportListQuery(
-    String name,
-    List<ActivityReportInfo> activityReports
+        Long clubId,
+        String clubName,
+        List<ActivityReportInfo> activityReports
 ) {
 
-  public static AdminActivityReportListQuery of(String name, List<ActivityReportInfo> activityReportInfos) {
-    return AdminActivityReportListQuery.builder()
-        .name(name)
-        .activityReports(activityReportInfos)
-        .build();
-  }
+    public static AdminActivityReportListQuery of(Club club, List<ActivityReportInfo> activityReportInfos) {
+        return AdminActivityReportListQuery.builder()
+                .clubId(club.getId())
+                .clubName(club.getName())
+                .activityReports(activityReportInfos)
+                .build();
+    }
 }


### PR DESCRIPTION
## 🚀 작업 내용
- 기존 공통으로 사용하던 중앙동아리 활동보고서 상세 조회 API 별도의 상세조회 요구사항에 따른 API 구현
	- `GET` /server/admin/activity-reports/clubs/{clubid}
		- query parater: term
- 어드민 - 활동보고서 전체 조회 응답 필드 추가
	- club 식별자 

## 🤔 고민했던 내용
## 💬 리뷰 중점사항

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - 관리자 활동 리포트 상세 조회 기능이 추가되었습니다. 관리자는 특정 클럽과 기간에 대한 상세 활동 리포트를 확인할 수 있습니다.

- **Refactor**
  - 활동 리포트 조회 API가 개선되어, 요청 파라미터와 응답 데이터에 클럽 정보(클럽 ID 및 이름)가 포함됩니다.
  - 데이터 처리 방식이 업데이트되어 보다 명확한 리포트 정보를 전달합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->