### PR TITLE
[DDING-124] 폼지 종료일자 수정 API 구현

### DIFF
--- a/src/main/java/ddingdong/ddingdongBE/common/exception/FormException.java
+++ b/src/main/java/ddingdong/ddingdongBE/common/exception/FormException.java
@@ -5,8 +5,9 @@ import static org.springframework.http.HttpStatus.BAD_REQUEST;
 public class FormException extends CustomException {
 
     public static final String FORM_PERIOD_ERROR_MESSAGE = "해당 폼지의 응답기간이 아닙니다";
-    private static final String INVALID_FORM_DATE_MESSAGE = "입력한 기간과 겹치는 폼이 존재합니다.";
+    private static final String OVERLAP_FORM_DATE_MESSAGE = "입력한 기간과 겹치는 폼이 존재합니다.";
     private static final String INVALID_FIELD_TYPE_MESSAGE = "통계를 조회할 질문 유형이 올바르지 않습니다.";
+    private static final String INVALID_FORM_DATE_MESSAGE = "폼지 종료일자는 폼지 시작일자 이전일 수 없습니다.";
 
 
     public FormException(String message, int errorCode) {
@@ -23,6 +24,13 @@ public class FormException extends CustomException {
     public static final class OverlapFormPeriodException extends FormException {
 
         public OverlapFormPeriodException() {
+            super(OVERLAP_FORM_DATE_MESSAGE, BAD_REQUEST.value());
+        }
+    }
+
+    public static final class InvalidFormEndDateException extends FormException {
+
+        public InvalidFormEndDateException() {
             super(INVALID_FORM_DATE_MESSAGE, BAD_REQUEST.value());
         }
     }

--- a/src/main/java/ddingdong/ddingdongBE/common/exception/FormException.java
+++ b/src/main/java/ddingdong/ddingdongBE/common/exception/FormException.java
@@ -5,7 +5,7 @@ import static org.springframework.http.HttpStatus.BAD_REQUEST;
 public class FormException extends CustomException {
 
     public static final String FORM_PERIOD_ERROR_MESSAGE = "해당 폼지의 응답기간이 아닙니다";
-    private static final String OVERLAP_FORM_DATE_MESSAGE = "입력한 기간과 겹치는 폼이 존재합니다.";
+    private static final String OVERLAPPED_FORM_DATE_MESSAGE = "입력한 기간과 겹치는 폼이 존재합니다.";
     private static final String INVALID_FIELD_TYPE_MESSAGE = "통계를 조회할 질문 유형이 올바르지 않습니다.";
     private static final String INVALID_FORM_DATE_MESSAGE = "폼지 종료일자는 폼지 시작일자 이전일 수 없습니다.";
 
@@ -24,7 +24,7 @@ public class FormException extends CustomException {
     public static final class OverlapFormPeriodException extends FormException {
 
         public OverlapFormPeriodException() {
-            super(OVERLAP_FORM_DATE_MESSAGE, BAD_REQUEST.value());
+            super(OVERLAPPED_FORM_DATE_MESSAGE, BAD_REQUEST.value());
         }
     }
 

--- a/src/main/java/ddingdong/ddingdongBE/domain/form/api/CentralFormApi.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/form/api/CentralFormApi.java
@@ -3,6 +3,7 @@ package ddingdong.ddingdongBE.domain.form.api;
 import ddingdong.ddingdongBE.auth.PrincipalDetails;
 import ddingdong.ddingdongBE.domain.form.controller.dto.request.CreateFormRequest;
 import ddingdong.ddingdongBE.domain.form.controller.dto.request.SendApplicationResultEmailRequest;
+import ddingdong.ddingdongBE.domain.form.controller.dto.request.UpdateFormEndDateRequest;
 import ddingdong.ddingdongBE.domain.form.controller.dto.request.UpdateFormRequest;
 import ddingdong.ddingdongBE.domain.form.controller.dto.response.FormListResponse;
 import ddingdong.ddingdongBE.domain.form.controller.dto.response.FormResponse;
@@ -22,6 +23,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
@@ -125,4 +127,15 @@ public interface CentralFormApi {
     void sendApplicationResultEmail(@PathVariable("formId") Long formId,
                                     @AuthenticationPrincipal PrincipalDetails principalDetails,
                                     @RequestBody SendApplicationResultEmailRequest request);
+
+    @Operation(summary = "동아리 폼지 종료일자 수정 API")
+    @ApiResponse(responseCode = "204", description = "동아리 폼지 지원기간 마감일자 수정 성공")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    @SecurityRequirement(name = "AccessToken")
+    @PatchMapping("/my/forms/{formId}/deadline")
+    void updateFormEndDate(
+            @Valid @RequestBody UpdateFormEndDateRequest updateFormEndDateRequest,
+            @PathVariable("formId") Long formId,
+            @AuthenticationPrincipal PrincipalDetails principalDetails
+    );
 }

--- a/src/main/java/ddingdong/ddingdongBE/domain/form/controller/CentralFormController.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/form/controller/CentralFormController.java
@@ -4,6 +4,7 @@ import ddingdong.ddingdongBE.auth.PrincipalDetails;
 import ddingdong.ddingdongBE.domain.form.api.CentralFormApi;
 import ddingdong.ddingdongBE.domain.form.controller.dto.request.CreateFormRequest;
 import ddingdong.ddingdongBE.domain.form.controller.dto.request.SendApplicationResultEmailRequest;
+import ddingdong.ddingdongBE.domain.form.controller.dto.request.UpdateFormEndDateRequest;
 import ddingdong.ddingdongBE.domain.form.controller.dto.request.UpdateFormRequest;
 import ddingdong.ddingdongBE.domain.form.controller.dto.response.FormListResponse;
 import ddingdong.ddingdongBE.domain.form.controller.dto.response.FormResponse;
@@ -103,5 +104,12 @@ public class CentralFormController implements CentralFormApi {
     ) {
         User user = principalDetails.getUser();
         facadeCentralFormService.sendApplicationResultEmail(request.toCommand(user.getId(), formId));
+    }
+
+    @Override
+    public void updateFormEndDate(UpdateFormEndDateRequest updateFormEndDateRequest, Long formId,
+            PrincipalDetails principalDetails) {
+        User user = principalDetails.getUser();
+        facadeCentralFormService.updateFormEndDate(updateFormEndDateRequest.toCommand(user, formId));
     }
 }

--- a/src/main/java/ddingdong/ddingdongBE/domain/form/controller/dto/request/UpdateFormEndDateRequest.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/form/controller/dto/request/UpdateFormEndDateRequest.java
@@ -3,10 +3,14 @@ package ddingdong.ddingdongBE.domain.form.controller.dto.request;
 import ddingdong.ddingdongBE.domain.form.service.dto.command.UpdateFormEndDateCommand;
 import ddingdong.ddingdongBE.domain.user.entity.User;
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import com.fasterxml.jackson.annotation.JsonFormat;
 import java.time.LocalDate;
 
 public record UpdateFormEndDateRequest (
         @Schema(description = "폼지 종료일자", example = "2025-03-10")
+        @NotNull(message = "폼지 종료일자는 null이 될 수 없습니다.")
+        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
         LocalDate endDate
 ){
     public UpdateFormEndDateCommand toCommand(User user, Long formId) {

--- a/src/main/java/ddingdong/ddingdongBE/domain/form/controller/dto/request/UpdateFormEndDateRequest.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/form/controller/dto/request/UpdateFormEndDateRequest.java
@@ -1,0 +1,19 @@
+package ddingdong.ddingdongBE.domain.form.controller.dto.request;
+
+import ddingdong.ddingdongBE.domain.form.service.dto.command.UpdateFormEndDateCommand;
+import ddingdong.ddingdongBE.domain.user.entity.User;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.LocalDate;
+
+public record UpdateFormEndDateRequest (
+        @Schema(description = "폼지 종료일자", example = "2025-03-10")
+        LocalDate endDate
+){
+    public UpdateFormEndDateCommand toCommand(User user, Long formId) {
+        return UpdateFormEndDateCommand.builder()
+                .user(user)
+                .formId(formId)
+                .endDate(endDate)
+                .build();
+    }
+}

--- a/src/main/java/ddingdong/ddingdongBE/domain/form/entity/Form.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/form/entity/Form.java
@@ -80,5 +80,7 @@ public class Form extends BaseEntity {
         return this.id.equals(formId);
     }
 
-    public void updateEndDate(LocalDate endDate) { this.endDate = endDate; }
+    public void updateEndDate(LocalDate endDate) {
+        this.endDate = endDate;
+    }
 }

--- a/src/main/java/ddingdong/ddingdongBE/domain/form/entity/Form.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/form/entity/Form.java
@@ -79,4 +79,6 @@ public class Form extends BaseEntity {
     public boolean isEqualsById(Long formId) {
         return this.id.equals(formId);
     }
+
+    public void updateEndDate(LocalDate endDate) { this.endDate = endDate; }
 }

--- a/src/main/java/ddingdong/ddingdongBE/domain/form/service/FacadeCentralFormService.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/form/service/FacadeCentralFormService.java
@@ -3,6 +3,7 @@ package ddingdong.ddingdongBE.domain.form.service;
 import ddingdong.ddingdongBE.domain.form.service.dto.command.CreateFormCommand;
 import ddingdong.ddingdongBE.domain.form.service.dto.command.SendApplicationResultEmailCommand;
 import ddingdong.ddingdongBE.domain.form.service.dto.command.UpdateFormCommand;
+import ddingdong.ddingdongBE.domain.form.service.dto.command.UpdateFormEndDateCommand;
 import ddingdong.ddingdongBE.domain.form.service.dto.query.FormListQuery;
 import ddingdong.ddingdongBE.domain.form.service.dto.query.FormQuery;
 import ddingdong.ddingdongBE.domain.form.service.dto.query.FormStatisticsQuery;
@@ -32,4 +33,6 @@ public interface FacadeCentralFormService {
     SingleFieldStatisticsQuery getTextFieldStatistics(Long fieldId);
 
     void sendApplicationResultEmail(SendApplicationResultEmailCommand command);
+
+    void updateFormEndDate(UpdateFormEndDateCommand command);
 }

--- a/src/main/java/ddingdong/ddingdongBE/domain/form/service/FacadeCentralFormServiceImpl.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/form/service/FacadeCentralFormServiceImpl.java
@@ -4,6 +4,7 @@ import static ddingdong.ddingdongBE.domain.club.entity.Position.MEMBER;
 
 import ddingdong.ddingdongBE.common.exception.AuthenticationException.NonHaveAuthority;
 import ddingdong.ddingdongBE.common.exception.FormException.InvalidFieldTypeException;
+import ddingdong.ddingdongBE.common.exception.FormException.InvalidFormEndDateException;
 import ddingdong.ddingdongBE.common.exception.FormException.OverlapFormPeriodException;
 import ddingdong.ddingdongBE.domain.club.entity.Club;
 import ddingdong.ddingdongBE.domain.club.service.ClubService;
@@ -198,7 +199,10 @@ public class FacadeCentralFormServiceImpl implements FacadeCentralFormService {
     @Transactional
     @Override
     public void updateFormEndDate(UpdateFormEndDateCommand command) {
+        Club club = clubService.getByUserId(command.user().getId());
         Form form = formService.getById(command.formId());
+        validateEndDate(form.getStartDate(), command.endDate());
+        validateDuplicationDateExcludingSelf(club, form.getStartDate(), command.endDate(), command.formId());
         form.updateEndDate(command.endDate());
     }
 
@@ -241,6 +245,10 @@ public class FacadeCentralFormServiceImpl implements FacadeCentralFormService {
         if (!overlappingForms.isEmpty()) {
             throw new OverlapFormPeriodException();
         }
+    }
+
+    private void validateEndDate(LocalDate startDate, LocalDate endDate) {
+        if (startDate.isAfter(endDate)) { throw new InvalidFormEndDateException(); }
     }
 
     private List<FormField> toUpdateFormFields(Form originform,

--- a/src/main/java/ddingdong/ddingdongBE/domain/form/service/FacadeCentralFormServiceImpl.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/form/service/FacadeCentralFormServiceImpl.java
@@ -18,6 +18,7 @@ import ddingdong.ddingdongBE.domain.form.service.dto.command.CreateFormCommand.C
 import ddingdong.ddingdongBE.domain.form.service.dto.command.SendApplicationResultEmailCommand;
 import ddingdong.ddingdongBE.domain.form.service.dto.command.UpdateFormCommand;
 import ddingdong.ddingdongBE.domain.form.service.dto.command.UpdateFormCommand.UpdateFormFieldCommand;
+import ddingdong.ddingdongBE.domain.form.service.dto.command.UpdateFormEndDateCommand;
 import ddingdong.ddingdongBE.domain.form.service.dto.query.FormListQuery;
 import ddingdong.ddingdongBE.domain.form.service.dto.query.FormQuery;
 import ddingdong.ddingdongBE.domain.form.service.dto.query.FormStatisticsQuery;
@@ -192,6 +193,13 @@ public class FacadeCentralFormServiceImpl implements FacadeCentralFormService {
             log.error("Failed to send bulk emails", e);
             throw new RuntimeException("이메일 전송 중 오류가 발생했습니다.", e);
         }
+    }
+
+    @Transactional
+    @Override
+    public void updateFormEndDate(UpdateFormEndDateCommand command) {
+        Form form = formService.getById(command.formId());
+        form.updateEndDate(command.endDate());
     }
 
     private FormListQuery buildFormListQuery(Form form) {

--- a/src/main/java/ddingdong/ddingdongBE/domain/form/service/FacadeCentralFormServiceImpl.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/form/service/FacadeCentralFormServiceImpl.java
@@ -248,7 +248,7 @@ public class FacadeCentralFormServiceImpl implements FacadeCentralFormService {
     }
 
     private void validateEndDate(LocalDate startDate, LocalDate endDate) {
-        if (startDate.isAfter(endDate)) { throw new InvalidFormEndDateException(); }
+        if (endDate.isBefore(startDate)) { throw new InvalidFormEndDateException(); }
     }
 
     private List<FormField> toUpdateFormFields(Form originform,

--- a/src/main/java/ddingdong/ddingdongBE/domain/form/service/dto/command/UpdateFormEndDateCommand.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/form/service/dto/command/UpdateFormEndDateCommand.java
@@ -1,0 +1,14 @@
+package ddingdong.ddingdongBE.domain.form.service.dto.command;
+
+import ddingdong.ddingdongBE.domain.user.entity.User;
+import java.time.LocalDate;
+import lombok.Builder;
+
+@Builder
+public record UpdateFormEndDateCommand (
+        Long formId,
+        LocalDate endDate,
+        User user
+){
+
+}


### PR DESCRIPTION
## 🚀 작업 내용
폼지 종료일자 수정 API 구현했습니다.

예외처리
1. 사용자 입력 종료일자와 겹치는 일자의 폼이 있다면 수정되지 못하게끔 막았습니다.
2. 사용자 입력 종료일자가 해당 폼지 시작일자의 이전일 경우 예외처리 했습니다.

## 🤔 고민했던 내용
FormException 클래스에 지원기간 중복 에러 메시지가 INVALID_FORM_DATE_MESSAGE로 정의되어 있어서 이를 OVERLAP_FORM_DATE_MESSAGE로 수정하고 위 예외처리의 2번 경우를 INVALID_FORM_DATE_MESSAGE로 정의했는데 괜찮을까요?

## 💬 리뷰 중점사항


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **새로운 기능**
  - 폼 종료일을 업데이트할 수 있는 새로운 API 엔드포인트가 추가되었습니다.
  - 종료일 갱신 시, 폼 시작일보다 이전인 날짜 입력에 대해 명확한 오류 메시지와 함께 유효성 검증이 강화되었습니다.
  - 폼 종료일 업데이트를 위한 커맨드 객체가 추가되었습니다.
  - 폼 종료일을 업데이트하는 기능이 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->