### PR TITLE
[DDING-001] 폼지 수정 로직 개선

### DIFF
--- a/src/main/java/ddingdong/ddingdongBE/domain/club/entity/Club.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/club/entity/Club.java
@@ -117,7 +117,7 @@ public class Club extends BaseEntity {
 
     public void addClubMember(ClubMember clubMember) {
         this.clubMembers.add(clubMember);
-        clubMember.setClubFormConvenience(this);
+        clubMember.setClubForConvenience(this);
     }
 
     public String getClubUrl() {

--- a/src/main/java/ddingdong/ddingdongBE/domain/clubmember/entity/ClubMember.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/clubmember/entity/ClubMember.java
@@ -70,7 +70,7 @@ public class ClubMember extends BaseEntity {
         this.department = updateClubMember.getDepartment();
     }
 
-    public void setClubFormConvenience(Club club) {
+    public void setClubForConvenience(Club club) {
         this.club = club;
     }
 }

--- a/src/main/java/ddingdong/ddingdongBE/domain/form/controller/dto/request/UpdateFormRequest.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/form/controller/dto/request/UpdateFormRequest.java
@@ -39,6 +39,9 @@ public record UpdateFormRequest(
 ) {
 
     record UpdateFormFieldRequest(
+            @Schema(description = "폼지 질문 식별자", example = "1")
+            Long id,
+
             @Schema(description = "폼지 질문", example = "우리 동아리 들어올겁니까?")
             @NotNull(message = "질문는 null이 될 수 없습니다.")
             String question,

--- a/src/main/java/ddingdong/ddingdongBE/domain/form/controller/dto/request/UpdateFormRequest.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/form/controller/dto/request/UpdateFormRequest.java
@@ -68,6 +68,7 @@ public record UpdateFormRequest(
 
         public UpdateFormFieldCommand toCommand() {
             return UpdateFormFieldCommand.builder()
+                    .id(id)
                     .question(question)
                     .type(FieldType.findType(type))
                     .options(options)

--- a/src/main/java/ddingdong/ddingdongBE/domain/form/controller/dto/response/FormResponse.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/form/controller/dto/response/FormResponse.java
@@ -29,6 +29,8 @@ public record FormResponse(
 
     @Builder
     record FormFieldListResponse(
+            @Schema(description = "폼지 질문 식별자", example = "1")
+            Long id,
             @Schema(description = "폼지 질문", example = "당신의 이름은?")
             String question,
             @Schema(description = "폼지 질문 유형", example = "CHECK_BOX")
@@ -45,6 +47,7 @@ public record FormResponse(
 
         public static FormFieldListResponse from(FormFieldListQuery formFieldListQuery) {
             return FormFieldListResponse.builder()
+                    .id(formFieldListQuery.id())
                     .question(formFieldListQuery.question())
                     .type(formFieldListQuery.type())
                     .options(formFieldListQuery.options())

--- a/src/main/java/ddingdong/ddingdongBE/domain/form/entity/Form.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/form/entity/Form.java
@@ -3,6 +3,7 @@ package ddingdong.ddingdongBE.domain.form.entity;
 import ddingdong.ddingdongBE.common.BaseEntity;
 import ddingdong.ddingdongBE.common.converter.StringListConverter;
 import ddingdong.ddingdongBE.domain.club.entity.Club;
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Convert;
 import jakarta.persistence.Entity;
@@ -11,7 +12,9 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
 import java.time.LocalDate;
+import java.util.ArrayList;
 import java.util.List;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -48,6 +51,9 @@ public class Form extends BaseEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     private Club club;
 
+    @OneToMany(mappedBy = "club", cascade = CascadeType.ALL)
+    private List<FormField> formFields = new ArrayList<>();
+
     @Builder
     private Form(
             String title,
@@ -56,7 +62,8 @@ public class Form extends BaseEntity {
             LocalDate endDate,
             boolean hasInterview,
             List<String> sections,
-            Club club
+            Club club,
+            List<FormField> formFields
     ) {
         this.title = title;
         this.description = description;
@@ -65,6 +72,12 @@ public class Form extends BaseEntity {
         this.hasInterview = hasInterview;
         this.sections = sections;
         this.club = club;
+        this.formFields = formFields;
+    }
+
+    public void addFormFields(FormField formField) {
+        this.formFields.add(formField);
+        formField.setFormForConvenience(this);
     }
 
     public void update(Form updateForm) {

--- a/src/main/java/ddingdong/ddingdongBE/domain/form/entity/Form.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/form/entity/Form.java
@@ -53,7 +53,7 @@ public class Form extends BaseEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     private Club club;
 
-    @OneToMany(mappedBy = "form", cascade = CascadeType.ALL)
+    @OneToMany(mappedBy = "form", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<FormField> formFields = new ArrayList<>();
 
     @Builder
@@ -99,6 +99,7 @@ public class Form extends BaseEntity {
         // 삭제될 폼 필드
         List<FormField> deletedFormFields = this.formFields.stream()
                 .filter(formField -> updatedFormFields.stream()
+                        .filter(updatedFormField -> updatedFormField.getId() != null)
                         .noneMatch(updatedField -> updatedField.getId().equals(formField.getId())))
                 .toList();
         this.formFields.removeAll(deletedFormFields);

--- a/src/main/java/ddingdong/ddingdongBE/domain/form/entity/FormField.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/form/entity/FormField.java
@@ -23,61 +23,61 @@ import lombok.NoArgsConstructor;
 @Getter
 public class FormField extends BaseEntity {
 
-  @Id
-  @GeneratedValue(strategy = GenerationType.IDENTITY)
-  private Long id;
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
 
-  @Column(nullable = false)
-  private String question;
+    @Column(nullable = false)
+    private String question;
 
-  @Column(nullable = false)
-  private boolean required;
+    @Column(nullable = false)
+    private boolean required;
 
-  @Column(nullable = false)
-  private int fieldOrder;
+    @Column(nullable = false)
+    private int fieldOrder;
 
-  @Column(nullable = false)
-  private String section;
+    @Column(nullable = false)
+    private String section;
 
-  @Convert(converter = StringListConverter.class)
-  private List<String> options;
+    @Convert(converter = StringListConverter.class)
+    private List<String> options;
 
-  @Enumerated(EnumType.STRING)
-  @Column(nullable = false)
-  private FieldType fieldType;
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private FieldType fieldType;
 
-  @ManyToOne(fetch = FetchType.LAZY)
-  private Form form;
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Form form;
 
-  @Builder
-  private FormField(
-      String question,
-      FieldType fieldType,
-      boolean required,
-      int fieldOrder,
-      String section,
-      List<String> options,
-      Form form
-  ) {
-    this.question = question;
-    this.fieldType = fieldType;
-    this.required = required;
-    this.fieldOrder = fieldOrder;
-    this.section = section;
-    this.options = options;
-    this.form = form;
-  }
+    @Builder
+    private FormField(
+            String question,
+            FieldType fieldType,
+            boolean required,
+            int fieldOrder,
+            String section,
+            List<String> options,
+            Form form
+            ) {
+        this.question = question;
+        this.fieldType = fieldType;
+        this.required = required;
+        this.fieldOrder = fieldOrder;
+        this.section = section;
+        this.options = options;
+        this.form = form;
+    }
 
-  public boolean isMultipleChoice() {
-    return this.fieldType == FieldType.CHECK_BOX || this.fieldType == FieldType.RADIO;
-  }
+    public boolean isMultipleChoice() {
+        return this.fieldType == FieldType.CHECK_BOX || this.fieldType == FieldType.RADIO;
+    }
 
-  public boolean isTextType() {
-    return this.fieldType == FieldType.TEXT || this.fieldType == FieldType.LONG_TEXT
-            || this.fieldType == FieldType.FILE;
-  }
+    public boolean isTextType() {
+        return this.fieldType == FieldType.TEXT || this.fieldType == FieldType.LONG_TEXT
+                || this.fieldType == FieldType.FILE;
+    }
 
-  public boolean isFile() {
-    return this.fieldType == FieldType.FILE;
-  }
+    public boolean isFile() {
+        return this.fieldType == FieldType.FILE;
+    }
 }

--- a/src/main/java/ddingdong/ddingdongBE/domain/form/entity/FormField.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/form/entity/FormField.java
@@ -59,7 +59,7 @@ public class FormField extends BaseEntity {
             String section,
             List<String> options,
             Form form
-            ) {
+    ) {
         this.id = id;
         this.question = question;
         this.fieldType = fieldType;

--- a/src/main/java/ddingdong/ddingdongBE/domain/form/entity/FormField.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/form/entity/FormField.java
@@ -51,6 +51,7 @@ public class FormField extends BaseEntity {
 
     @Builder
     private FormField(
+            Long id,
             String question,
             FieldType fieldType,
             boolean required,
@@ -59,6 +60,7 @@ public class FormField extends BaseEntity {
             List<String> options,
             Form form
             ) {
+        this.id = id;
         this.question = question;
         this.fieldType = fieldType;
         this.required = required;
@@ -83,5 +85,14 @@ public class FormField extends BaseEntity {
 
     public void setFormForConvenience(Form form) {
         this.form = form;
+    }
+
+    public void update(FormField updatedField) {
+        this.question = updatedField.getQuestion();
+        this.fieldType = updatedField.getFieldType();
+        this.required = updatedField.isRequired();
+        this.fieldOrder = updatedField.getFieldOrder();
+        this.section = updatedField.getSection();
+        this.options = updatedField.getOptions();
     }
 }

--- a/src/main/java/ddingdong/ddingdongBE/domain/form/entity/FormField.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/form/entity/FormField.java
@@ -80,4 +80,8 @@ public class FormField extends BaseEntity {
     public boolean isFile() {
         return this.fieldType == FieldType.FILE;
     }
+
+    public void setFormForConvenience(Form form) {
+        this.form = form;
+    }
 }

--- a/src/main/java/ddingdong/ddingdongBE/domain/form/service/FacadeCentralFormServiceImpl.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/form/service/FacadeCentralFormServiceImpl.java
@@ -82,12 +82,9 @@ public class FacadeCentralFormServiceImpl implements FacadeCentralFormService {
         Form updateForm = command.toEntity();
         originform.update(updateForm);
 
-        List<FormField> originFormFields = formFieldService.findAllByForm(originform);
-        formFieldService.deleteAll(originFormFields);
-
-        List<FormField> updateFormFields = toUpdateFormFields(originform,
+        List<FormField> updatedFormFields = toUpdateFormFields(originform,
                 command.formFieldCommands());
-        formFieldService.createAll(updateFormFields);
+        originform.updateFormFields(updatedFormFields);
     }
 
     @Transactional

--- a/src/main/java/ddingdong/ddingdongBE/domain/form/service/FacadeCentralFormServiceImpl.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/form/service/FacadeCentralFormServiceImpl.java
@@ -82,8 +82,7 @@ public class FacadeCentralFormServiceImpl implements FacadeCentralFormService {
         Form updateForm = command.toEntity();
         originform.update(updateForm);
 
-        List<FormField> updatedFormFields = toUpdateFormFields(originform,
-                command.formFieldCommands());
+        List<FormField> updatedFormFields = toUpdateFormFields(originform, command.formFieldCommands());
         originform.updateFormFields(updatedFormFields);
     }
 
@@ -233,13 +232,13 @@ public class FacadeCentralFormServiceImpl implements FacadeCentralFormService {
     }
 
     private List<FormField> toUpdateFormFields(Form originform,
-                                               List<UpdateFormFieldCommand> updateFormFieldCommands) {
+            List<UpdateFormFieldCommand> updateFormFieldCommands) {
         return updateFormFieldCommands.stream()
                 .map(formFieldCommand -> formFieldCommand.toEntity(originform)).toList();
     }
 
     private List<FormField> toCreateFormFields(Form savedForm,
-                                               List<CreateFormFieldCommand> createFormFieldCommands) {
+            List<CreateFormFieldCommand> createFormFieldCommands) {
         return createFormFieldCommands.stream()
                 .map(formFieldCommand -> formFieldCommand.toEntity(savedForm)).toList();
     }

--- a/src/main/java/ddingdong/ddingdongBE/domain/form/service/dto/command/UpdateFormCommand.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/form/service/dto/command/UpdateFormCommand.java
@@ -23,6 +23,7 @@ public record UpdateFormCommand(
 
     @Builder
     public record UpdateFormFieldCommand(
+            Long id,
             String question,
             FieldType type,
             List<String> options,
@@ -33,6 +34,7 @@ public record UpdateFormCommand(
 
         public FormField toEntity(Form form) {
             return FormField.builder()
+                    .id(id)
                     .form(form)
                     .question(question)
                     .fieldType(type)

--- a/src/main/java/ddingdong/ddingdongBE/domain/formapplication/entity/FormAnswer.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/formapplication/entity/FormAnswer.java
@@ -17,10 +17,14 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.SQLRestriction;
 
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
+@SQLDelete(sql = "update form_answer set deleted_at = CURRENT_TIMESTAMP where id=?")
+@SQLRestriction("deleted_at IS NULL")
 public class FormAnswer extends BaseEntity {
 
     @Id

--- a/src/main/java/ddingdong/ddingdongBE/domain/formapplication/entity/FormAnswer.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/formapplication/entity/FormAnswer.java
@@ -4,6 +4,7 @@ import ddingdong.ddingdongBE.common.BaseEntity;
 import ddingdong.ddingdongBE.common.converter.StringListConverter;
 import ddingdong.ddingdongBE.domain.form.entity.FieldType;
 import ddingdong.ddingdongBE.domain.form.entity.FormField;
+import jakarta.persistence.Column;
 import jakarta.persistence.Convert;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
@@ -12,6 +13,7 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import java.time.LocalDateTime;
 import java.util.List;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -32,6 +34,7 @@ public class FormAnswer extends BaseEntity {
     private Long id;
 
     @Convert(converter = StringListConverter.class)
+    @Column(columnDefinition = "TEXT")
     private List<String> value;
 
     @JoinColumn(name = "application_id")
@@ -42,11 +45,20 @@ public class FormAnswer extends BaseEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     private FormField formField;
 
+    @Column(columnDefinition = "TIMESTAMP")
+    private LocalDateTime deletedAt;
+
     @Builder
-    private FormAnswer(List<String> value, FormApplication formApplication, FormField formField) {
+    private FormAnswer(
+            List<String> value,
+            FormApplication formApplication,
+            FormField formField,
+            LocalDateTime deletedAt
+    ) {
         this.value = value;
         this.formApplication = formApplication;
         this.formField = formField;
+        this.deletedAt = deletedAt;
     }
 
     public boolean isFile() {

--- a/src/main/java/ddingdong/ddingdongBE/domain/formapplication/entity/FormApplication.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/formapplication/entity/FormApplication.java
@@ -3,6 +3,7 @@ package ddingdong.ddingdongBE.domain.formapplication.entity;
 import ddingdong.ddingdongBE.common.BaseEntity;
 import ddingdong.ddingdongBE.domain.form.entity.Form;
 import jakarta.persistence.*;
+import java.time.LocalDateTime;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -21,13 +22,13 @@ public class FormApplication extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(nullable = false)
+    @Column(nullable = false, length = 50)
     private String name;
 
-    @Column(nullable = false)
+    @Column(nullable = false, length = 50)
     private String studentNumber;
 
-    @Column(nullable = false)
+    @Column(nullable = false, length = 50)
     private String department;
 
     @Column(nullable = false)
@@ -37,18 +38,29 @@ public class FormApplication extends BaseEntity {
     private String email;
 
     @Enumerated(EnumType.STRING)
-    @Column(nullable = false, name = "status")
+    @Column(nullable = false, length = 50)
     private FormApplicationStatus status;
 
     @ManyToOne(fetch = FetchType.LAZY)
     private Form form;
 
+    @Column(length = 500)
     private String note;
 
+    @Column(columnDefinition = "TIMESTAMP")
+    private LocalDateTime deletedAt;
+
     @Builder
-    private FormApplication(String name, String studentNumber, String department,
-            String phoneNumber, String email,
-            FormApplicationStatus status, Form form) {
+    private FormApplication(
+            String name,
+            String studentNumber,
+            String department,
+            String phoneNumber,
+            String email,
+            FormApplicationStatus status,
+            Form form,
+            LocalDateTime deletedAt
+    ) {
         this.name = name;
         this.studentNumber = studentNumber;
         this.department = department;
@@ -56,6 +68,7 @@ public class FormApplication extends BaseEntity {
         this.email = email;
         this.status = status;
         this.form = form;
+        this.deletedAt = deletedAt;
     }
 
     public void updateStatus(FormApplicationStatus status) {

--- a/src/main/java/ddingdong/ddingdongBE/domain/formapplication/entity/FormApplication.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/formapplication/entity/FormApplication.java
@@ -7,10 +7,14 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.SQLRestriction;
 
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
+@SQLDelete(sql = "update form_application set deleted_at = CURRENT_TIMESTAMP where id=?")
+@SQLRestriction("deleted_at IS NULL")
 public class FormApplication extends BaseEntity {
 
     @Id

--- a/src/main/resources/db/migration/V43__alter_table_form_application_and_form_answer.sql
+++ b/src/main/resources/db/migration/V43__alter_table_form_application_and_form_answer.sql
@@ -1,0 +1,11 @@
+ALTER TABLE form_answer
+    ADD deleted_at timestamp NULL;
+
+ALTER TABLE form_application
+    ADD deleted_at timestamp NULL;
+
+ALTER TABLE form_application
+    MODIFY email VARCHAR (255) NOT NULL;
+
+ALTER TABLE form_application
+    MODIFY phone_number VARCHAR (255) NOT NULL;

--- a/src/test/java/ddingdong/ddingdongBE/domain/form/entity/FormTest.java
+++ b/src/test/java/ddingdong/ddingdongBE/domain/form/entity/FormTest.java
@@ -1,0 +1,138 @@
+package ddingdong.ddingdongBE.domain.form.entity;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class FormTest {
+
+    private Form form;
+    private FormField field1, field2, field3, updatedField2, newField4;
+
+    @BeforeEach
+    void setUp() {
+        form = new Form();
+        field1 = FormField.builder()
+                .id(1L)
+                .question("질문 1")
+                .fieldType(FieldType.TEXT)
+                .required(true)
+                .fieldOrder(1)
+                .section("섹션 1")
+                .options(null)
+                .build();
+
+        field2 = FormField.builder()
+                .id(2L)
+                .question("질문 2")
+                .fieldType(FieldType.RADIO)
+                .required(false)
+                .fieldOrder(2)
+                .section("섹션 1")
+                .options(List.of("옵션1", "옵션2"))
+                .build();
+
+        field3 = FormField.builder()
+                .id(3L)
+                .question("질문 3")
+                .fieldType(FieldType.CHECK_BOX)
+                .required(true)
+                .fieldOrder(3)
+                .section("섹션 2")
+                .options(List.of("옵션A", "옵션B", "옵션C"))
+                .build();
+
+        form.addFormFields(field1);
+        form.addFormFields(field2);
+        form.addFormFields(field3);
+
+        updatedField2 = FormField.builder()
+                .id(2L) // field2와 같은 ID
+                .question("수정된 질문 2")
+                .fieldType(FieldType.RADIO)
+                .required(true) // 변경됨
+                .fieldOrder(5) // 변경됨
+                .section("섹션 1")
+                .options(List.of("옵션1", "옵션2", "새 옵션")) // 옵션 추가됨
+                .build();
+
+        newField4 = FormField.builder()
+                .id(4L)
+                .question("새 질문 4")
+                .fieldType(FieldType.LONG_TEXT)
+                .required(false)
+                .fieldOrder(4)
+                .section("섹션 3")
+                .options(null)
+                .build();
+    }
+
+    @DisplayName("폼지 수정: 삭제대상 폼지 질문을 삭제한다.")
+    @Test
+    void shouldRemoveDeletedFields() {
+        // given
+        List<FormField> updatedFields = List.of(field1, field3);
+
+        // when
+        form.updateFormFields(updatedFields);
+
+        // then
+        assertThat(form.getFormFields()).hasSize(2);
+        assertThat(form.getFormFields())
+                .extracting(FormField::getId)
+                .containsExactlyInAnyOrder(1L, 3L)
+                .doesNotContain(2L);
+    }
+    
+    @DisplayName("폼지 수정: 추가 대상 폼지 질문을 추가한다.")
+    @Test
+    void shouldAddNewFields() {
+        //given
+        List<FormField> updatedFields = List.of(field1, field2, field3, newField4);
+
+        //when
+        form.updateFormFields(updatedFields);
+    
+        //then
+        Assertions.assertThat(form.getFormFields()).hasSize(4);
+
+        FormField addedField = form.getFormFields().stream()
+                .filter(field -> field.getId() != null && field.getId().equals(4L))
+                .findFirst()
+                .orElse(null);
+        assertThat(addedField).isNotNull();
+        assertThat(addedField.getQuestion()).isEqualTo("새 질문 4");
+        assertThat(addedField.getFieldType()).isEqualTo(FieldType.LONG_TEXT);
+        assertThat(addedField.getSection()).isEqualTo("섹션 3");
+        assertThat(addedField.getForm()).isEqualTo(form);
+    }
+
+    @DisplayName("폼지 수정: 기존 폼지 질문을 수정한다.")
+    @Test
+    void shouldUpdateExistingFields() {
+        //given
+        List<FormField> updatedFields = List.of(field1, updatedField2, field3);
+
+        //when
+        form.updateFormFields(updatedFields);
+
+        //then
+        assertThat(form.getFormFields()).hasSize(3);
+        FormField updatedField = form.getFormFields().stream()
+                .filter(field -> field.getId().equals(2L))
+                .findFirst()
+                .orElse(null);
+        assertThat(updatedField).isNotNull();
+        assertThat(updatedField.getQuestion()).isEqualTo("수정된 질문 2");
+        assertThat(updatedField.isRequired()).isTrue();
+        assertThat(updatedField.getFieldOrder()).isEqualTo(5);
+        assertThat(updatedField.getOptions())
+                .hasSize(3)
+                .contains("옵션1", "옵션2", "새 옵션");
+    }
+
+}


### PR DESCRIPTION
## 🚀 작업 내용
### 폼지 수정 시 지원자 답변 내역 삭제 에러 해결을 위한 로직 개선
- 에러 원인
	- 기존의 폼지 수정 로직 중 formField 수정 시 모든 formField 삭제 후 재생성 하는 로직 존재
	- 현재 API는 운영상의 이유로 폼지의 모집 마감기한만 수정 가능
	- 모집 마감기한 수정 요청 시 formField가 모두 삭제되고 이와 연관된 formAnswer 모두 삭제
	
- 폼지 질문 수정 로직 개선
	- `Form`, `FormField`의 양방향 연관관계 설정
	- 폼지 수정 시 추가된 FormField, 삭제된 FormField, 수정된 FormField를 구분하여 List<FormField>에 반영하도록 구현

## 🤔 고민했던 내용
## 💬 리뷰 중점사항


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - 폼 관리 기능이 개선되어, 필드 추가·수정·삭제가 더욱 효율적으로 수행됩니다.
  - 각 폼 필드에 식별자(ID)가 도입되어 데이터 관리의 일관성이 강화되었습니다.
  - 폼 응답 및 신청에 소프트 딜리트 기능이 추가되어, 삭제된 항목이 향후 복구 가능합니다.

- **Tests**
  - 폼 관련 기능의 안정성을 검증하는 새로운 테스트 케이스들이 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->