### PR TITLE
[DDING-125-1] 섹션 여러 개일 경우 폼지 생성 수정

### DIFF
--- a/src/main/java/ddingdong/ddingdongBE/domain/form/entity/Form.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/form/entity/Form.java
@@ -83,4 +83,8 @@ public class Form extends BaseEntity {
     public void updateEndDate(LocalDate endDate) {
         this.endDate = endDate;
     }
+
+    public boolean isLargerSectionThan(int sectionSize) {
+        return this.sections.size() > sectionSize;
+    }
 }

--- a/src/main/java/ddingdong/ddingdongBE/domain/form/service/FacadeCentralFormServiceImpl.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/form/service/FacadeCentralFormServiceImpl.java
@@ -70,8 +70,7 @@ public class FacadeCentralFormServiceImpl implements FacadeCentralFormService {
         Form savedForm = formService.create(form);
         List<FormField> formFields = toCreateFormFields(savedForm,
                 createFormCommand.formFieldCommands());
-        List<FormField> newFormFields = formFields.stream().flatMap(formField -> formField.generateFormFieldsBySection(form)).toList();
-        formFieldService.createAll(newFormFields);
+        formFieldService.createAll(formFields);
     }
 
     @Transactional
@@ -262,6 +261,7 @@ public class FacadeCentralFormServiceImpl implements FacadeCentralFormService {
             List<CreateFormFieldCommand> createFormFieldCommands) {
         return createFormFieldCommands.stream()
                 .map(formFieldCommand -> formFieldCommand.toEntity(savedForm))
+                .flatMap(formField -> formField.generateFormFieldsBySection(savedForm))
                 .toList();
     }
 }

--- a/src/main/java/ddingdong/ddingdongBE/domain/form/service/dto/command/CreateFormCommand.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/form/service/dto/command/CreateFormCommand.java
@@ -42,6 +42,19 @@ public record CreateFormCommand(
                     .form(savedForm)
                     .build();
         }
+
+        public FormField toEntityWithSection(Form savedForm, String section) {
+            return FormField.builder()
+                    .question(question)
+                    .fieldType(type)
+                    .options(options)
+                    .required(required)
+                    .fieldOrder(order)
+                    .section(section)
+                    .form(savedForm)
+                    .build();
+        }
+
     }
 
     public Form toEntity(Club club) {


### PR DESCRIPTION
## 🚀 작업 내용

섹션 여러 개일 경우 폼지 생성 기능 수정하였습니다.
form의 sections 사이즈가 1보다 클 경우, 아닐 경우로 분기하고 그에 따른 private 메서드 toCreateFormFieldsForMultipleSections, toCreateFormFieldsForSingleSection을 각각 만들었습니다. 

유저 폼지 조회도 수정하도록 하겠습니다.

## 🤔 고민했던 내용

분기를 private 메서드 외부에서 할지 내부에서 할지, private 메서드는 어떤 기준으로 분리해야 할지 고민되었습니다.
달리 선택지가 없어서 그대로 두긴 했지만 메서드명이 너무 긴 것 같다는 생각이 들었습니다.
람다식 내부에 if-else문도 있고... 내부 로직이 조금 난잡하다는 생각도 들었습니다.
그리고 이 로직이 Facade에 있는 게 맞는지 잘 모르겠습니다. FormStatistics처럼 따로 빼는 건 좀 이상하겠죠..??

## 💬 리뷰 중점사항


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - 폼 생성 시 단일 섹션과 다중 섹션에 따라 항목 배분이 개선되어, 사용자 맞춤형 폼 구성이 보다 명확해졌습니다.
  - 신규 섹션 지정 기능이 추가되어, 공통 항목과 개별 섹션 항목이 효과적으로 구분됩니다.
  - 섹션 크기 비교 기능이 추가되어, 폼의 섹션 수에 따라 로직이 유연하게 조정됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->