### PR TITLE
[DDING-000] Form 제거시 Form과 연관된 FileMetaData 삭제로직 구현

### DIFF
--- a/src/main/java/ddingdong/ddingdongBE/domain/filemetadata/service/FileMetaDataService.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/filemetadata/service/FileMetaDataService.java
@@ -31,6 +31,8 @@ public interface FileMetaDataService {
 
     void updateStatusToDelete(DomainType domainType, Long entityId);
 
+    void updateStatusToDelete(List<FileMetaData> fileMetaDatas);
+
     void update(String id, DomainType domainType, Long entityId);
 
     void update(List<String> ids, DomainType domainType, Long entityId);

--- a/src/main/java/ddingdong/ddingdongBE/domain/filemetadata/service/FileMetaDataServiceImpl.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/filemetadata/service/FileMetaDataServiceImpl.java
@@ -174,6 +174,11 @@ public class FileMetaDataServiceImpl implements FileMetaDataService {
         fileMetaDatas.forEach(fileMetaData -> fileMetaData.updateStatus(DELETED));
     }
 
+    @Override
+    public void updateStatusToDelete(List<FileMetaData> fileMetaDatas) {
+        fileMetaDatas.forEach(fileMetaData -> fileMetaData.updateStatus(DELETED));
+    }
+
     private List<String> getNewIds(List<String> ids) {
         List<FileMetaData> fileMetaDatas = fileMetaDataRepository.findByIdIn(toUUIDs(ids));
         return fileMetaDatas.stream()

--- a/src/main/java/ddingdong/ddingdongBE/domain/form/service/FacadeCentralFormServiceImpl.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/form/service/FacadeCentralFormServiceImpl.java
@@ -9,6 +9,8 @@ import ddingdong.ddingdongBE.common.exception.FormException.OverlapFormPeriodExc
 import ddingdong.ddingdongBE.domain.club.entity.Club;
 import ddingdong.ddingdongBE.domain.club.service.ClubService;
 import ddingdong.ddingdongBE.domain.clubmember.entity.ClubMember;
+import ddingdong.ddingdongBE.domain.filemetadata.entity.FileMetaData;
+import ddingdong.ddingdongBE.domain.filemetadata.service.FileMetaDataService;
 import ddingdong.ddingdongBE.domain.form.entity.Form;
 import ddingdong.ddingdongBE.domain.form.entity.FormField;
 import ddingdong.ddingdongBE.domain.form.entity.FormStatus;
@@ -30,6 +32,7 @@ import ddingdong.ddingdongBE.domain.form.service.dto.query.SingleFieldStatistics
 import ddingdong.ddingdongBE.domain.form.service.dto.query.SingleFieldStatisticsQuery.SingleStatisticsQuery;
 import ddingdong.ddingdongBE.domain.formapplication.entity.FormApplication;
 import ddingdong.ddingdongBE.domain.formapplication.entity.FormApplicationStatus;
+import ddingdong.ddingdongBE.domain.formapplication.service.FormAnswerService;
 import ddingdong.ddingdongBE.domain.formapplication.service.FormApplicationService;
 import ddingdong.ddingdongBE.domain.user.entity.User;
 import ddingdong.ddingdongBE.email.SesEmailService;
@@ -58,6 +61,8 @@ public class FacadeCentralFormServiceImpl implements FacadeCentralFormService {
     private final FormStatisticService formStatisticService;
     private final FormApplicationService formApplicationService;
     private final SesEmailService sesEmailService;
+    private final FormAnswerService formAnswerService;
+    private final FileMetaDataService fileMetaDataService;
 
     @Transactional
     @Override
@@ -97,7 +102,8 @@ public class FacadeCentralFormServiceImpl implements FacadeCentralFormService {
         Club club = clubService.getByUserId(user.getId());
         Form form = formService.getById(formId);
         validateEqualsClub(club, form);
-        // TODO : fileMetaData의 formFile formAnswer 지우기
+        List<FileMetaData> fileMetaDatas = formAnswerService.getAllFileByForm(form);
+        fileMetaDataService.updateStatusToDelete(fileMetaDatas);
         formService.delete(form); //테이블 생성 시 외래 키에 cascade 설정하여 formField 삭제도 자동으로 됨.
     }
 

--- a/src/main/java/ddingdong/ddingdongBE/domain/formapplication/repository/FormAnswerRepository.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/formapplication/repository/FormAnswerRepository.java
@@ -1,5 +1,6 @@
 package ddingdong.ddingdongBE.domain.formapplication.repository;
 
+import ddingdong.ddingdongBE.domain.filemetadata.entity.FileMetaData;
 import ddingdong.ddingdongBE.domain.form.entity.FormField;
 import ddingdong.ddingdongBE.domain.formapplication.entity.FormAnswer;
 import ddingdong.ddingdongBE.domain.formapplication.entity.FormApplication;
@@ -58,5 +59,15 @@ public interface FormAnswerRepository extends JpaRepository<FormAnswer, Long> {
     List<FileAnswerInfo> findAllFileAnswerInfo(
             @Param("domainType") String domainType,
             @Param("answerIds") List<Long> answerIds,
-            @Param("fileStatus") String fileStatus    );
+            @Param("fileStatus") String fileStatus);
+
+
+    @Query("""
+            SELECT fmd
+            FROM FileMetaData fmd
+            JOIN FormAnswer fa ON fmd.entityId = fa.id
+            JOIN FormField ffd ON fa.formField.id = ffd.id
+            WHERE fmd.domainType = 'FORM_FILE' AND ffd.form.id = :formId
+            """)
+    List<FileMetaData> getAllFileByForm(@Param("formId") Long formId);
 }

--- a/src/main/java/ddingdong/ddingdongBE/domain/formapplication/service/FormAnswerService.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/formapplication/service/FormAnswerService.java
@@ -1,8 +1,9 @@
 package ddingdong.ddingdongBE.domain.formapplication.service;
 
+import ddingdong.ddingdongBE.domain.filemetadata.entity.FileMetaData;
+import ddingdong.ddingdongBE.domain.form.entity.Form;
 import ddingdong.ddingdongBE.domain.formapplication.entity.FormAnswer;
 import ddingdong.ddingdongBE.domain.formapplication.entity.FormApplication;
-
 import java.util.List;
 
 public interface FormAnswerService {
@@ -11,4 +12,5 @@ public interface FormAnswerService {
 
     List<FormAnswer> getAllByApplication(FormApplication formApplication);
 
+    List<FileMetaData> getAllFileByForm(Form form);
 }

--- a/src/main/java/ddingdong/ddingdongBE/domain/formapplication/service/GeneralFormAnswerService.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/formapplication/service/GeneralFormAnswerService.java
@@ -1,5 +1,7 @@
 package ddingdong.ddingdongBE.domain.formapplication.service;
 
+import ddingdong.ddingdongBE.domain.filemetadata.entity.FileMetaData;
+import ddingdong.ddingdongBE.domain.form.entity.Form;
 import ddingdong.ddingdongBE.domain.formapplication.entity.FormAnswer;
 import ddingdong.ddingdongBE.domain.formapplication.entity.FormApplication;
 import ddingdong.ddingdongBE.domain.formapplication.repository.FormAnswerRepository;
@@ -25,5 +27,10 @@ public class GeneralFormAnswerService implements FormAnswerService {
     @Override
     public List<FormAnswer> getAllByApplication(FormApplication formApplication) {
         return formAnswerRepository.findAllByFormApplication(formApplication);
+    }
+
+    @Override
+    public List<FileMetaData> getAllFileByForm(Form form) {
+        return formAnswerRepository.getAllFileByForm(form.getId());
     }
 }

--- a/src/test/java/ddingdong/ddingdongBE/common/fixture/FileMetaDataFixture.java
+++ b/src/test/java/ddingdong/ddingdongBE/common/fixture/FileMetaDataFixture.java
@@ -1,0 +1,20 @@
+package ddingdong.ddingdongBE.common.fixture;
+
+import ddingdong.ddingdongBE.domain.filemetadata.entity.DomainType;
+import ddingdong.ddingdongBE.domain.filemetadata.entity.FileMetaData;
+import ddingdong.ddingdongBE.domain.filemetadata.entity.FileStatus;
+import java.util.UUID;
+
+public class FileMetaDataFixture {
+
+    public static FileMetaData formFileMetaData(UUID id, Long entityId) {
+        return FileMetaData.builder()
+                .id(id)
+                .fileKey("1")
+                .fileStatus(FileStatus.COUPLED)
+                .fileName("파일")
+                .domainType(DomainType.FORM_FILE)
+                .entityId(entityId)
+                .build();
+    }
+}

--- a/src/test/java/ddingdong/ddingdongBE/common/fixture/FormFixture.java
+++ b/src/test/java/ddingdong/ddingdongBE/common/fixture/FormFixture.java
@@ -1,0 +1,41 @@
+package ddingdong.ddingdongBE.common.fixture;
+
+import ddingdong.ddingdongBE.domain.form.entity.FieldType;
+import ddingdong.ddingdongBE.domain.form.entity.Form;
+import ddingdong.ddingdongBE.domain.form.entity.FormField;
+import ddingdong.ddingdongBE.domain.formapplication.entity.FormAnswer;
+import java.time.LocalDate;
+import java.util.List;
+
+public class FormFixture {
+
+    public static Form formWithClubNull() {
+        return Form.builder()
+                .title("모집 지원서")
+                .description("동아리 모집을 위한 지원서입니다.")
+                .startDate(LocalDate.of(2025, 4, 1))
+                .endDate(LocalDate.of(2025, 4, 15))
+                .hasInterview(true)
+                .sections(List.of("자기소개", "지원 동기", "경력 및 경험"))
+                .build();
+    }
+
+    public static FormField formFieldWithFormNull() {
+        return FormField.builder()
+                .question("자기소개를 해주세요.")
+                .required(true)
+                .fieldOrder(1)
+                .section("기본 정보")
+                .options(List.of("없음"))
+                .fieldType(FieldType.TEXT)
+                .form(null)
+                .build();
+    }
+
+    public static FormAnswer formAnswerByFormField(FormField savedFormField) {
+        return FormAnswer.builder()
+                .value(List.of("답변"))
+                .formField(savedFormField)
+                .build();
+    }
+}

--- a/src/test/java/ddingdong/ddingdongBE/domain/formapplication/repository/FormAnswerRepositoryTest.java
+++ b/src/test/java/ddingdong/ddingdongBE/domain/formapplication/repository/FormAnswerRepositoryTest.java
@@ -1,11 +1,20 @@
 package ddingdong.ddingdongBE.domain.formapplication.repository;
 
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
+
+import ddingdong.ddingdongBE.common.fixture.FileMetaDataFixture;
+import ddingdong.ddingdongBE.common.fixture.FormFixture;
 import ddingdong.ddingdongBE.common.support.DataJpaTestSupport;
+import ddingdong.ddingdongBE.domain.filemetadata.entity.FileMetaData;
+import ddingdong.ddingdongBE.domain.filemetadata.repository.FileMetaDataRepository;
 import ddingdong.ddingdongBE.domain.form.entity.FieldType;
+import ddingdong.ddingdongBE.domain.form.entity.Form;
 import ddingdong.ddingdongBE.domain.form.entity.FormField;
 import ddingdong.ddingdongBE.domain.form.repository.FormFieldRepository;
+import ddingdong.ddingdongBE.domain.form.repository.FormRepository;
 import ddingdong.ddingdongBE.domain.formapplication.entity.FormAnswer;
 import java.util.List;
+import java.util.UUID;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -17,6 +26,10 @@ class FormAnswerRepositoryTest extends DataJpaTestSupport {
     FormAnswerRepository formAnswerRepository;
     @Autowired
     FormFieldRepository formFieldRepository;
+    @Autowired
+    FormRepository formRepository;
+    @Autowired
+    FileMetaDataRepository fileMetaDataRepository;
 
     @DisplayName("주어진 FormField와 연관된 FormAnswer의 value를 모두 반환한다.")
     @Test
@@ -46,5 +59,45 @@ class FormAnswerRepositoryTest extends DataJpaTestSupport {
         // then
         Assertions.assertThat(allValueByFormField).hasSize(2);
         Assertions.assertThat(allValueByFormField.get(0)).isEqualTo("[\"서버\",\"웹\"]");
+    }
+
+    @DisplayName("FormID에 해당하는 모든 FormAnswer ID를 EntityId로 보유한 FileMetaData를 모두 조회한다")
+    @Test
+    void getAllFileByForm() {
+        // given
+        Form form = FormFixture.formWithClubNull();
+        Form savedForm = formRepository.save(form);
+        FormField formField = FormFixture.formFieldWithFormNull();
+
+        formField.setFormForConvenience(savedForm);
+        FormField savedField = formFieldRepository.save(formField);
+
+        FormAnswer formAnswer1 = FormFixture.formAnswerByFormField(savedField);
+        FormAnswer savedFormAnswer1 = formAnswerRepository.save(formAnswer1);
+
+        FormAnswer formAnswer2 = FormFixture.formAnswerByFormField(savedField);
+        FormAnswer savedFormAnswer2 = formAnswerRepository.save(formAnswer2);
+
+        FormAnswer formAnswer3 = FormFixture.formAnswerByFormField(savedField);
+        FormAnswer savedFormAnswer3 = formAnswerRepository.save(formAnswer3);
+
+        UUID fileId1 = UUID.randomUUID();
+        UUID fileId2 = UUID.randomUUID();
+        UUID fileId3 = UUID.randomUUID();
+
+        FileMetaData fileMetaData1 = FileMetaDataFixture.formFileMetaData(fileId1, savedFormAnswer1.getId());
+        FileMetaData fileMetaData2 = FileMetaDataFixture.formFileMetaData(fileId2, savedFormAnswer2.getId());
+        FileMetaData fileMetaData3 = FileMetaDataFixture.formFileMetaData(fileId3, savedFormAnswer3.getId());
+        fileMetaDataRepository.saveAll(List.of(fileMetaData1, fileMetaData2, fileMetaData3));
+
+        // when
+        List<FileMetaData> allFileByForm = formAnswerRepository.getAllFileByForm(savedForm.getId());
+
+        // then
+        assertSoftly(softly -> {
+            softly.assertThat(allFileByForm.get(0).getEntityId()).isEqualTo(savedFormAnswer1.getId());
+            softly.assertThat(allFileByForm.get(1).getEntityId()).isEqualTo(savedFormAnswer2.getId());
+            softly.assertThat(allFileByForm.get(2).getEntityId()).isEqualTo(savedFormAnswer3.getId());
+        });
     }
 }


### PR DESCRIPTION
## 🚀 작업 내용
- Form 제거시 Form과 연관된 FileMetaData 상태를 DELETE로 변환시켰습니다
- formId로 formAnswerId로 생성된 FileMetaData 조회 쿼리 작성하였습니다.
- 쿼리 작동 테스트 구현하였습니다

## 🤔 고민했던 내용
- 직접 DELETE, UPDATE 쿼리를 날리는 것이 효율적일지, SELECT 후 애플리케이션 단에서 수정하는 것이 효율적일지 잠깐 고민해봤습니다~
- 대량 데이터가 아니라 조회 후 수정하였습니다

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
  - 여러 파일의 상태를 일괄 변경하여 삭제 처리를 지원하는 기능을 추가했습니다.
  - 폼 삭제 시 연관 파일의 상태 업데이트가 자동으로 이루어지도록 기능을 확장했습니다.
  - 폼과 관련된 파일 정보를 조회하는 기능을 도입했습니다.
  
- **테스트**
  - 파일 및 폼 관련 기능 검증을 위한 새로운 테스트 케이스와 테스트용 고정 데이터를 추가했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->