### PR TITLE
[DDING-000] 최근 폼지 구하기 로직 위치 수정

### DIFF
--- a/src/main/java/ddingdong/ddingdongBE/domain/club/service/FacadeCentralClubServiceImpl.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/club/service/FacadeCentralClubServiceImpl.java
@@ -1,14 +1,19 @@
 package ddingdong.ddingdongBE.domain.club.service;
 
+import static ddingdong.ddingdongBE.domain.form.entity.FormStatus.ONGOING;
+
 import ddingdong.ddingdongBE.domain.club.entity.Club;
 import ddingdong.ddingdongBE.domain.club.service.dto.command.UpdateClubInfoCommand;
 import ddingdong.ddingdongBE.domain.club.service.dto.query.MyClubInfoQuery;
 import ddingdong.ddingdongBE.domain.filemetadata.entity.DomainType;
 import ddingdong.ddingdongBE.domain.filemetadata.service.FileMetaDataService;
 import ddingdong.ddingdongBE.domain.form.entity.Form;
+import ddingdong.ddingdongBE.domain.form.entity.FormStatus;
 import ddingdong.ddingdongBE.domain.form.service.FormService;
 import ddingdong.ddingdongBE.file.service.S3FileService;
 import ddingdong.ddingdongBE.file.service.dto.query.UploadedFileUrlQuery;
+import java.time.LocalDate;
+import java.util.Comparator;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -28,9 +33,7 @@ public class FacadeCentralClubServiceImpl implements FacadeCentralClubService {
     public MyClubInfoQuery getMyClubInfo(Long userId) {
         Club club = clubService.getByUserId(userId);
         List<Form> forms = formService.getAllByClub(club);
-        Form form = formService.findActiveForm(forms) != null
-                ? formService.findActiveForm(forms)
-                : formService.getNewestForm(forms);
+        Form form = chooseActiveOrNewestForm(forms);
         return MyClubInfoQuery.of(
                 club,
                 form,
@@ -47,6 +50,15 @@ public class FacadeCentralClubServiceImpl implements FacadeCentralClubService {
         fileMetaDataService.update(command.profileImageId(), DomainType.CLUB_PROFILE, club.getId());
         fileMetaDataService.update(command.introductionImageId(), DomainType.CLUB_INTRODUCTION, club.getId());
         return club.getId();
+    }
+
+    private Form chooseActiveOrNewestForm(List<Form> forms) {
+        return forms.stream()
+                .filter(f -> f.getFormStatus(LocalDate.now()) == ONGOING)
+                .findFirst()
+                .orElse(forms.stream()
+                        .max(Comparator.comparing(Form::getId))
+                        .orElse(null));
     }
 
     private UploadedFileUrlQuery getFileKey(DomainType domainType, Long clubId) {

--- a/src/main/java/ddingdong/ddingdongBE/domain/club/service/FacadeUserClubServiceImpl.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/club/service/FacadeUserClubServiceImpl.java
@@ -3,7 +3,6 @@ package ddingdong.ddingdongBE.domain.club.service;
 import static ddingdong.ddingdongBE.domain.club.entity.RecruitmentStatus.BEFORE_RECRUIT;
 import static ddingdong.ddingdongBE.domain.club.entity.RecruitmentStatus.END_RECRUIT;
 import static ddingdong.ddingdongBE.domain.club.entity.RecruitmentStatus.RECRUITING;
-import static ddingdong.ddingdongBE.domain.form.entity.FormStatus.ONGOING;
 
 import ddingdong.ddingdongBE.domain.club.entity.Club;
 import ddingdong.ddingdongBE.domain.club.entity.RecruitmentStatus;
@@ -13,12 +12,11 @@ import ddingdong.ddingdongBE.domain.club.service.dto.query.UserClubQuery;
 import ddingdong.ddingdongBE.domain.filemetadata.entity.DomainType;
 import ddingdong.ddingdongBE.domain.filemetadata.service.FileMetaDataService;
 import ddingdong.ddingdongBE.domain.form.entity.Form;
-import ddingdong.ddingdongBE.domain.form.entity.FormStatus;
+import ddingdong.ddingdongBE.domain.form.entity.Forms;
 import ddingdong.ddingdongBE.domain.form.service.FormService;
 import ddingdong.ddingdongBE.file.service.S3FileService;
 import ddingdong.ddingdongBE.file.service.dto.query.UploadedFileUrlQuery;
 import java.time.LocalDate;
-import java.util.Comparator;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -45,23 +43,14 @@ public class FacadeUserClubServiceImpl implements FacadeUserClubService {
     @Override
     public UserClubQuery getClub(Long clubId) {
         Club club = clubService.getById(clubId);
-        List<Form> forms = formService.getAllByClub(club);
-        Form form = chooseActiveOrNewestForm(forms);
+        Forms forms = formService.getAllByClub(club);
+        Form form = forms.getActiveOrNewest();
         return UserClubQuery.of(
                 club,
                 form,
                 getFileKey(DomainType.CLUB_PROFILE, clubId),
                 getFileKey(DomainType.CLUB_INTRODUCTION, clubId)
         );
-    }
-
-    private Form chooseActiveOrNewestForm(List<Form> forms) {
-        return forms.stream()
-                .filter(f -> f.getFormStatus(LocalDate.now()) == ONGOING)
-                .findFirst()
-                .orElse(forms.stream()
-                        .max(Comparator.comparing(Form::getId))
-                        .orElse(null));
     }
 
     private RecruitmentStatus checkRecruit(LocalDate now, LocalDate startDate, LocalDate endDate) {

--- a/src/main/java/ddingdong/ddingdongBE/domain/form/entity/Form.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/form/entity/Form.java
@@ -123,4 +123,14 @@ public class Form extends BaseEntity {
     public void updateEndDate(LocalDate endDate) {
         this.endDate = endDate;
     }
+
+    public FormStatus getFormStatus(LocalDate now) {
+        if (now.isBefore(startDate)) {
+            return FormStatus.UPCOMING;
+        }
+        if (!now.isAfter(endDate)) {
+            return FormStatus.ONGOING;
+        }
+        return FormStatus.CLOSED;
+    }
 }

--- a/src/main/java/ddingdong/ddingdongBE/domain/form/entity/Form.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/form/entity/Form.java
@@ -125,21 +125,23 @@ public class Form extends BaseEntity {
         this.endDate = endDate;
     }
 
-    public FormStatus getFormStatus(LocalDate now) {
-        if (now.isBefore(startDate)) {
-            return FormStatus.UPCOMING;
-        }
-        if (!now.isAfter(endDate)) {
-            return FormStatus.ONGOING;
-        }
-        return FormStatus.CLOSED;
-    }
-
-    public boolean isLargerSectionThan(int sectionSize) {
-        return this.sections.size() > sectionSize;
-    }
-
     public boolean isNotEqualClubId(Long clubId) {
         return !Objects.equals(club.getId(), clubId);
+    }
+
+    public FormStatus getFormStatus(LocalDate localDate) {
+        return FormStatus.determineStatus(this, localDate);
+    }
+
+    public boolean isEqualStatusTo(FormStatus formStatus) {
+        return FormStatus.determineStatus(this, LocalDate.now()) == formStatus;
+    }
+
+    public boolean isAfterStartDateTo(LocalDate date) {
+        return date.isBefore(startDate);
+    }
+
+    public boolean isNotAfterEndDateTo(LocalDate date) {
+        return !date.isAfter(endDate);
     }
 }

--- a/src/main/java/ddingdong/ddingdongBE/domain/form/entity/FormStatus.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/form/entity/FormStatus.java
@@ -12,4 +12,14 @@ public enum FormStatus {
     CLOSED("마감");
 
     private final String description;
+
+    public static FormStatus determineStatus(Form form, LocalDate date) {
+        if (form.isAfterStartDateTo(date)) {
+            return UPCOMING;
+        }
+        if (form.isNotAfterEndDateTo(date)) {
+            return ONGOING;
+        }
+        return CLOSED;
+    }
 }

--- a/src/main/java/ddingdong/ddingdongBE/domain/form/entity/FormStatus.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/form/entity/FormStatus.java
@@ -12,17 +12,4 @@ public enum FormStatus {
     CLOSED("마감");
 
     private final String description;
-
-
-    public static FormStatus getDescription(LocalDate now, LocalDate startDate, LocalDate endDate) {
-        if (now.isBefore(startDate)) {
-            return FormStatus.UPCOMING;
-        }
-
-        if (!now.isAfter(endDate)) {
-            return FormStatus.ONGOING;
-        }
-
-        return FormStatus.CLOSED;
-    }
 }

--- a/src/main/java/ddingdong/ddingdongBE/domain/form/entity/Forms.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/form/entity/Forms.java
@@ -1,0 +1,41 @@
+package ddingdong.ddingdongBE.domain.form.entity;
+
+import static ddingdong.ddingdongBE.domain.form.entity.FormStatus.ONGOING;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Optional;
+
+public class Forms {
+
+    private final List<Form> forms;
+
+    public Forms(List<Form> forms) {
+        this.forms = forms;
+    }
+
+    public Form getActiveOrNewest() {
+        Optional<Form> activeForm = findActiveForm();
+        if (activeForm.isPresent()) {
+            return activeForm.get();
+        }
+        Optional<Form> newestForm = findNewestForm();
+        return newestForm.orElse(null);
+    }
+
+    public List<Form> getForms() {
+        return new ArrayList<>(forms);
+    }
+
+    private Optional<Form> findNewestForm() {
+        return forms.stream()
+                .max(Comparator.comparing(Form::getId));
+    }
+
+    private Optional<Form> findActiveForm() {
+        return forms.stream()
+                .filter(form -> form.isEqualStatusTo(ONGOING))
+                .findFirst();
+    }
+}

--- a/src/main/java/ddingdong/ddingdongBE/domain/form/service/FacadeCentralFormServiceImpl.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/form/service/FacadeCentralFormServiceImpl.java
@@ -206,8 +206,7 @@ public class FacadeCentralFormServiceImpl implements FacadeCentralFormService {
     }
 
     private FormListQuery buildFormListQuery(Form form) {
-        FormStatus formStatus = FormStatus.getDescription(LocalDate.now(), form.getStartDate(),
-                form.getEndDate());
+        FormStatus formStatus = form.getFormStatus(LocalDate.now());
         return FormListQuery.from(form, formStatus);
     }
 

--- a/src/main/java/ddingdong/ddingdongBE/domain/form/service/FacadeCentralFormServiceImpl.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/form/service/FacadeCentralFormServiceImpl.java
@@ -13,7 +13,7 @@ import ddingdong.ddingdongBE.domain.filemetadata.entity.FileMetaData;
 import ddingdong.ddingdongBE.domain.filemetadata.service.FileMetaDataService;
 import ddingdong.ddingdongBE.domain.form.entity.Form;
 import ddingdong.ddingdongBE.domain.form.entity.FormField;
-import ddingdong.ddingdongBE.domain.form.entity.FormStatus;
+import ddingdong.ddingdongBE.domain.form.entity.Forms;
 import ddingdong.ddingdongBE.domain.form.service.dto.command.CreateFormCommand;
 import ddingdong.ddingdongBE.domain.form.service.dto.command.CreateFormCommand.CreateFormFieldCommand;
 import ddingdong.ddingdongBE.domain.form.service.dto.command.SendApplicationResultEmailCommand;
@@ -109,9 +109,9 @@ public class FacadeCentralFormServiceImpl implements FacadeCentralFormService {
     @Override
     public List<FormListQuery> getAllMyForm(User user) {
         Club club = clubService.getByUserId(user.getId());
-        List<Form> forms = formService.getAllByClub(club);
-        return forms.stream()
-                .map(this::buildFormListQuery)
+        Forms forms = formService.getAllByClub(club);
+        return forms.getForms().stream()
+                .map(FormListQuery::from)
                 .toList();
     }
 
@@ -209,11 +209,6 @@ public class FacadeCentralFormServiceImpl implements FacadeCentralFormService {
         validateEndDate(form.getStartDate(), command.endDate());
         validateDuplicationDateExcludingSelf(club, form.getStartDate(), command.endDate(), command.formId());
         form.updateEndDate(command.endDate());
-    }
-
-    private FormListQuery buildFormListQuery(Form form) {
-        FormStatus formStatus = form.getFormStatus(LocalDate.now());
-        return FormListQuery.from(form, formStatus);
     }
 
     private void validateEqualsClub(Club club, Form form) {

--- a/src/main/java/ddingdong/ddingdongBE/domain/form/service/FormService.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/form/service/FormService.java
@@ -2,6 +2,7 @@ package ddingdong.ddingdongBE.domain.form.service;
 
 import ddingdong.ddingdongBE.domain.club.entity.Club;
 import ddingdong.ddingdongBE.domain.form.entity.Form;
+import ddingdong.ddingdongBE.domain.form.entity.Forms;
 import java.time.LocalDate;
 import java.util.List;
 
@@ -13,7 +14,7 @@ public interface FormService {
 
     void delete(Form form);
 
-    List<Form> getAllByClub(Club club);
+    Forms getAllByClub(Club club);
 
     List<Form> findOverlappingForms(Long id, LocalDate startDate, LocalDate endDate);
 

--- a/src/main/java/ddingdong/ddingdongBE/domain/form/service/FormService.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/form/service/FormService.java
@@ -17,7 +17,4 @@ public interface FormService {
 
     List<Form> findOverlappingForms(Long id, LocalDate startDate, LocalDate endDate);
 
-    Form findActiveForm(List<Form> forms);
-
-    Form getNewestForm(List<Form> forms);
 }

--- a/src/main/java/ddingdong/ddingdongBE/domain/form/service/GeneralFormService.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/form/service/GeneralFormService.java
@@ -3,10 +3,9 @@ package ddingdong.ddingdongBE.domain.form.service;
 import ddingdong.ddingdongBE.common.exception.PersistenceException.ResourceNotFound;
 import ddingdong.ddingdongBE.domain.club.entity.Club;
 import ddingdong.ddingdongBE.domain.form.entity.Form;
-import ddingdong.ddingdongBE.domain.form.entity.FormStatus;
+import ddingdong.ddingdongBE.domain.form.entity.Forms;
 import ddingdong.ddingdongBE.domain.form.repository.FormRepository;
 import java.time.LocalDate;
-import java.util.Comparator;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.cache.annotation.CacheEvict;
@@ -48,8 +47,8 @@ public class GeneralFormService implements FormService {
     }
 
     @Override
-    public List<Form> getAllByClub(Club club) {
-        return formRepository.findAllByClub(club);
+    public Forms getAllByClub(Club club) {
+        return new Forms(formRepository.findAllByClub(club));
     }
 
     @Override

--- a/src/main/java/ddingdong/ddingdongBE/domain/form/service/GeneralFormService.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/form/service/GeneralFormService.java
@@ -57,19 +57,4 @@ public class GeneralFormService implements FormService {
         return formRepository.findOverlappingForms(id, startDate, endDate);
     }
 
-    @Override
-    public Form findActiveForm(List<Form> forms) {
-        return forms.stream()
-                .filter(f -> FormStatus.getDescription(LocalDate.now(), f.getStartDate(), f.getEndDate()) == FormStatus.ONGOING)
-                .findFirst()
-                .orElse(null);
-    }
-
-    @Override
-    public Form getNewestForm(List<Form> forms) {
-        return forms.stream()
-                .max(Comparator.comparing(Form::getId))
-                .orElse(null);
-    }
-
 }

--- a/src/main/java/ddingdong/ddingdongBE/domain/form/service/dto/query/FormListQuery.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/form/service/dto/query/FormListQuery.java
@@ -1,7 +1,6 @@
 package ddingdong.ddingdongBE.domain.form.service.dto.query;
 
 import ddingdong.ddingdongBE.domain.form.entity.Form;
-import ddingdong.ddingdongBE.domain.form.entity.FormStatus;
 import java.time.LocalDate;
 import lombok.Builder;
 
@@ -14,13 +13,13 @@ public record FormListQuery(
     String formStatus
 ) {
 
-  public static FormListQuery from(Form form, FormStatus formStatus) {
+  public static FormListQuery from(Form form) {
     return FormListQuery.builder()
         .formId(form.getId())
         .title(form.getTitle())
         .startDate(form.getStartDate())
         .endDate(form.getEndDate())
-        .formStatus(formStatus.getDescription())
+        .formStatus(form.getFormStatus(LocalDate.now()).getDescription())
         .build();
   }
 

--- a/src/main/java/ddingdong/ddingdongBE/domain/formapplication/service/FacadeCentralFormApplicationServiceImpl.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/formapplication/service/FacadeCentralFormApplicationServiceImpl.java
@@ -46,7 +46,7 @@ public class FacadeCentralFormApplicationServiceImpl implements
         Form form = formService.getById(formId);
         validateAuthority(club, form);
         List<FormApplication> formApplications = formApplicationService.getAllByForm(form);
-        FormStatus formStatus = FormStatus.getDescription(LocalDate.now(), form.getStartDate(), form.getEndDate());
+        FormStatus formStatus = form.getFormStatus(LocalDate.now());
         if (formApplications == null) {
             return MyAllFormApplicationsQuery.createEmpty(form, formStatus.getDescription());
         }


### PR DESCRIPTION
## 🚀 작업 내용

getNewestForm 메서드와 findActiveForm 메서드가 DB에 접근하는 메서드도 아닌데 FormService에 있어서 삭제했습니다.
로직들은 수환님이 말씀해주신대로 FacadeClubService에 위치하도록 수정하였습니다!
FormStatus에 있던 getDescription 메서드도 Form 도메인 내에 위치하도록 수정하였습니다.

## 🤔 고민했던 내용

도메인 로직과 서비스 로직, 파사드 패턴에 대해 확실하게 모르는 상태에서 코드를 짰어서 메서드들이 요상한 위치에 있었던 것 같습니다...
get과 find도 무슨 기준으로 이름을 지었는지 모르겠네요... 공부하였고 다음부턴 더 좋은 코드 작성해보겠습니다!

## 💬 리뷰 중점사항

메서드명 괜찮은지 확인 부탁드립니다!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


## Summary by CodeRabbit

- **새로운 기능**
  - 현재 날짜 기준으로 양식 상태를 판단하는 기능이 `Form` 객체 내부 메서드로 통합되어 더욱 직관적으로 개선되었습니다.
  - 여러 양식을 감싸는 `Forms` 객체가 도입되어, 진행 중이거나 최신 양식을 간편하게 조회할 수 있습니다.

- **리팩토링**
  - 양식 선택 로직이 `Forms` 클래스의 `getActiveOrNewest()` 메서드로 통합되어 코드 가독성과 재사용성이 향상되었습니다.
  - 양식 상태 판단 로직이 정적 메서드에서 인스턴스 메서드로 변경되어 책임이 명확해졌습니다.

- **정리**
  - 중복되던 양식 조회 및 상태 판단 관련 메서드들이 제거되어 유지보수성이 개선되었습니다.
  - 인터페이스와 서비스 메서드 반환 타입이 `List<Form>`에서 `Forms`로 변경되어 일관성이 높아졌습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->