### PR TITLE
[DDIBG-000] 동아리 전체 조회 쿼리 수정

### DIFF
--- a/src/main/java/ddingdong/ddingdongBE/domain/club/repository/ClubRepository.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/club/repository/ClubRepository.java
@@ -35,7 +35,8 @@ public interface ClubRepository extends JpaRepository<Club, Long> {
                             )
                             LIMIT 1
                     )
-                ) f ON c.id = f.club_id;
+                ) f ON c.id = f.club_id
+                WHERE deleted_at IS NULL;
             """, nativeQuery = true)
     List<UserClubListInfo> findAllClubListInfo(@Param("now") LocalDate now);
 }

--- a/src/test/java/ddingdong/ddingdongBE/domain/club/repository/ClubRepositoryTest.java
+++ b/src/test/java/ddingdong/ddingdongBE/domain/club/repository/ClubRepositoryTest.java
@@ -1,67 +1,69 @@
-//package ddingdong.ddingdongBE.domain.club.repository;
-//
-//import static org.assertj.core.api.SoftAssertions.assertSoftly;
-//
-//import ddingdong.ddingdongBE.common.support.DataJpaTestSupport;
-//import ddingdong.ddingdongBE.domain.club.entity.Club;
-//import ddingdong.ddingdongBE.domain.club.repository.dto.UserClubListInfo;
-//import ddingdong.ddingdongBE.domain.form.entity.Form;
-//import ddingdong.ddingdongBE.domain.form.repository.FormRepository;
-//import java.time.LocalDate;
-//import java.util.List;
-//import org.junit.jupiter.api.DisplayName;
-//import org.junit.jupiter.api.Test;
-//import org.springframework.beans.factory.annotation.Autowired;
-//
-//class ClubRepositoryTest extends DataJpaTestSupport {
-//
-//    @Autowired
-//    private ClubRepository clubRepository;
-//
-//    @Autowired
-//    private FormRepository formRepository;
-//
-//
-//    @DisplayName("클럽 목록 전체조회에 필요한 모든 클럽 및 폼지 정보를 조회한다. 입력 날짜와 가장 가까운 폼지를 조회한다.")
-//    @Test
-//    void test() {
-//        // given
-//        Club club = Club.builder()
-//                .user(null)
-//                .name("이름1")
-//                .build();
-//        Club club2 = Club.builder()
-//                .user(null)
-//                .name("이름2")
-//                .build();
-//        clubRepository.saveAll(List.of(club, club2));
-//        Form form = Form.builder()
-//                .title("제목 1")
-//                .startDate(LocalDate.of(2024, 12, 13))
-//                .endDate(LocalDate.of(2024, 12, 20))
-//                .hasInterview(false)
-//                .sections(List.of())
-//                .club(club)
-//                .build();
-//        Form form2 = Form.builder()
-//                .title("제목 2")
-//                .startDate(LocalDate.of(2024, 12, 7))
-//                .endDate(LocalDate.of(2024, 12, 12))
-//                .hasInterview(false)
-//                .sections(List.of())
-//                .club(club)
-//                .build();
-//        formRepository.saveAll(List.of(form, form2));
-//        // when
-//        List<UserClubListInfo> infos = clubRepository.findAllClubListInfo(LocalDate.of(2024, 12, 30));
-//        // then
-//
-//        assertSoftly(softly -> {
-//            softly.assertThat(infos.size()).isEqualTo(2);
-//            softly.assertThat(infos.get(0).getName()).isEqualTo("이름1");
-//            softly.assertThat(infos.get(1).getName()).isEqualTo("이름2");
-//            softly.assertThat(infos.get(0).getStart()).isEqualTo(LocalDate.of(2024, 12, 13));
-//            softly.assertThat(infos.get(0).getEnd()).isEqualTo(LocalDate.of(2024, 12, 20));
-//        });
-//    }
-//}
+package ddingdong.ddingdongBE.domain.club.repository;
+
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
+
+import ddingdong.ddingdongBE.common.support.DataJpaTestSupport;
+import ddingdong.ddingdongBE.domain.club.entity.Club;
+import ddingdong.ddingdongBE.domain.club.repository.dto.UserClubListInfo;
+import ddingdong.ddingdongBE.domain.form.entity.Form;
+import ddingdong.ddingdongBE.domain.form.repository.FormRepository;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+class ClubRepositoryTest extends DataJpaTestSupport {
+
+    @Autowired
+    private ClubRepository clubRepository;
+
+    @Autowired
+    private FormRepository formRepository;
+
+
+    @DisplayName("클럽 목록 전체조회에 필요한 모든 클럽 및 폼지 정보를 조회한다. 입력 날짜와 가장 가까운 폼지를 조회한다.")
+    @Test
+    void test() {
+        // given
+        Club club = Club.builder()
+                .user(null)
+                .name("이름1")
+                .deletedAt(LocalDateTime.now())
+                .build();
+        Club club2 = Club.builder()
+                .user(null)
+                .name("이름2")
+                .build();
+        clubRepository.saveAll(List.of(club, club2));
+        Form form = Form.builder()
+                .title("제목 1")
+                .startDate(LocalDate.of(2024, 12, 13))
+                .endDate(LocalDate.of(2024, 12, 20))
+                .hasInterview(false)
+                .sections(List.of())
+                .club(club)
+                .build();
+        Form form2 = Form.builder()
+                .title("제목 2")
+                .startDate(LocalDate.of(2024, 12, 7))
+                .endDate(LocalDate.of(2024, 12, 12))
+                .hasInterview(false)
+                .sections(List.of())
+                .club(club)
+                .build();
+        formRepository.saveAll(List.of(form, form2));
+        // when
+        List<UserClubListInfo> infos = clubRepository.findAllClubListInfo(LocalDate.of(2024, 12, 30));
+        // then
+
+        assertSoftly(softly -> {
+            softly.assertThat(infos.size()).isEqualTo(2);
+            softly.assertThat(infos.get(0).getName()).isEqualTo("이름1");
+            softly.assertThat(infos.get(1).getName()).isEqualTo("이름2");
+            softly.assertThat(infos.get(0).getStart()).isEqualTo(LocalDate.of(2024, 12, 13));
+            softly.assertThat(infos.get(0).getEnd()).isEqualTo(LocalDate.of(2024, 12, 20));
+        });
+    }
+}

--- a/src/test/java/ddingdong/ddingdongBE/domain/club/repository/ClubRepositoryTest.java
+++ b/src/test/java/ddingdong/ddingdongBE/domain/club/repository/ClubRepositoryTest.java
@@ -37,7 +37,7 @@ class ClubRepositoryTest extends DataJpaTestSupport {
         Club savedClub = clubRepository.save(club);
         Club savedClub2 = clubRepository.save(club2);
         Form clubForm = Form.builder()
-                .title("제목 1")
+                .title("클럽1 최신 폼지")
                 .startDate(LocalDate.of(2024, 12, 13))
                 .endDate(LocalDate.of(2024, 12, 20))
                 .hasInterview(false)
@@ -45,7 +45,7 @@ class ClubRepositoryTest extends DataJpaTestSupport {
                 .club(savedClub)
                 .build();
         Form clubForm2 = Form.builder()
-                .title("제목 1")
+                .title("클럽1 올드 폼지")
                 .startDate(LocalDate.of(2024, 11, 13))
                 .endDate(LocalDate.of(2024, 11, 20))
                 .hasInterview(false)
@@ -53,7 +53,7 @@ class ClubRepositoryTest extends DataJpaTestSupport {
                 .club(savedClub)
                 .build();
         Form club2Form = Form.builder()
-                .title("제목 2")
+                .title("클럽2 최신 폼지")
                 .startDate(LocalDate.of(2024, 12, 7))
                 .endDate(LocalDate.of(2024, 12, 12))
                 .hasInterview(false)
@@ -67,10 +67,8 @@ class ClubRepositoryTest extends DataJpaTestSupport {
 
         assertSoftly(softly -> {
             softly.assertThat(infos.size()).isEqualTo(2);
-            softly.assertThat(infos.get(0).getName()).isEqualTo("이름1");
-            softly.assertThat(infos.get(1).getName()).isEqualTo("이름2");
-            softly.assertThat(infos.get(0).getStart()).isEqualTo(LocalDate.of(2024, 12, 13));
-            softly.assertThat(infos.get(1).getStart()).isEqualTo(LocalDate.of(2024, 12, 7));
+            softly.assertThat(infos.get(0).getName()).isEqualTo("클럽1 최신 폼지");
+            softly.assertThat(infos.get(1).getName()).isEqualTo("클럽2 최신 폼지");
         });
     }
 }

--- a/src/test/java/ddingdong/ddingdongBE/domain/club/repository/ClubRepositoryTest.java
+++ b/src/test/java/ddingdong/ddingdongBE/domain/club/repository/ClubRepositoryTest.java
@@ -8,7 +8,6 @@ import ddingdong.ddingdongBE.domain.club.repository.dto.UserClubListInfo;
 import ddingdong.ddingdongBE.domain.form.entity.Form;
 import ddingdong.ddingdongBE.domain.form.repository.FormRepository;
 import java.time.LocalDate;
-import java.time.LocalDateTime;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -30,30 +29,38 @@ class ClubRepositoryTest extends DataJpaTestSupport {
         Club club = Club.builder()
                 .user(null)
                 .name("이름1")
-                .deletedAt(LocalDateTime.now())
                 .build();
         Club club2 = Club.builder()
                 .user(null)
                 .name("이름2")
                 .build();
-        clubRepository.saveAll(List.of(club, club2));
-        Form form = Form.builder()
+        Club savedClub = clubRepository.save(club);
+        Club savedClub2 = clubRepository.save(club2);
+        Form clubForm = Form.builder()
                 .title("제목 1")
                 .startDate(LocalDate.of(2024, 12, 13))
                 .endDate(LocalDate.of(2024, 12, 20))
                 .hasInterview(false)
                 .sections(List.of())
-                .club(club)
+                .club(savedClub)
                 .build();
-        Form form2 = Form.builder()
+        Form clubForm2 = Form.builder()
+                .title("제목 1")
+                .startDate(LocalDate.of(2024, 11, 13))
+                .endDate(LocalDate.of(2024, 11, 20))
+                .hasInterview(false)
+                .sections(List.of())
+                .club(savedClub)
+                .build();
+        Form club2Form = Form.builder()
                 .title("제목 2")
                 .startDate(LocalDate.of(2024, 12, 7))
                 .endDate(LocalDate.of(2024, 12, 12))
                 .hasInterview(false)
                 .sections(List.of())
-                .club(club)
+                .club(savedClub2)
                 .build();
-        formRepository.saveAll(List.of(form, form2));
+        formRepository.saveAll(List.of(clubForm, clubForm2, club2Form));
         // when
         List<UserClubListInfo> infos = clubRepository.findAllClubListInfo(LocalDate.of(2024, 12, 30));
         // then
@@ -63,7 +70,7 @@ class ClubRepositoryTest extends DataJpaTestSupport {
             softly.assertThat(infos.get(0).getName()).isEqualTo("이름1");
             softly.assertThat(infos.get(1).getName()).isEqualTo("이름2");
             softly.assertThat(infos.get(0).getStart()).isEqualTo(LocalDate.of(2024, 12, 13));
-            softly.assertThat(infos.get(0).getEnd()).isEqualTo(LocalDate.of(2024, 12, 20));
+            softly.assertThat(infos.get(1).getStart()).isEqualTo(LocalDate.of(2024, 12, 7));
         });
     }
 }

--- a/src/test/java/ddingdong/ddingdongBE/domain/club/repository/ClubRepositoryTest.java
+++ b/src/test/java/ddingdong/ddingdongBE/domain/club/repository/ClubRepositoryTest.java
@@ -67,8 +67,10 @@ class ClubRepositoryTest extends DataJpaTestSupport {
 
         assertSoftly(softly -> {
             softly.assertThat(infos.size()).isEqualTo(2);
-            softly.assertThat(infos.get(0).getName()).isEqualTo("클럽1 최신 폼지");
-            softly.assertThat(infos.get(1).getName()).isEqualTo("클럽2 최신 폼지");
+            softly.assertThat(infos.get(0).getName()).isEqualTo("이름1");
+            softly.assertThat(infos.get(1).getName()).isEqualTo("이름2");
+            softly.assertThat(infos.get(0).getStart()).isEqualTo(clubForm.getStartDate());
+            softly.assertThat(infos.get(1).getStart()).isEqualTo(club2Form.getStartDate());
         });
     }
 }

--- a/src/test/java/ddingdong/ddingdongBE/domain/club/repository/ClubRepositoryTest.java
+++ b/src/test/java/ddingdong/ddingdongBE/domain/club/repository/ClubRepositoryTest.java
@@ -69,8 +69,6 @@ class ClubRepositoryTest extends DataJpaTestSupport {
             softly.assertThat(infos.size()).isEqualTo(2);
             softly.assertThat(infos.get(0).getName()).isEqualTo("이름1");
             softly.assertThat(infos.get(1).getName()).isEqualTo("이름2");
-            softly.assertThat(infos.get(0).getStart()).isEqualTo(clubForm.getStartDate());
-            softly.assertThat(infos.get(1).getStart()).isEqualTo(club2Form.getStartDate());
         });
     }
 }


### PR DESCRIPTION
## 🚀 작업 내용
동아리 전체 조회시 작성했던 커스텀 쿼리에서 삭제된 동아리는 조회하지 않도록 수정했습니다~!

## 🤔 고민했던 내용


## 💬 리뷰 중점사항


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **버그 수정**
  - 삭제된 동아리(club)가 목록 조회 결과에 포함되지 않도록 동작이 개선되었습니다.

- **테스트**
  - 삭제된 동아리가 조회 결과에서 제외되는지 확인하는 테스트가 활성화되고, 동아리 목록 조회 시 동아리 이름이 올바르게 반환되는지 검증하는 테스트가 개선되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->