### PR TITLE
[DDING-131] 동아리원 개별 삭제 및 생성 API 구현

### DIFF
--- a/src/main/java/ddingdong/ddingdongBE/domain/clubmember/api/ClubMemberApi.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/clubmember/api/ClubMemberApi.java
@@ -1,6 +1,7 @@
 package ddingdong.ddingdongBE.domain.clubmember.api;
 
 import ddingdong.ddingdongBE.auth.PrincipalDetails;
+import ddingdong.ddingdongBE.domain.clubmember.api.dto.request.CreateClubMemberRequest;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
@@ -9,6 +10,8 @@ import org.springframework.http.HttpStatus;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.ResponseStatus;
 
@@ -22,4 +25,11 @@ public interface ClubMemberApi {
     @SecurityRequirement(name = "AccessToken")
     @DeleteMapping("/{id}")
     void delete(@AuthenticationPrincipal PrincipalDetails principalDetails, @PathVariable("id") Long clubMemberId);
+
+    @Operation(summary = "동아리원 개별 추가 API")
+    @ResponseStatus(HttpStatus.CREATED)
+    @ApiResponse(responseCode = "201", description = "동아리원 개별 생성 성공")
+    @SecurityRequirement(name = "AccessToken")
+    @PostMapping
+    void create(@AuthenticationPrincipal PrincipalDetails principalDetails, @RequestBody CreateClubMemberRequest request);
 }

--- a/src/main/java/ddingdong/ddingdongBE/domain/clubmember/api/ClubMemberApi.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/clubmember/api/ClubMemberApi.java
@@ -1,0 +1,25 @@
+package ddingdong.ddingdongBE.domain.clubmember.api;
+
+import ddingdong.ddingdongBE.auth.PrincipalDetails;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@Tag(name = "ClubMember - Central", description = "ClubMember API")
+@RequestMapping("/server/club-members")
+public interface ClubMemberApi {
+
+    @Operation(summary = "동아리원 개별 삭제 API")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    @ApiResponse(responseCode = "204", description = "동아리원 개별 삭제 성공")
+    @SecurityRequirement(name = "AccessToken")
+    @DeleteMapping("/{id}")
+    void delete(@AuthenticationPrincipal PrincipalDetails principalDetails, @PathVariable("id") Long clubMemberId);
+}

--- a/src/main/java/ddingdong/ddingdongBE/domain/clubmember/api/ClubMemberController.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/clubmember/api/ClubMemberController.java
@@ -1,0 +1,19 @@
+package ddingdong.ddingdongBE.domain.clubmember.api;
+
+import ddingdong.ddingdongBE.auth.PrincipalDetails;
+import ddingdong.ddingdongBE.domain.clubmember.service.FacadeCentralClubMemberService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class ClubMemberController implements ClubMemberApi{
+
+    private final FacadeCentralClubMemberService facadeCentralClubMemberService;
+
+    @Override
+    public void delete(final PrincipalDetails principalDetails, final Long clubMemberId) {
+        Long userId = principalDetails.getUser().getId();
+        facadeCentralClubMemberService.delete(userId, clubMemberId);
+    }
+}

--- a/src/main/java/ddingdong/ddingdongBE/domain/clubmember/api/ClubMemberController.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/clubmember/api/ClubMemberController.java
@@ -1,6 +1,7 @@
 package ddingdong.ddingdongBE.domain.clubmember.api;
 
 import ddingdong.ddingdongBE.auth.PrincipalDetails;
+import ddingdong.ddingdongBE.domain.clubmember.api.dto.request.CreateClubMemberRequest;
 import ddingdong.ddingdongBE.domain.clubmember.service.FacadeCentralClubMemberService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.RestController;
@@ -12,8 +13,14 @@ public class ClubMemberController implements ClubMemberApi{
     private final FacadeCentralClubMemberService facadeCentralClubMemberService;
 
     @Override
-    public void delete(final PrincipalDetails principalDetails, final Long clubMemberId) {
+    public void delete(PrincipalDetails principalDetails, Long clubMemberId) {
         Long userId = principalDetails.getUser().getId();
         facadeCentralClubMemberService.delete(userId, clubMemberId);
+    }
+
+    @Override
+    public void create(PrincipalDetails principalDetails, CreateClubMemberRequest request) {
+        Long userId = principalDetails.getUser().getId();
+        facadeCentralClubMemberService.create(request.toCommand(userId));
     }
 }

--- a/src/main/java/ddingdong/ddingdongBE/domain/clubmember/api/dto/request/CreateClubMemberRequest.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/clubmember/api/dto/request/CreateClubMemberRequest.java
@@ -1,0 +1,50 @@
+package ddingdong.ddingdongBE.domain.clubmember.api.dto.request;
+
+import ddingdong.ddingdongBE.domain.club.entity.Position;
+import ddingdong.ddingdongBE.domain.clubmember.service.dto.command.CreateClubMemberCommand;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import lombok.Builder;
+
+@Schema(
+        name = "CreateClubMemberRequest",
+        description = "동아리원 정보 생성 요청"
+)
+@Builder
+public record CreateClubMemberRequest(
+
+        @Schema(description = "이름", example = "홍길동")
+        @NotNull(message = "이름은 필수로 입력해야 합니다.")
+        String name,
+
+        @Schema(description = "학번", example = "60001234")
+        @NotNull(message = "학번은 필수로 입력해야 합니다.")
+        String studentNumber,
+
+        @Schema(description = "전화번호", example = "010-1234-5678")
+        @NotNull(message = "전화번호는 필수로 입력해야 합니다.")
+        String phoneNumber,
+
+        @Schema(description = "동아리원 역할",
+                example = "LEADER",
+                allowableValues = {"LEADER", "EXECUTION", "MEMBER"}
+        )
+        @NotNull(message = "역할은 필수로 입력해야 합니다.")
+        String position,
+
+        @Schema(description = "학과(부)", example = "융합소프트웨어학부")
+        @NotNull(message = "학과(부)는 필수로 입력해야 합니다.")
+        String department
+) {
+
+    public CreateClubMemberCommand toCommand(Long userId) {
+        return CreateClubMemberCommand.builder()
+                .userId(userId)
+                .name(name)
+                .studentNumber(studentNumber)
+                .phoneNumber(phoneNumber)
+                .position(Position.from(position))
+                .department(department)
+                .build();
+    }
+}

--- a/src/main/java/ddingdong/ddingdongBE/domain/clubmember/entity/ClubMember.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/clubmember/entity/ClubMember.java
@@ -19,6 +19,7 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.NonNull;
 import org.hibernate.annotations.SQLDelete;
 import org.hibernate.annotations.SQLRestriction;
 
@@ -75,7 +76,7 @@ public class ClubMember extends BaseEntity {
         this.club = club;
     }
 
-    public void validateBelongsToClub(final Club targetClub) {
+    public void validateBelongsToClub(@NonNull final Club targetClub) {
         if (this.club == null || !Objects.equals(this.club.getId(), targetClub.getId())) {
             throw new IllegalArgumentException("동아리원은 해당 동아리에 속해 있지 않습니다");
         }

--- a/src/main/java/ddingdong/ddingdongBE/domain/clubmember/entity/ClubMember.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/clubmember/entity/ClubMember.java
@@ -14,6 +14,7 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import java.time.LocalDateTime;
+import java.util.Objects;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -72,5 +73,11 @@ public class ClubMember extends BaseEntity {
 
     public void setClubForConvenience(Club club) {
         this.club = club;
+    }
+
+    public void validateBelongsToClub(final Club targetClub) {
+        if (this.club == null || !Objects.equals(this.club.getId(), targetClub.getId())) {
+            throw new IllegalArgumentException("동아리원은 해당 동아리에 속해 있지 않습니다");
+        }
     }
 }

--- a/src/main/java/ddingdong/ddingdongBE/domain/clubmember/service/ClubMemberService.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/clubmember/service/ClubMemberService.java
@@ -12,4 +12,6 @@ public interface ClubMemberService {
     void deleteAll(List<ClubMember> clubMembers);
 
     void delete(ClubMember clubMember);
+
+    void save(ClubMember clubMember);
 }

--- a/src/main/java/ddingdong/ddingdongBE/domain/clubmember/service/ClubMemberService.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/clubmember/service/ClubMemberService.java
@@ -10,4 +10,6 @@ public interface ClubMemberService {
     void saveAll(List<ClubMember> clubMembers);
 
     void deleteAll(List<ClubMember> clubMembers);
+
+    void delete(ClubMember clubMember);
 }

--- a/src/main/java/ddingdong/ddingdongBE/domain/clubmember/service/FacadeCentralClubMemberService.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/clubmember/service/FacadeCentralClubMemberService.java
@@ -14,4 +14,5 @@ public interface FacadeCentralClubMemberService {
 
     void update(UpdateClubMemberCommand updateClubMemberCommand);
 
+    void delete(Long userId, Long clubMemberId);
 }

--- a/src/main/java/ddingdong/ddingdongBE/domain/clubmember/service/FacadeCentralClubMemberService.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/clubmember/service/FacadeCentralClubMemberService.java
@@ -1,5 +1,6 @@
 package ddingdong.ddingdongBE.domain.clubmember.service;
 
+import ddingdong.ddingdongBE.domain.clubmember.service.dto.command.CreateClubMemberCommand;
 import ddingdong.ddingdongBE.domain.clubmember.service.dto.command.UpdateClubMemberCommand;
 import ddingdong.ddingdongBE.domain.clubmember.service.dto.command.UpdateClubMemberListCommand;
 import ddingdong.ddingdongBE.domain.clubmember.service.dto.query.AllClubMemberInfoQuery;
@@ -15,4 +16,6 @@ public interface FacadeCentralClubMemberService {
     void update(UpdateClubMemberCommand updateClubMemberCommand);
 
     void delete(Long userId, Long clubMemberId);
+
+    void create(CreateClubMemberCommand command);
 }

--- a/src/main/java/ddingdong/ddingdongBE/domain/clubmember/service/FacadeCentralClubMemberServiceImpl.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/clubmember/service/FacadeCentralClubMemberServiceImpl.java
@@ -3,6 +3,7 @@ package ddingdong.ddingdongBE.domain.clubmember.service;
 import ddingdong.ddingdongBE.domain.club.entity.Club;
 import ddingdong.ddingdongBE.domain.club.service.ClubService;
 import ddingdong.ddingdongBE.domain.clubmember.entity.ClubMember;
+import ddingdong.ddingdongBE.domain.clubmember.service.dto.command.CreateClubMemberCommand;
 import ddingdong.ddingdongBE.domain.clubmember.service.dto.command.UpdateClubMemberCommand;
 import ddingdong.ddingdongBE.domain.clubmember.service.dto.command.UpdateClubMemberListCommand;
 import ddingdong.ddingdongBE.domain.clubmember.service.dto.query.AllClubMemberInfoQuery;
@@ -65,11 +66,20 @@ public class FacadeCentralClubMemberServiceImpl implements FacadeCentralClubMemb
 
     @Override
     @Transactional
-    public void delete(final Long userId, final Long clubMemberId) {
+    public void delete(Long userId, Long clubMemberId) {
         Club club = clubService.getByUserId(userId);
         ClubMember clubMember = clubMemberService.getById(clubMemberId);
         clubMember.validateBelongsToClub(club);
         clubMemberService.delete(clubMember);
+    }
+
+    @Override
+    @Transactional
+    public void create(final CreateClubMemberCommand command) {
+        Club club = clubService.getByUserId(command.userId());
+        ClubMember clubMember = command.toEntity(club);
+        clubMemberService.save(clubMember);
+        club.addClubMember(clubMember);
     }
 
     private List<ClubMember> filterCreatedMembers(List<ClubMember> updatedClubMembers, Set<Long> updatedMemberIds,

--- a/src/main/java/ddingdong/ddingdongBE/domain/clubmember/service/FacadeCentralClubMemberServiceImpl.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/clubmember/service/FacadeCentralClubMemberServiceImpl.java
@@ -63,6 +63,14 @@ public class FacadeCentralClubMemberServiceImpl implements FacadeCentralClubMemb
         clubMember.updateInformation(command.toEntity());
     }
 
+    @Override
+    @Transactional
+    public void delete(final Long userId, final Long clubMemberId) {
+        Club club = clubService.getByUserId(userId);
+        ClubMember clubMember = clubMemberService.getById(clubMemberId);
+        clubMember.validateBelongsToClub(club);
+        clubMemberService.delete(clubMember);
+    }
 
     private List<ClubMember> filterCreatedMembers(List<ClubMember> updatedClubMembers, Set<Long> updatedMemberIds,
                                                   Set<Long> currentMemberIds) {

--- a/src/main/java/ddingdong/ddingdongBE/domain/clubmember/service/GeneralClubMemberService.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/clubmember/service/GeneralClubMemberService.java
@@ -33,4 +33,8 @@ public class GeneralClubMemberService implements ClubMemberService {
         clubMemberRepository.deleteAllInBatch(clubMembers);
     }
 
+    @Override
+    public void delete(final ClubMember clubMember) {
+        clubMemberRepository.delete(clubMember);
+    }
 }

--- a/src/main/java/ddingdong/ddingdongBE/domain/clubmember/service/GeneralClubMemberService.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/clubmember/service/GeneralClubMemberService.java
@@ -34,7 +34,12 @@ public class GeneralClubMemberService implements ClubMemberService {
     }
 
     @Override
-    public void delete(final ClubMember clubMember) {
+    public void delete(ClubMember clubMember) {
         clubMemberRepository.delete(clubMember);
+    }
+
+    @Override
+    public void save(ClubMember clubMember) {
+        clubMemberRepository.save(clubMember);
     }
 }

--- a/src/main/java/ddingdong/ddingdongBE/domain/clubmember/service/GeneralClubMemberService.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/clubmember/service/GeneralClubMemberService.java
@@ -34,11 +34,13 @@ public class GeneralClubMemberService implements ClubMemberService {
     }
 
     @Override
+    @Transactional
     public void delete(ClubMember clubMember) {
         clubMemberRepository.delete(clubMember);
     }
 
     @Override
+    @Transactional
     public void save(ClubMember clubMember) {
         clubMemberRepository.save(clubMember);
     }

--- a/src/main/java/ddingdong/ddingdongBE/domain/clubmember/service/dto/command/CreateClubMemberCommand.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/clubmember/service/dto/command/CreateClubMemberCommand.java
@@ -1,0 +1,28 @@
+package ddingdong.ddingdongBE.domain.clubmember.service.dto.command;
+
+import ddingdong.ddingdongBE.domain.club.entity.Club;
+import ddingdong.ddingdongBE.domain.club.entity.Position;
+import ddingdong.ddingdongBE.domain.clubmember.entity.ClubMember;
+import lombok.Builder;
+
+@Builder
+public record CreateClubMemberCommand(
+        Long userId,
+        String name,
+        String studentNumber,
+        String phoneNumber,
+        Position position,
+        String department
+) {
+
+    public ClubMember toEntity(Club club) {
+        return ClubMember.builder()
+                .name(name)
+                .studentNumber(studentNumber)
+                .phoneNumber(phoneNumber)
+                .position(position)
+                .department(department)
+                .club(club)
+                .build();
+    }
+}

--- a/src/test/java/ddingdong/ddingdongBE/common/fixture/ClubFixture.java
+++ b/src/test/java/ddingdong/ddingdongBE/common/fixture/ClubFixture.java
@@ -1,0 +1,30 @@
+package ddingdong.ddingdongBE.common.fixture;
+
+import ddingdong.ddingdongBE.domain.club.entity.Club;
+import ddingdong.ddingdongBE.domain.club.entity.Location;
+import ddingdong.ddingdongBE.domain.club.entity.PhoneNumber;
+import ddingdong.ddingdongBE.domain.scorehistory.entity.Score;
+import ddingdong.ddingdongBE.domain.user.entity.User;
+import java.math.BigDecimal;
+import java.util.ArrayList;
+
+public class ClubFixture {
+
+    public static Club createClub(final User user) {
+        return Club.builder()
+                .user(user)
+                .clubMembers(new ArrayList<>())
+                .name("컴퓨터공학과 동아리")
+                .category("학술")
+                .tag("프로그래밍, 개발, IT")
+                .leader("김동아")
+                .phoneNumber(PhoneNumber.from("010-1234-5678"))
+                .location(Location.from("S3014"))  // S + 4자리 숫자
+                .regularMeeting("매주 수요일 18:00")
+                .introduction("컴퓨터공학과 학생들이 함께 공부하고 프로젝트를 진행하는 동아리입니다.")
+                .activity("알고리즘 스터디, 웹 개발 프로젝트, 해커톤 참가")
+                .ideal("함께 성장하는 개발자 커뮤니티")
+                .score(Score.from(BigDecimal.valueOf(85.5)))
+                .build();
+    }
+}

--- a/src/test/java/ddingdong/ddingdongBE/common/fixture/UserFixture.java
+++ b/src/test/java/ddingdong/ddingdongBE/common/fixture/UserFixture.java
@@ -1,0 +1,14 @@
+package ddingdong.ddingdongBE.common.fixture;
+
+import ddingdong.ddingdongBE.domain.user.entity.Role;
+import ddingdong.ddingdongBE.domain.user.entity.User;
+
+public class UserFixture {
+
+    public static User createClubUser() {
+        return User.builder()
+                .name("랜덤 이름")
+                .role(Role.CLUB)
+                .build();
+    }
+}

--- a/src/test/java/ddingdong/ddingdongBE/domain/clubmember/service/ClubMemberFixture.java
+++ b/src/test/java/ddingdong/ddingdongBE/domain/clubmember/service/ClubMemberFixture.java
@@ -1,0 +1,14 @@
+package ddingdong.ddingdongBE.domain.clubmember.service;
+
+import ddingdong.ddingdongBE.domain.club.entity.Club;
+import ddingdong.ddingdongBE.domain.clubmember.entity.ClubMember;
+
+public class ClubMemberFixture {
+
+    public static ClubMember createClubMember(Club club) {
+        return ClubMember.builder()
+                .name("웨이드")
+                .club(club)
+                .build();
+    }
+}


### PR DESCRIPTION
## 🚀 작업 내용
- 동아리원 개별 삭제 API 구현
- 동아리원 개별 생성 API 구현
- 테스트 작성



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - 클럽 구성원 생성/삭제 API 추가: 인증 필요, 생성 시 이름·학번·연락처·직책·학과 입력을 받아 201 생성/204 삭제 응답 반환.
- Bug Fixes
  - 삭제 시 구성원이 해당 동아리에 속하는지 검증을 강화하여 잘못된 삭제 방지.
- Tests
  - 생성/삭제 흐름 통합 테스트 및 테스트용 픽스처 추가: 정상 처리 확인, 삭제 후 조회 불가, 권한 없는 삭제 예외 검증.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->