### PR TITLE
[DDING-000] 힙 메모리 증가 및 GC 로그 설정

### DIFF
--- a/.ebextensions/00-makeFiles.config
+++ b/.ebextensions/00-makeFiles.config
@@ -14,7 +14,7 @@ files:
             java \
               -Dfile.encoding=UTF-8 \
               -Xms512m -Xmx1024m \
-              -Xlog:gc*,gc+heap:file=$LOG_DIR/gc.log:time,uptime,level \
+              +-Xlog:gc*:file="$GC_LOG_DIR/gc.log":time,uptime,level,tags,filecount=5,filesize=100M \
               -XX:+HeapDumpOnOutOfMemoryError \
               -XX:HeapDumpPath=$LOG_DIR/heapdump.hprof \
               -jar $JAR_PATH \

--- a/.ebextensions/00-makeFiles.config
+++ b/.ebextensions/00-makeFiles.config
@@ -6,7 +6,7 @@ files:
         content: |
             #!/usr/bin/env bash
             JAR_PATH=/var/app/current/application.jar
-            LOG_DIR=/var/app/current/logs
+            LOG_DIR=/var/app/current/logs/gc
             mkdir -p $LOG_DIR
 
             # run app
@@ -15,6 +15,7 @@ files:
               -Dfile.encoding=UTF-8 \
               -Xms512m -Xmx1024m \
               -Xlog:gc*,gc+heap:file=$LOG_DIR/gc.log:time,uptime,level \
+              -XX:+HeapDumpOnOutOfMemoryError \
+              -XX:HeapDumpPath=$LOG_DIR/heapdump.hprof \
               -jar $JAR_PATH \
               >> $LOG_DIR/app.log 2>&1
-

--- a/.ebextensions/00-makeFiles.config
+++ b/.ebextensions/00-makeFiles.config
@@ -9,4 +9,5 @@ files:
 
             # run app
             killall java
-            java -Dfile.encoding=UTF-8 -jar $JAR_PATH
+            java -Dfile.encoding=UTF-8 -Xms512m -Xmx1024m -jar $JAR_PATH
+

--- a/.ebextensions/00-makeFiles.config
+++ b/.ebextensions/00-makeFiles.config
@@ -14,8 +14,7 @@ files:
             java \
               -Dfile.encoding=UTF-8 \
               -Xms512m -Xmx1024m \
-              +-Xlog:gc*:file="$GC_LOG_DIR/gc.log":time,uptime,level,tags,filecount=5,filesize=100M \
+              -Xlog:gc*:file="$GC_LOG_DIR/gc.log":time,uptime,level,tags,filecount=5,filesize=100M \
               -XX:+HeapDumpOnOutOfMemoryError \
               -XX:HeapDumpPath=$LOG_DIR/heapdump.hprof \
               -jar $JAR_PATH \
-              >> $LOG_DIR/app.log 2>&1

--- a/.ebextensions/00-makeFiles.config
+++ b/.ebextensions/00-makeFiles.config
@@ -6,8 +6,15 @@ files:
         content: |
             #!/usr/bin/env bash
             JAR_PATH=/var/app/current/application.jar
+            LOG_DIR=/var/app/current/logs
+            mkdir -p $LOG_DIR
 
             # run app
             killall java
-            java -Dfile.encoding=UTF-8 -Xms512m -Xmx1024m -jar $JAR_PATH
+            java \
+              -Dfile.encoding=UTF-8 \
+              -Xms512m -Xmx1024m \
+              -Xlog:gc*,gc+heap:file=$LOG_DIR/gc.log:time,uptime,level \
+              -jar $JAR_PATH \
+              >> $LOG_DIR/app.log 2>&1
 


### PR DESCRIPTION
## 문제 상황

1. 힙 메모리 93%이상 사용하는 것을 발견
<img width="1403" height="487" alt="스크린샷 2025-08-24 오후 3 23 45" src="https://github.com/user-attachments/assets/5a6f73f1-78b5-43d5-9b86-6035df308fc0" />


2. old generation이 꽉 채워짐
<img width="485" height="315" alt="스크린샷 2025-08-25 오후 4 05 54" src="https://github.com/user-attachments/assets/dca27f46-d82d-4447-a1fe-6909873bc5cf" />


3. major gc 16초 실행으로 Pause 시간도 16초 이상 발생
<img width="747" height="352" alt="스크린샷 2025-08-25 오후 2 42 18" src="https://github.com/user-attachments/assets/36fcdebe-e8b4-478a-a831-00c56a1e9d93" />


[예상 문제 원인]
- Old Generation이 꽉차 GC가 객체들을 청소할 때, Live Object가 많아 오랜시간 스캔을 한 것 같음.
Live Object가 많은 이유가 Cache 설정 때문인 것 같음.

## 해결 방안

1. 1차적으로 힙 메모리 증가

2. GC 로그를 통해 pause 원인을 모니터링

3. GC 덤프로 old generation에 차지하고 있는 Live Object 분석
- 예상 : 캐시 과다. Spring Cache가 문제가 아닐까...

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* Chores
  * 전용 로그 디렉터리 생성 및 애플리케이션·GC/힙 로그 통합 활성화, OOM 발생 시 힙 덤프 저장을 적용해 운영 중 문제 조사와 로그 접근성이 개선됩니다.
* Refactor
  * JVM 메모리 한도(초기/최대)와 실행 옵션을 명시적으로 정리해 메모리 동작이 보다 예측 가능하고 안정성이 향상됩니다. 단, 로그 경로 관련 환경 변수 불일치로 런타임 이슈가 발생할 수 있으니 배포 전 확인이 필요합니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->