### PR TITLE
[DDING-000] SSE 비동기 전송 시 Spring Security AccessDeniedException 발생 문제 해결

### DIFF
--- a/src/main/java/ddingdong/ddingdongBE/common/config/SecurityConfig.java
+++ b/src/main/java/ddingdong/ddingdongBE/common/config/SecurityConfig.java
@@ -7,6 +7,7 @@ import ddingdong.ddingdongBE.auth.service.JwtAuthService;
 import ddingdong.ddingdongBE.common.filter.JwtAuthenticationFilter;
 import ddingdong.ddingdongBE.common.handler.CustomAccessDeniedHandler;
 import ddingdong.ddingdongBE.common.handler.RestAuthenticationEntryPoint;
+import jakarta.servlet.DispatcherType;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -32,6 +33,7 @@ public class SecurityConfig {
             throws Exception {
         http
                 .authorizeHttpRequests(auth -> auth
+                        .dispatcherTypeMatchers(DispatcherType.ASYNC).permitAll()
                         .requestMatchers(API_PREFIX + "/auth/**",
                                 API_PREFIX + "/events/**")
                         .permitAll()

--- a/src/main/java/ddingdong/ddingdongBE/domain/feed/service/FacadeClubFeedServiceImpl.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/feed/service/FacadeClubFeedServiceImpl.java
@@ -19,10 +19,12 @@ import ddingdong.ddingdongBE.sse.service.dto.SseVodProcessingNotificationDto;
 import java.time.LocalDateTime;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
@@ -88,6 +90,7 @@ public class FacadeClubFeedServiceImpl implements FacadeClubFeedService {
     private void checkVodProcessingJobAndNotify(Feed feed) {
         VodProcessingJob vodProcessingJob = vodProcessingJobService.findByVideoFeedId(feed.getId());
         if (vodProcessingJob != null && vodProcessingJob.isPossibleNotify()) {
+            log.info("피드 생성이 뒤늦게 완료되어 알람 전송 {} : {}", feed.getClub().getName(), feed.getId());
             SseEvent<SseVodProcessingNotificationDto> sseEvent = SseEvent.of(
                     "vod-processing",
                     new SseVodProcessingNotificationDto(

--- a/src/main/java/ddingdong/ddingdongBE/domain/vodprocessing/service/FacadeVodProcessingJobServiceImpl.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/vodprocessing/service/FacadeVodProcessingJobServiceImpl.java
@@ -14,11 +14,13 @@ import ddingdong.ddingdongBE.sse.service.dto.SseVodProcessingNotificationDto;
 import java.time.LocalDateTime;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @Transactional(readOnly = true)
+@Slf4j
 @RequiredArgsConstructor
 public class FacadeVodProcessingJobServiceImpl implements FacadeVodProcessingJobService {
 
@@ -40,6 +42,7 @@ public class FacadeVodProcessingJobServiceImpl implements FacadeVodProcessingJob
     @Override
     @Transactional
     public void updateVodProcessingJobStatus(UpdateVodProcessingJobStatusCommand command) {
+        log.info("vod상태 업데이트 메서드 호출 {} : {}", command.convertJobId(), command.status());
         VodProcessingJob vodProcessingJob = vodProcessingJobService.getByConvertJobId(command.convertJobId());
         vodProcessingJob.updateConvertJobStatus(command.status());
         checkVodProcessingJobStatus(vodProcessingJob);
@@ -54,10 +57,12 @@ public class FacadeVodProcessingJobServiceImpl implements FacadeVodProcessingJob
     private void checkExistingFeedAndNotify(VodProcessingJob vodProcessingJob) {
         Long entityId = vodProcessingJob.getFileMetaData().getEntityId();
         if(entityId == null) {
+            log.info("현재 피드 업로드가 완료되지 않아 알림 보내지 않고 종료");
             return;
         }
         Optional<Feed> optionalFeed = feedService.findById(entityId);
         if (optionalFeed.isPresent()) {
+            log.info("피드 업로드가 완료된 상태로, 알람 전송");
             SseEvent<SseVodProcessingNotificationDto> sseEvent = SseEvent.of(
                     "vod-processing",
                     new SseVodProcessingNotificationDto(

--- a/src/main/java/ddingdong/ddingdongBE/sse/service/SseConnectionService.java
+++ b/src/main/java/ddingdong/ddingdongBE/sse/service/SseConnectionService.java
@@ -61,7 +61,7 @@ public class SseConnectionService {
                 sseEmitter.send(SseEmitter.event()
                         .name("sse")
                         .data(data));
-                log.debug("SSE Event sent to user {}: {}", sseId, "sse");
+                log.info("SSE Event 사용자에게 전송완료 userid:{}: {}", sseId, "sse");
             } catch (IOException e) {
                 log.error("Error sending SSE event to user: {}", sseId, e);
                 sseEmitter.complete();


### PR DESCRIPTION
## 🚀 작업 내용
- SSE(Server-Sent Events) 구독 중 SseEmitter.send() 호출 시 AccessDeniedException 발생 이슈 해결
- DispatcherType.ASYNC 상태에서 Spring Security의 AuthorizationFilter가 재실행되며 인증정보가 비어 발생
- DispatcherType.ASYNC 요청을 인증 제외 처리해 비동기 디스패치 중 발생하는 AccessDeniedException 방지

## 🤔 고민했던 내용
- [Spring Security 공식 이슈 #16266](https://github.com/spring-projects/spring-security/issues/16266)￼ 참고
→ SSE는 내부적으로 AsyncContext.dispatch() 로 비동기 디스패치를 수행하며, 이때 인증정보가 전파되지 않음
-> 비동기 스레드에서 인증 검사를 완전히 비활성화(permitAll)하는 것이 가장 명확하고 안전한 해결책으로 판단

## 💬 리뷰 중점사항


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **보안 개선**
  * 비동기 요청(Async)에 대한 인증 절차 최적화

* **개선 사항**
  * VOD 처리 및 알림 발송 과정에 대한 상세 로깅 추가
  * SSE 이벤트 전송 로그 메시지 개선

<!-- end of auto-generated comment: release notes by coderabbit.ai -->