### PR TITLE
fix: WebP 이미지 지원을 위한 TwelveMonkeys 의존성 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -61,6 +61,7 @@ dependencies {
     implementation 'software.amazon.awssdk:ses:2.24.0'
     implementation 'com.google.guava:guava:32.1.3-jre'
     implementation 'com.github.ben-manes.caffeine:caffeine'
+    implementation 'com.twelvemonkeys.imageio:imageio-webp:3.12.0'
 
     //security
     implementation 'org.springframework.boot:spring-boot-starter-security'


### PR DESCRIPTION
## 🚀 작업 내용
- 이달의 피드 랭킹 1위 배너 자동 생성 시, WebP 포맷 로고가 렌더링되지 않는 버그 수정
- `TwelveMonkeys ImageIO WebP` 플러그인 의존성 추가 (`build.gradle` 1줄)
- Java ImageIO SPI 방식으로 동작하여 기존 코드 변경 없이 `ImageIO.read()`가 WebP를 자동 인식

## 🤔 고민했던 내용
- 카우(clubId=91) 동아리 프로필 이미지가 실제로는 WebP 포맷이지만 S3 content-type이 `image/png`으로 잘못 저장되어 있었음
- `ImageIO.read()`가 WebP를 지원하지 않아 `null` 반환 → 로고 없이 배경색만 렌더링되는 현상 발생
- 다른 동아리도 WebP 이미지를 업로드할 수 있으므로 근본적으로 WebP 디코딩 지원이 필요

## 💬 리뷰 중점사항
- SPI 확장 방식이라 기존 PNG, JPEG 처리에는 영향 없음
- 로컬에서 실제 카우 WebP 로고로 배너 생성 테스트 완료 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **개선사항**
  * WebP 이미지 형식 지원이 추가되어 더 효율적인 이미지 처리가 가능해졌습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->