### PR TITLE
feat: 총동연 피드 랭킹 스냅샷 조회 API 추가 및 가중치 계산 중복 제거

### DIFF
--- a/src/main/java/ddingdong/ddingdongBE/domain/feed/api/AdminFeedApi.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/feed/api/AdminFeedApi.java
@@ -31,4 +31,15 @@ public interface AdminFeedApi {
             @RequestParam("year") @Min(value = 2000, message = "year는 2000 이상이어야 합니다.") @Max(value = 2100, message = "year는 2100 이하여야 합니다.") int year,
             @RequestParam("month") @Min(value = 1, message = "month는 1 이상이어야 합니다.") @Max(value = 12, message = "month는 12 이하여야 합니다.") int month
     );
+
+    @Operation(summary = "총동연 피드 랭킹 스냅샷 조회 API")
+    @ApiResponse(responseCode = "200", description = "동아리별 피드 랭킹 스냅샷 조회 성공",
+            content = @Content(array = @ArraySchema(schema = @Schema(implementation = AdminClubFeedRankingResponse.class))))
+    @ResponseStatus(HttpStatus.OK)
+    @SecurityRequirement(name = "AccessToken")
+    @GetMapping("/ranking/snapshot")
+    List<AdminClubFeedRankingResponse> getClubFeedRankingSnapshot(
+            @RequestParam("year") @Min(value = 2000, message = "year는 2000 이상이어야 합니다.") @Max(value = 2100, message = "year는 2100 이하여야 합니다.") int year,
+            @RequestParam("month") @Min(value = 1, message = "month는 1 이상이어야 합니다.") @Max(value = 12, message = "month는 12 이하여야 합니다.") int month
+    );
 }

--- a/src/main/java/ddingdong/ddingdongBE/domain/feed/controller/AdminFeedController.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/feed/controller/AdminFeedController.java
@@ -21,4 +21,11 @@ public class AdminFeedController implements AdminFeedApi {
                 feedRankingService.getClubFeedRanking(year, month)
         );
     }
+
+    @Override
+    public List<AdminClubFeedRankingResponse> getClubFeedRankingSnapshot(int year, int month) {
+        return AdminClubFeedRankingResponse.from(
+                feedRankingService.getClubFeedRankingSnapshot(year, month)
+        );
+    }
 }

--- a/src/main/java/ddingdong/ddingdongBE/domain/feed/repository/FeedMonthlyRankingRepository.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/feed/repository/FeedMonthlyRankingRepository.java
@@ -10,4 +10,7 @@ public interface FeedMonthlyRankingRepository extends JpaRepository<FeedMonthlyR
 
     List<FeedMonthlyRanking> findAllByTargetYearAndTargetMonthAndRanking(
             int targetYear, int targetMonth, int ranking);
+
+    List<FeedMonthlyRanking> findAllByTargetYearAndTargetMonthOrderByRankingAsc(
+            int targetYear, int targetMonth);
 }

--- a/src/main/java/ddingdong/ddingdongBE/domain/feed/service/FeedRankingService.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/feed/service/FeedRankingService.java
@@ -9,4 +9,6 @@ public interface FeedRankingService {
     List<ClubFeedRankingQuery> getClubFeedRanking(int year, int month);
 
     ClubMonthlyStatusQuery getClubMonthlyStatus(Long userId, int year, int month);
+
+    List<ClubFeedRankingQuery> getClubFeedRankingSnapshot(int year, int month);
 }


### PR DESCRIPTION
## 🚀 작업 내용
- 총동연이 특정 연/월의 피드 랭킹 스냅샷을 조회할 수 있는 API를 추가했습니다 (`GET /ranking/snapshot`)
- 코드리뷰 반영: 실시간 랭킹 변환과 스냅샷 랭킹 변환에서 가중치 점수 계산 로직이 중복되어 있어, raw count를 직접 받는 공통 메서드를 추출하고 두 메서드가 위임하도록 리팩토링했습니다

## 🤔 고민했던 내용
- 스냅샷 엔티티의 `score` 필드를 totalScore로 직접 사용하는 방안도 있지만, 개별 가중치 점수(feedScore, viewScore 등)를 계산하는 과정에서 totalScore도 자연스럽게 산출되므로 공통 메서드에서 일관되게 계산하는 것이 더 명확하다고 판단했습니다

## 💬 리뷰 중점사항
- 공통 메서드 추출 후 기존 동작이 변경되지 않았는지 확인 부탁드립니다

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 클럽 피드 랭킹 스냅샷을 조회하는 새로운 API 엔드포인트 추가. 기존 랭킹 엔드포인트와 동일한 연도 및 월 파라미터로 조회 가능.

* **테스트**
  * 스냅샷 조회 기능에 대한 테스트 케이스 추가. 랭킹 정렬, 빈 결과, 가중치 점수 계산 검증 포함.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->