### PR TITLE
feat: 이달의 현황 API lastMonthRank를 스냅샷 단건 조회로 변경

### DIFF
--- a/src/main/java/ddingdong/ddingdongBE/domain/feed/repository/FeedMonthlyRankingRepository.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/feed/repository/FeedMonthlyRankingRepository.java
@@ -2,6 +2,7 @@ package ddingdong.ddingdongBE.domain.feed.repository;
 
 import ddingdong.ddingdongBE.domain.feed.entity.FeedMonthlyRanking;
 import java.util.List;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface FeedMonthlyRankingRepository extends JpaRepository<FeedMonthlyRanking, Long> {
@@ -10,4 +11,10 @@ public interface FeedMonthlyRankingRepository extends JpaRepository<FeedMonthlyR
 
     List<FeedMonthlyRanking> findAllByTargetYearAndTargetMonthAndRanking(
             int targetYear, int targetMonth, int ranking);
+
+    List<FeedMonthlyRanking> findAllByTargetYearAndTargetMonthOrderByRankingAsc(
+            int targetYear, int targetMonth);
+
+    Optional<FeedMonthlyRanking> findByClubIdAndTargetYearAndTargetMonth(
+            Long clubId, int targetYear, int targetMonth);
 }

--- a/src/main/java/ddingdong/ddingdongBE/domain/feed/service/GeneralFeedRankingService.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/feed/service/GeneralFeedRankingService.java
@@ -2,6 +2,8 @@ package ddingdong.ddingdongBE.domain.feed.service;
 
 import ddingdong.ddingdongBE.domain.club.entity.Club;
 import ddingdong.ddingdongBE.domain.club.service.ClubService;
+import ddingdong.ddingdongBE.domain.feed.entity.FeedMonthlyRanking;
+import ddingdong.ddingdongBE.domain.feed.repository.FeedMonthlyRankingRepository;
 import ddingdong.ddingdongBE.domain.feed.repository.FeedRepository;
 import ddingdong.ddingdongBE.domain.feed.repository.dto.MonthlyFeedRankingDto;
 import ddingdong.ddingdongBE.domain.feed.service.dto.query.ClubFeedRankingQuery;
@@ -24,6 +26,7 @@ public class GeneralFeedRankingService implements FeedRankingService {
     private static final int COMMENT_WEIGHT = 5;
 
     private final FeedRepository feedRepository;
+    private final FeedMonthlyRankingRepository feedMonthlyRankingRepository;
     private final ClubService clubService;
 
     @Override

--- a/src/main/java/ddingdong/ddingdongBE/domain/feed/service/GeneralFeedRankingService.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/feed/service/GeneralFeedRankingService.java
@@ -73,12 +73,9 @@ public class GeneralFeedRankingService implements FeedRankingService {
         int lastYear = month == 1 ? year - 1 : year;
         int lastMonth = month == 1 ? 12 : month - 1;
 
-        List<ClubFeedRankingQuery> lastMonthRankings = getClubFeedRanking(lastYear, lastMonth);
-        return lastMonthRankings.stream()
-                .filter(ranking -> ranking.clubId().equals(clubId))
-                .filter(ranking -> ranking.totalScore() > 0)
-                .findFirst()
-                .map(ClubFeedRankingQuery::rank)
+        return feedMonthlyRankingRepository
+                .findByClubIdAndTargetYearAndTargetMonth(clubId, lastYear, lastMonth)
+                .map(FeedMonthlyRanking::getRanking)
                 .orElse(0);
     }
 

--- a/src/test/java/ddingdong/ddingdongBE/domain/feed/service/GeneralFeedRankingServiceTest.java
+++ b/src/test/java/ddingdong/ddingdongBE/domain/feed/service/GeneralFeedRankingServiceTest.java
@@ -5,12 +5,14 @@ import static org.assertj.core.api.SoftAssertions.assertSoftly;
 
 import ddingdong.ddingdongBE.common.fixture.ClubFixture;
 import ddingdong.ddingdongBE.common.fixture.FeedFixture;
+import ddingdong.ddingdongBE.common.fixture.FeedMonthlyRankingFixture;
 import ddingdong.ddingdongBE.common.fixture.UserFixture;
 import ddingdong.ddingdongBE.common.support.TestContainerSupport;
 import ddingdong.ddingdongBE.domain.club.entity.Club;
 import ddingdong.ddingdongBE.domain.club.repository.ClubRepository;
 import ddingdong.ddingdongBE.domain.feed.entity.Feed;
 import ddingdong.ddingdongBE.domain.feed.repository.FeedCommentRepository;
+import ddingdong.ddingdongBE.domain.feed.repository.FeedMonthlyRankingRepository;
 import ddingdong.ddingdongBE.domain.feed.repository.FeedRepository;
 import ddingdong.ddingdongBE.domain.feed.service.dto.query.ClubFeedRankingQuery;
 import ddingdong.ddingdongBE.domain.feed.service.dto.query.ClubMonthlyStatusQuery;
@@ -40,6 +42,9 @@ class GeneralFeedRankingServiceTest extends TestContainerSupport {
 
     @Autowired
     private FeedCommentRepository feedCommentRepository;
+
+    @Autowired
+    private FeedMonthlyRankingRepository feedMonthlyRankingRepository;
 
     @Autowired
     private UserRepository userRepository;


### PR DESCRIPTION
## 🚀 작업 내용

이달의 현황 API에서 지난달 순위(`lastMonthRank`)를 조회할 때 매번 전체 클럽의 피드 데이터를 조회해 가중치를 재계산하던 방식을, 이미 저장된 `FeedMonthlyRanking` 스냅샷 테이블에서 해당 클럽의 순위만 단건 조회하도록 변경했습니다.

## 🤔 고민했던 내용

- 기존 방식은 `getClubFeedRanking(lastYear, lastMonth)`를 호출해 모든 클럽의 피드를 조회하고 가중치를 계산한 뒤 해당 클럽만 필터링하는 비효율적인 구조였습니다.
- 스냅샷 테이블에 이미 지난달 랭킹이 저장되어 있으므로 단건 조회로 충분합니다.

## 💬 리뷰 중점사항

- `FeedMonthlyRankingRepository`에 추가한 `findByClubIdAndTargetYearAndTargetMonth` 메서드가 적절한지
- 테스트에서 지난달 피드 백데이트 방식을 스냅샷 직접 저장 방식으로 변경한 부분

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리즈 노트

* **개선사항**
  * 월별 랭킹 조회 로직 개선 — 지난달 랭킹을 저장된 스냅샷에서 직접 조회하도록 변경하여 정확성과 성능 향상
  * 월별 상태 계산에서 지난달 순위 처리 방식 간소화

* **테스트**
  * 지난달 랭킹 스냅샷을 반영하도록 관련 단위 테스트 및 설명 업데이트
<!-- end of auto-generated comment: release notes by coderabbit.ai -->