### PR TITLE
feat: 피드 랭킹 좋아요·조회수 가중치 변경

### DIFF
--- a/src/main/java/ddingdong/ddingdongBE/domain/feed/service/GeneralFeedRankingService.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/feed/service/GeneralFeedRankingService.java
@@ -21,8 +21,8 @@ import org.springframework.transaction.annotation.Transactional;
 public class GeneralFeedRankingService implements FeedRankingService {
 
     private static final int FEED_WEIGHT = 10;
-    private static final int VIEW_WEIGHT = 1;
-    private static final int LIKE_WEIGHT = 3;
+    private static final int VIEW_WEIGHT = 3;
+    private static final int LIKE_WEIGHT = 1;
     private static final int COMMENT_WEIGHT = 5;
 
     private final FeedRepository feedRepository;

--- a/src/test/java/ddingdong/ddingdongBE/domain/feed/controller/AdminFeedControllerE2ETest.java
+++ b/src/test/java/ddingdong/ddingdongBE/domain/feed/controller/AdminFeedControllerE2ETest.java
@@ -70,7 +70,7 @@ class AdminFeedControllerE2ETest extends NonTxTestContainerSupport {
         // 동아리A: 피드 1개 → score = 10
         feedRepository.save(FeedFixture.createImageFeed(clubA, "피드A"));
 
-        // 동아리B: 피드 2개 + 좋아요 1개 → score = 2*10 + 1*3 = 23
+        // 동아리B: 피드 2개 + 좋아요 1개 → score = 2*10 + 1*1 = 21
         Feed feedB = feedRepository.save(FeedFixture.createImageFeed(clubB, "피드B1"));
         feedRepository.save(FeedFixture.createImageFeed(clubB, "피드B2"));
         given()
@@ -105,9 +105,9 @@ class AdminFeedControllerE2ETest extends NonTxTestContainerSupport {
         assertThat(first.rank()).isEqualTo(1);
         assertThat(first.feedScore()).isEqualTo(2 * 10);
         assertThat(first.viewScore()).isEqualTo(0);
-        assertThat(first.likeScore()).isEqualTo(1 * 3);
+        assertThat(first.likeScore()).isEqualTo(1);
         assertThat(first.commentScore()).isEqualTo(0);
-        assertThat(first.totalScore()).isEqualTo(23);
+        assertThat(first.totalScore()).isEqualTo(21);
 
         AdminClubFeedRankingResponse second = response.get(1);
         assertThat(second.clubName()).isEqualTo("동아리A");

--- a/src/test/java/ddingdong/ddingdongBE/domain/feed/controller/ClubFeedStatusE2ETest.java
+++ b/src/test/java/ddingdong/ddingdongBE/domain/feed/controller/ClubFeedStatusE2ETest.java
@@ -80,7 +80,7 @@ class ClubFeedStatusE2ETest extends NonTxTestContainerSupport {
         String token = signIn("club123", "1234");
 
         // when & then
-        // score = feedCount(2)*10 + viewCount(0)*1 + likeCount(1)*3 + commentCount(1)*5 = 28
+        // score = feedCount(2)*10 + viewCount(0)*3 + likeCount(1)*1 + commentCount(1)*5 = 26
         Map<?, ?> response = given()
                 .contentType(ContentType.JSON)
                 .header("Authorization", "Bearer " + token)
@@ -93,14 +93,14 @@ class ClubFeedStatusE2ETest extends NonTxTestContainerSupport {
                 .extract()
                 .as(Map.class);
 
-        // feedScore = 2*10=20, viewScore = 0, likeScore = 1*3=3, commentScore = 1*5=5, totalScore = 28
+        // feedScore = 2*10=20, viewScore = 0, likeScore = 1*1=1, commentScore = 1*5=5, totalScore = 26
         assertSoftly(softly -> {
             softly.assertThat(response.get("year")).isEqualTo(year);
             softly.assertThat(response.get("month")).isEqualTo(month);
             softly.assertThat(((Number) response.get("feedScore")).longValue()).isEqualTo(20L);
-            softly.assertThat(((Number) response.get("likeScore")).longValue()).isEqualTo(3L);
+            softly.assertThat(((Number) response.get("likeScore")).longValue()).isEqualTo(1L);
             softly.assertThat(((Number) response.get("commentScore")).longValue()).isEqualTo(5L);
-            softly.assertThat(((Number) response.get("totalScore")).longValue()).isEqualTo(28L);
+            softly.assertThat(((Number) response.get("totalScore")).longValue()).isEqualTo(26L);
             softly.assertThat(((Number) response.get("rank")).intValue()).isEqualTo(1);
             softly.assertThat(((Number) response.get("lastMonthRank")).intValue()).isEqualTo(0);
         });

--- a/src/test/java/ddingdong/ddingdongBE/domain/feed/service/GeneralFeedRankingServiceTest.java
+++ b/src/test/java/ddingdong/ddingdongBE/domain/feed/service/GeneralFeedRankingServiceTest.java
@@ -194,14 +194,14 @@ class GeneralFeedRankingServiceTest extends TestContainerSupport {
         List<ClubFeedRankingQuery> result = feedRankingService.getClubFeedRanking(year, month);
 
         // then
-        // score = feedCount(1)*10 + viewCount(0)*1 + likeCount(2)*3 + commentCount(1)*5 = 10+0+6+5 = 21
+        // score = feedCount(1)*10 + viewCount(0)*3 + likeCount(2)*1 + commentCount(1)*5 = 10+0+2+5 = 17
         assertThat(result).hasSize(1);
         assertSoftly(softly -> {
             softly.assertThat(result.get(0).clubName()).isEqualTo("활발한동아리");
             softly.assertThat(result.get(0).feedScore()).isEqualTo(10L);
-            softly.assertThat(result.get(0).likeScore()).isEqualTo(6L);
+            softly.assertThat(result.get(0).likeScore()).isEqualTo(2L);
             softly.assertThat(result.get(0).commentScore()).isEqualTo(5L);
-            softly.assertThat(result.get(0).totalScore()).isEqualTo(21L);
+            softly.assertThat(result.get(0).totalScore()).isEqualTo(17L);
         });
     }
 
@@ -438,14 +438,14 @@ class GeneralFeedRankingServiceTest extends TestContainerSupport {
         List<ClubFeedRankingQuery> result = feedRankingService.getClubFeedRankingSnapshot(2026, 2);
 
         // then
-        // feedScore=10*10=100, viewScore=100*1=100, likeScore=50*3=150, commentScore=20*5=100, total=450
+        // feedScore=10*10=100, viewScore=100*3=300, likeScore=50*1=50, commentScore=20*5=100, total=550
         assertThat(result).hasSize(1);
         assertSoftly(softly -> {
             softly.assertThat(result.get(0).feedScore()).isEqualTo(100L);
-            softly.assertThat(result.get(0).viewScore()).isEqualTo(100L);
-            softly.assertThat(result.get(0).likeScore()).isEqualTo(150L);
+            softly.assertThat(result.get(0).viewScore()).isEqualTo(300L);
+            softly.assertThat(result.get(0).likeScore()).isEqualTo(50L);
             softly.assertThat(result.get(0).commentScore()).isEqualTo(100L);
-            softly.assertThat(result.get(0).totalScore()).isEqualTo(450L);
+            softly.assertThat(result.get(0).totalScore()).isEqualTo(550L);
         });
     }
 }


### PR DESCRIPTION
## 🚀 작업 내용
- 피드 랭킹 점수 계산 시 조회수와 좋아요의 가중치를 변경했습니다
  - 조회수 가중치: 1 → 3
  - 좋아요 가중치: 3 → 1
- 변경된 가중치에 맞게 테스트 기대값을 수정했습니다

## 🤔 고민했던 내용
- 조회수가 좋아요보다 랭킹에 더 큰 영향을 미치도록 가중치를 조정했습니다

## 💬 리뷰 중점사항
- 가중치 상수 값 변경이 의도에 맞는지 확인 부탁드립니다

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **기능 개선**
  * 피드 랭킹 계산에서 조회수의 가중치가 증가하고(기존보다 더 큰 영향), 좋아요의 가중치는 감소했습니다. 이 변경으로 피드 점수와 순위가 일부 달라질 수 있습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->