### PR TITLE
fix: 배너 이미지 한글 깨짐 수정 및 재생성 API 추가

### DIFF
--- a/src/main/java/ddingdong/ddingdongBE/domain/banner/api/AdminBannerApi.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/banner/api/AdminBannerApi.java
@@ -51,4 +51,10 @@ public interface AdminBannerApi {
     @DeleteMapping("/{bannerId}")
     void deleteBanner(@PathVariable("bannerId") Long bannerId);
 
+    @Operation(summary = "랭킹 배너 재생성 API (임시)")
+    @ApiResponse(responseCode = "204", description = "랭킹 배너 재생성 성공")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    @SecurityRequirement(name = "AccessToken")
+    @PostMapping("/ranking/regenerate")
+    void regenerateRankingBanners();
 }

--- a/src/main/java/ddingdong/ddingdongBE/domain/banner/controller/AdminBannerController.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/banner/controller/AdminBannerController.java
@@ -5,6 +5,7 @@ import ddingdong.ddingdongBE.domain.banner.api.AdminBannerApi;
 import ddingdong.ddingdongBE.domain.banner.controller.dto.request.CreateBannerRequest;
 import ddingdong.ddingdongBE.domain.banner.controller.dto.response.AdminBannerListResponse;
 import ddingdong.ddingdongBE.domain.banner.service.FacadeAdminBannerService;
+import ddingdong.ddingdongBE.domain.banner.service.FacadeRankingBannerService;
 import ddingdong.ddingdongBE.domain.user.entity.User;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -15,6 +16,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class AdminBannerController implements AdminBannerApi {
 
     private final FacadeAdminBannerService facadeAdminBannerService;
+    private final FacadeRankingBannerService facadeRankingBannerService;
 
     @Override
     public void createBanner(PrincipalDetails principalDetails, CreateBannerRequest request) {
@@ -34,4 +36,8 @@ public class AdminBannerController implements AdminBannerApi {
         facadeAdminBannerService.delete(bannerId);
     }
 
+    @Override
+    public void regenerateRankingBanners() {
+        facadeRankingBannerService.regenerateLatestRankingBanners();
+    }
 }

--- a/src/main/java/ddingdong/ddingdongBE/domain/banner/service/BannerImageGenerator.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/banner/service/BannerImageGenerator.java
@@ -5,6 +5,7 @@ import ddingdong.ddingdongBE.domain.banner.entity.ClubCategoryColor;
 import java.awt.Color;
 import java.awt.Font;
 import java.awt.FontMetrics;
+import java.awt.GraphicsEnvironment;
 import java.awt.Graphics2D;
 import java.awt.RenderingHints;
 import java.awt.font.TextAttribute;
@@ -190,13 +191,18 @@ public class BannerImageGenerator {
 
     private Font loadFont(String path) {
         try (InputStream fontStream = getClass().getClassLoader().getResourceAsStream(path)) {
-            if (fontStream != null) {
-                return Font.createFont(Font.TRUETYPE_FONT, fontStream);
+            if (fontStream == null) {
+                throw new BannerImageGenerationException();
             }
+            Font font = Font.createFont(Font.TRUETYPE_FONT, fontStream);
+            GraphicsEnvironment.getLocalGraphicsEnvironment().registerFont(font);
+            return font;
+        } catch (BannerImageGenerationException e) {
+            throw e;
         } catch (Exception e) {
-            log.warn("커스텀 폰트 로드 실패 ({}), 기본 폰트 사용: {}", path, e.getMessage());
+            log.error("커스텀 폰트 로드 실패 ({}): {}", path, e.getMessage());
+            throw new BannerImageGenerationException();
         }
-        return new Font("SansSerif", Font.BOLD, 36);
     }
 
     private byte[] toPngBytes(BufferedImage image) {

--- a/src/main/java/ddingdong/ddingdongBE/domain/banner/service/FacadeRankingBannerService.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/banner/service/FacadeRankingBannerService.java
@@ -6,4 +6,6 @@ import java.util.List;
 public interface FacadeRankingBannerService {
 
     void createRankingBanners(List<FeedMonthlyRanking> firstPlaceRankings);
+
+    void regenerateLatestRankingBanners();
 }

--- a/src/main/java/ddingdong/ddingdongBE/domain/banner/service/FacadeRankingBannerServiceImpl.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/banner/service/FacadeRankingBannerServiceImpl.java
@@ -6,6 +6,7 @@ import ddingdong.ddingdongBE.domain.banner.entity.BannerType;
 import ddingdong.ddingdongBE.domain.club.entity.Club;
 import ddingdong.ddingdongBE.domain.club.service.ClubService;
 import ddingdong.ddingdongBE.domain.feed.entity.FeedMonthlyRanking;
+import ddingdong.ddingdongBE.domain.feed.repository.FeedMonthlyRankingRepository;
 import ddingdong.ddingdongBE.domain.filemetadata.entity.DomainType;
 import ddingdong.ddingdongBE.domain.filemetadata.entity.FileMetaData;
 import ddingdong.ddingdongBE.domain.filemetadata.entity.FileStatus;
@@ -14,6 +15,7 @@ import ddingdong.ddingdongBE.file.service.S3FileService;
 import ddingdong.ddingdongBE.file.service.dto.query.UploadedFileUrlQuery;
 import java.awt.image.BufferedImage;
 import java.net.URI;
+import java.time.LocalDate;
 import java.util.List;
 import java.util.UUID;
 import javax.imageio.ImageIO;
@@ -36,6 +38,7 @@ public class FacadeRankingBannerServiceImpl implements FacadeRankingBannerServic
     private final FileMetaDataService fileMetaDataService;
     private final S3FileService s3FileService;
     private final BannerImageGenerator bannerImageGenerator;
+    private final FeedMonthlyRankingRepository feedMonthlyRankingRepository;
 
     @Override
     @Transactional
@@ -45,6 +48,25 @@ public class FacadeRankingBannerServiceImpl implements FacadeRankingBannerServic
         for (FeedMonthlyRanking ranking : firstPlaceRankings) {
             createBannerForRanking(ranking);
         }
+    }
+
+    @Override
+    @Transactional
+    public void regenerateLatestRankingBanners() {
+        LocalDate lastMonth = LocalDate.now().minusMonths(1);
+        List<FeedMonthlyRanking> firstPlaceRankings =
+                feedMonthlyRankingRepository.findAllByTargetYearAndTargetMonthAndRanking(
+                        lastMonth.getYear(), lastMonth.getMonthValue(), 1);
+
+        if (firstPlaceRankings.isEmpty()) {
+            log.info("재생성할 랭킹 1위 동아리가 없습니다. year={}, month={}",
+                    lastMonth.getYear(), lastMonth.getMonthValue());
+            return;
+        }
+
+        createRankingBanners(firstPlaceRankings);
+        log.info("랭킹 배너 재생성 완료. year={}, month={}, count={}",
+                lastMonth.getYear(), lastMonth.getMonthValue(), firstPlaceRankings.size());
     }
 
     private void deleteExistingRankingBanners() {


### PR DESCRIPTION
## 🚀 작업 내용

- Docker 환경에서 배너 이미지의 한글이 깨지는 문제를 수정했습니다
- `BannerImageGenerator`에서 Pretendard 폰트를 Java `GraphicsEnvironment`에 명시적으로 등록하여 `fontconfig` 시스템 라이브러리 없이도 한글이 정상 렌더링되도록 변경했습니다
- 폰트 로드 실패 시 깨진 이미지를 조용히 생성하는 대신 즉시 예외를 던지도록 fail-fast 처리했습니다
- 기존에 S3에 올라간 깨진 배너 이미지를 복구하기 위한 임시 Admin 재생성 API를 추가했습니다

## 🤔 고민했던 내용

- **Dockerfile에 fontconfig 설치 vs 코드 레벨 해결**: `GraphicsEnvironment.registerFont()`를 사용하면 인프라 변경 없이 해결 가능하여 코드 레벨 방식을 선택했습니다
- **폰트 로드 실패 시 fallback vs fail-fast**: 한글 미지원 SansSerif로 깨진 이미지를 만드는 것보다 명시적 실패가 낫다고 판단했습니다
- **재생성 API 위치**: Controller에서 Repository를 직접 의존하지 않도록 `FacadeRankingBannerService`에 재생성 로직을 배치했습니다

## 💬 리뷰 중점사항

- 재생성 API는 배너 복구 후 다음 PR에서 제거 예정입니다
- `@PostConstruct`에서 폰트 로드 실패 시 애플리케이션 기동이 실패하는데, 폰트 파일이 resources에 포함되어 있으므로 fail-fast가 적절하다고 판단했습니다

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 관리자가 순위 배너를 수동으로 재생성할 수 있는 새로운 기능이 추가되었습니다.

* **버그 수정**
  * 배너 생성 시 폰트 리소스 누락으로 인한 오류 처리가 개선되었습니다. 기본 폰트 대신 명확한 오류 메시지를 반환하도록 변경되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->