### PR TITLE
[BE] chore: MySQL 8.4 환경 전환

### DIFF
--- a/compose-dev.yaml
+++ b/compose-dev.yaml
@@ -16,7 +16,7 @@ services:
       - "8080:8080"
 
   mysql:
-    image: mysql:8.0.40
+    image: mysql:8.4.6
     environment:
       MYSQL_DATABASE: ddingdong
       MYSQL_ROOT_PASSWORD: ${DEV_DB_PASSWORD}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   ddingdong-local-db:
-    image: mysql:8.0
+    image: mysql:8.4.6
     container_name: ddingdong_local_mysql
     platform: linux/x86_64
     environment:   # 환경 변수 설정

--- a/src/test/java/ddingdong/ddingdongBE/common/support/NonTxTestContainerSupport.java
+++ b/src/test/java/ddingdong/ddingdongBE/common/support/NonTxTestContainerSupport.java
@@ -19,7 +19,7 @@ import org.testcontainers.containers.MySQLContainer;
 @Import(TestConfig.class)
 public abstract class NonTxTestContainerSupport {
 
-    private static final String MYSQL_IMAGE = "mysql:8";
+    private static final String MYSQL_IMAGE = "mysql:8.4.6";
     private static final int MYSQL_PORT = 3306;
     private static final JdbcDatabaseContainer<?> MYSQL;
 

--- a/src/test/java/ddingdong/ddingdongBE/common/support/TestContainerSupport.java
+++ b/src/test/java/ddingdong/ddingdongBE/common/support/TestContainerSupport.java
@@ -22,7 +22,7 @@ import org.testcontainers.containers.MySQLContainer;
 @Transactional
 public abstract class TestContainerSupport {
 
-  private static final String MYSQL_IMAGE = "mysql:8";
+  private static final String MYSQL_IMAGE = "mysql:8.4.6";
   private static final int MYSQL_PORT = 3306;
   private static final JdbcDatabaseContainer<?> MYSQL;
 


### PR DESCRIPTION
## 🚀 작업 내용

- 로컬, 개발, 테스트 환경의 MySQL 실행 버전을 8.4 계열로 맞췄습니다.
- RDS 8.4 마이그레이션 이후에도 개발 및 테스트 환경에서 동일한 MySQL 메이저/마이너 버전을 기준으로 동작하도록 정렬했습니다.

## 🤔 고민했던 내용

- 테스트 환경은 태그 범위를 넓게 두지 않고 명시 버전으로 고정해, 로컬과 개발 환경에서 재현 가능한 기준을 유지하도록 했습니다.
- 전체 테스트는 TestContainers가 Docker 환경을 찾지 못해 완료되지 않았고, 컴파일 검증은 별도로 통과했습니다.

## 💬 리뷰 중점사항

- 개발 서버 compose 환경에서 사용하는 MySQL 버전이 RDS 마이그레이션 버전과 맞는지 확인 부탁드립니다.
- 테스트 컨테이너 이미지도 동일 버전으로 고정하는 방향이 운영 정책과 맞는지 봐주세요.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * MySQL 컨테이너 이미지 버전을 8.0/8에서 8.4.6으로 업데이트했습니다.
  * 개발 환경과 테스트 환경의 데이터베이스 런타임 버전이 통일되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->