### PR TITLE
[BE] fix: 랭킹 배너 한글 폰트 깨짐 방지

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,14 @@
 # Build stage
-FROM gradle:jdk17 AS build
+FROM gradle:jdk21 AS build
 COPY --chown=gradle:gradle . /home/gradle/src
 WORKDIR /home/gradle/src
 RUN ./gradlew clean build -x test --no-daemon
 
 # Package stage
-FROM eclipse-temurin:17-jdk
+FROM eclipse-temurin:21-jdk
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends fontconfig fonts-noto-cjk \
+    && rm -rf /var/lib/apt/lists/*
 COPY --from=build /home/gradle/src/build/libs/*.jar /app.jar
 EXPOSE 8080
 ENTRYPOINT ["java", "-jar", "/app.jar"]

--- a/src/main/java/ddingdong/ddingdongBE/domain/banner/service/BannerImageGenerator.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/banner/service/BannerImageGenerator.java
@@ -142,8 +142,8 @@ public class BannerImageGenerator {
         int textBlockHeight = 68;
         int textStartY = (WEB_HEIGHT - textBlockHeight) / 2;
 
-        // PC/Title/Bold1: Pretendard Bold 36px, line-height 40px, letter-spacing -1%
-        Font mainFont = createStyledFont(boldBaseFont, Font.BOLD, 36f, -0.01f);
+        // Use the Pretendard-Bold font face without applying Java synthetic bold style.
+        Font mainFont = createStyledFont(boldBaseFont, Font.PLAIN, 36f, -0.01f);
         graphics.setFont(mainFont);
         graphics.setColor(Color.decode("#1F2937"));
         FontMetrics mainMetrics = graphics.getFontMetrics();
@@ -162,8 +162,7 @@ public class BannerImageGenerator {
     }
 
     private void drawMobileTexts(Graphics2D graphics, String clubName, int month, int textStartY) {
-        // Mobile/Title: Pretendard Bold 18px, centered
-        Font mainFont = createStyledFont(boldBaseFont, Font.BOLD, 18f, -0.01f);
+        Font mainFont = createStyledFont(boldBaseFont, Font.PLAIN, 18f, -0.01f);
         graphics.setFont(mainFont);
         graphics.setColor(new Color(33, 33, 33));
         FontMetrics mainMetrics = graphics.getFontMetrics();

--- a/src/test/java/ddingdong/ddingdongBE/domain/banner/service/BannerImageGeneratorTest.java
+++ b/src/test/java/ddingdong/ddingdongBE/domain/banner/service/BannerImageGeneratorTest.java
@@ -5,6 +5,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.awt.Color;
 import java.awt.Graphics2D;
 import java.awt.image.BufferedImage;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import javax.imageio.ImageIO;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -21,7 +24,7 @@ class BannerImageGeneratorTest {
 
     @DisplayName("웹 배너 이미지가 정상적으로 생성된다")
     @Test
-    void generateWebBannerImage_success() {
+    void generateWebBannerImage_success() throws IOException {
         // given
         BufferedImage logo = createTestLogo();
 
@@ -31,11 +34,25 @@ class BannerImageGeneratorTest {
         // then
         assertThat(result).isNotNull();
         assertThat(result.length).isGreaterThan(0);
+        assertKoreanTextRendered(readImage(result), 360, 70, 450, 55);
+    }
+
+    @DisplayName("웹 배너 제목은 Bold 굵기로 렌더링된다")
+    @Test
+    void generateWebBannerImage_titleRenderedBold() throws IOException {
+        // given
+        BufferedImage logo = createTestLogo();
+
+        // when
+        byte[] result = bannerImageGenerator.generateWebBannerImage("테스트동아리", logo, "학술", 2);
+
+        // then
+        assertThat(countDarkTextPixels(readImage(result), 780, 120, 1_000, 100)).isGreaterThan(20_000);
     }
 
     @DisplayName("모바일 배너 이미지가 정상적으로 생성된다")
     @Test
-    void generateMobileBannerImage_success() {
+    void generateMobileBannerImage_success() throws IOException {
         // given
         BufferedImage logo = createTestLogo();
 
@@ -45,6 +62,7 @@ class BannerImageGeneratorTest {
         // then
         assertThat(result).isNotNull();
         assertThat(result.length).isGreaterThan(0);
+        assertKoreanTextRendered(readImage(result), 75, 230, 535, 55);
     }
 
     @DisplayName("로고가 null이어도 배너 이미지가 정상적으로 생성된다")
@@ -79,5 +97,72 @@ class BannerImageGeneratorTest {
         graphics.fillOval(0, 0, 100, 100);
         graphics.dispose();
         return logo;
+    }
+
+    private BufferedImage readImage(byte[] imageBytes) throws IOException {
+        BufferedImage image = ImageIO.read(new ByteArrayInputStream(imageBytes));
+        assertThat(image).isNotNull();
+        return image;
+    }
+
+    private void assertKoreanTextRendered(BufferedImage image, int startX, int startY, int width, int height) {
+        Color backgroundColor = new Color(image.getRGB(0, 0), true);
+        int textPixelCount = countTextPixels(image, startX, startY, width, height);
+        boolean[] seenGrayScale = new boolean[256];
+        int uniqueTextColorCount = 0;
+
+        for (int y = startY; y < startY + height; y++) {
+            for (int x = startX; x < startX + width; x++) {
+                Color pixelColor = new Color(image.getRGB(x, y), true);
+                if (isDifferentColor(pixelColor, backgroundColor)) {
+                    int grayScale = (pixelColor.getRed() + pixelColor.getGreen() + pixelColor.getBlue()) / 3;
+                    if (!seenGrayScale[grayScale]) {
+                        seenGrayScale[grayScale] = true;
+                        uniqueTextColorCount++;
+                    }
+                }
+            }
+        }
+
+        assertThat(textPixelCount).isGreaterThan(1_000);
+        assertThat(uniqueTextColorCount).isGreaterThan(10);
+    }
+
+    private int countTextPixels(BufferedImage image, int startX, int startY, int width, int height) {
+        Color backgroundColor = new Color(image.getRGB(0, 0), true);
+        int textPixelCount = 0;
+
+        for (int y = startY; y < startY + height; y++) {
+            for (int x = startX; x < startX + width; x++) {
+                Color pixelColor = new Color(image.getRGB(x, y), true);
+                if (isDifferentColor(pixelColor, backgroundColor)) {
+                    textPixelCount++;
+                }
+            }
+        }
+
+        return textPixelCount;
+    }
+
+    private int countDarkTextPixels(BufferedImage image, int startX, int startY, int width, int height) {
+        int textPixelCount = 0;
+
+        for (int y = startY; y < startY + height; y++) {
+            for (int x = startX; x < startX + width; x++) {
+                Color pixelColor = new Color(image.getRGB(x, y), true);
+                if (pixelColor.getRed() < 80 && pixelColor.getGreen() < 90 && pixelColor.getBlue() < 110) {
+                    textPixelCount++;
+                }
+            }
+        }
+
+        return textPixelCount;
+    }
+
+    private boolean isDifferentColor(Color source, Color target) {
+        int redDiff = Math.abs(source.getRed() - target.getRed());
+        int greenDiff = Math.abs(source.getGreen() - target.getGreen());
+        int blueDiff = Math.abs(source.getBlue() - target.getBlue());
+        return redDiff + greenDiff + blueDiff > 30;
     }
 }


### PR DESCRIPTION
## 🚀 작업 내용

- 운영 랭킹 배너 재생성 후에도 제목 한글이 네모로 표시되는 문제를 방지합니다.
- 배너 생성 런타임을 Java 21 환경으로 맞추고, 운영 이미지에 한글 fallback 폰트를 포함합니다.
- 배너 이미지 테스트가 단순 생성 여부가 아니라 한글 텍스트가 실제로 렌더링되는지 확인하도록 보강했습니다.

## 🤔 고민했던 내용

- 직전 수정은 폰트 등록과 재생성 API를 추가했지만, 제목에는 계속 Pretendard Bold를 사용했습니다.
- 운영에서 새 배너를 직접 내려받아 확인한 결과 본문은 정상이고 제목만 깨졌으므로, 전체 인코딩 문제가 아니라 headless Linux AWT 런타임에서 Pretendard Bold가 한글 glyph를 정상 렌더링하지 못하는 케이스로 판단했습니다.
- 기존 테스트는 PNG byte 존재만 검증해 이런 렌더링 실패를 잡지 못했습니다.

## 💬 리뷰 중점사항

1. 제목 폰트를 운영에서 정상 확인된 경로로 낮추는 방식이 긴급 복구에 적절한지
2. 운영 Docker 이미지의 Java 21 및 한글 fallback 폰트 포함이 배포 환경에 맞는지
3. 이미지 픽셀 기반 테스트 임계값이 과도하게 취약하지 않은지

## 테스트

- [x] ./gradlew test --tests "*BannerImageGeneratorTest"
- [x] ./gradlew clean build -x test
- [ ] 전체 테스트: 로컬 Docker/TestContainers가 mysql:8.4.6 이미지를 가져오지 못해 실패

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Bug Fixes**
  * 한글 텍스트 렌더링 문제를 해결하기 위해 필요한 폰트 및 설정을 추가했습니다.
  * 배너의 텍스트 스타일을 조정하여 렌더링 안정성을 개선했습니다.

* **Chores**
  * Java 21로 업그레이드했습니다.

* **Tests**
  * 한글 텍스트 렌더링 검증 테스트를 추가했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->