### PR TITLE
fix: 피드 월별 랭킹 가중치 상수 단일화

### DIFF
--- a/src/main/java/ddingdong/ddingdongBE/domain/feed/entity/FeedMonthlyRanking.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/feed/entity/FeedMonthlyRanking.java
@@ -20,11 +20,6 @@ import lombok.NoArgsConstructor;
 @Table(uniqueConstraints = @UniqueConstraint(columnNames = {"club_id", "target_year", "target_month"}))
 public class FeedMonthlyRanking extends BaseEntity {
 
-    public static final int FEED_WEIGHT = 10;
-    public static final int VIEW_WEIGHT = 3;
-    public static final int LIKE_WEIGHT = 1;
-    public static final int COMMENT_WEIGHT = 5;
-
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
@@ -76,10 +71,10 @@ public class FeedMonthlyRanking extends BaseEntity {
     }
 
     public long calculateScore() {
-        return feedCount * FEED_WEIGHT
-                + viewCount * VIEW_WEIGHT
-                + likeCount * LIKE_WEIGHT
-                + commentCount * COMMENT_WEIGHT;
+        return feedCount * FeedRankingWeight.FEED
+                + viewCount * FeedRankingWeight.VIEW
+                + likeCount * FeedRankingWeight.LIKE
+                + commentCount * FeedRankingWeight.COMMENT;
     }
 
     public void assignRanking(int ranking) {

--- a/src/main/java/ddingdong/ddingdongBE/domain/feed/entity/FeedMonthlyRanking.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/feed/entity/FeedMonthlyRanking.java
@@ -20,10 +20,10 @@ import lombok.NoArgsConstructor;
 @Table(uniqueConstraints = @UniqueConstraint(columnNames = {"club_id", "target_year", "target_month"}))
 public class FeedMonthlyRanking extends BaseEntity {
 
-    private static final int FEED_WEIGHT = 10;
-    private static final int VIEW_WEIGHT = 1;
-    private static final int LIKE_WEIGHT = 3;
-    private static final int COMMENT_WEIGHT = 5;
+    public static final int FEED_WEIGHT = 10;
+    public static final int VIEW_WEIGHT = 3;
+    public static final int LIKE_WEIGHT = 1;
+    public static final int COMMENT_WEIGHT = 5;
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/ddingdong/ddingdongBE/domain/feed/entity/FeedRankingWeight.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/feed/entity/FeedRankingWeight.java
@@ -1,0 +1,14 @@
+package ddingdong.ddingdongBE.domain.feed.entity;
+
+// 피드 월별 랭킹 점수 가중치. 스냅샷 저장(FeedMonthlyRanking)과 실시간 조회(GeneralFeedRankingService)가
+// 동일한 기준으로 점수를 계산하도록 가중치를 한 곳에서만 정의한다.
+public final class FeedRankingWeight {
+
+    public static final int FEED = 10;
+    public static final int VIEW = 3;
+    public static final int LIKE = 1;
+    public static final int COMMENT = 5;
+
+    private FeedRankingWeight() {
+    }
+}

--- a/src/main/java/ddingdong/ddingdongBE/domain/feed/service/GeneralFeedRankingService.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/feed/service/GeneralFeedRankingService.java
@@ -20,11 +20,6 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional(readOnly = true)
 public class GeneralFeedRankingService implements FeedRankingService {
 
-    private static final int FEED_WEIGHT = 10;
-    private static final int VIEW_WEIGHT = 3;
-    private static final int LIKE_WEIGHT = 1;
-    private static final int COMMENT_WEIGHT = 5;
-
     private final FeedRepository feedRepository;
     private final FeedMonthlyRankingRepository feedMonthlyRankingRepository;
     private final ClubService clubService;
@@ -94,10 +89,10 @@ public class GeneralFeedRankingService implements FeedRankingService {
 
     private ClubFeedRankingQuery toClubFeedRankingQuery(int rank, Long clubId, String clubName,
             long feedCount, long viewCount, long likeCount, long commentCount) {
-        long feedScore = feedCount * FEED_WEIGHT;
-        long viewScore = viewCount * VIEW_WEIGHT;
-        long likeScore = likeCount * LIKE_WEIGHT;
-        long commentScore = commentCount * COMMENT_WEIGHT;
+        long feedScore = feedCount * FeedMonthlyRanking.FEED_WEIGHT;
+        long viewScore = viewCount * FeedMonthlyRanking.VIEW_WEIGHT;
+        long likeScore = likeCount * FeedMonthlyRanking.LIKE_WEIGHT;
+        long commentScore = commentCount * FeedMonthlyRanking.COMMENT_WEIGHT;
         long totalScore = feedScore + viewScore + likeScore + commentScore;
         return ClubFeedRankingQuery.of(rank, clubId, clubName,
                 feedScore, viewScore, likeScore, commentScore, totalScore);
@@ -116,9 +111,9 @@ public class GeneralFeedRankingService implements FeedRankingService {
     }
 
     private long calculateScore(MonthlyFeedRankingDto rawRanking) {
-        return rawRanking.getFeedCount() * FEED_WEIGHT
-                + rawRanking.getViewCount() * VIEW_WEIGHT
-                + rawRanking.getLikeCount() * LIKE_WEIGHT
-                + rawRanking.getCommentCount() * COMMENT_WEIGHT;
+        return rawRanking.getFeedCount() * FeedMonthlyRanking.FEED_WEIGHT
+                + rawRanking.getViewCount() * FeedMonthlyRanking.VIEW_WEIGHT
+                + rawRanking.getLikeCount() * FeedMonthlyRanking.LIKE_WEIGHT
+                + rawRanking.getCommentCount() * FeedMonthlyRanking.COMMENT_WEIGHT;
     }
 }

--- a/src/main/java/ddingdong/ddingdongBE/domain/feed/service/GeneralFeedRankingService.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/feed/service/GeneralFeedRankingService.java
@@ -3,6 +3,7 @@ package ddingdong.ddingdongBE.domain.feed.service;
 import ddingdong.ddingdongBE.domain.club.entity.Club;
 import ddingdong.ddingdongBE.domain.club.service.ClubService;
 import ddingdong.ddingdongBE.domain.feed.entity.FeedMonthlyRanking;
+import ddingdong.ddingdongBE.domain.feed.entity.FeedRankingWeight;
 import ddingdong.ddingdongBE.domain.feed.repository.FeedMonthlyRankingRepository;
 import ddingdong.ddingdongBE.domain.feed.repository.FeedRepository;
 import ddingdong.ddingdongBE.domain.feed.repository.dto.MonthlyFeedRankingDto;
@@ -89,10 +90,10 @@ public class GeneralFeedRankingService implements FeedRankingService {
 
     private ClubFeedRankingQuery toClubFeedRankingQuery(int rank, Long clubId, String clubName,
             long feedCount, long viewCount, long likeCount, long commentCount) {
-        long feedScore = feedCount * FeedMonthlyRanking.FEED_WEIGHT;
-        long viewScore = viewCount * FeedMonthlyRanking.VIEW_WEIGHT;
-        long likeScore = likeCount * FeedMonthlyRanking.LIKE_WEIGHT;
-        long commentScore = commentCount * FeedMonthlyRanking.COMMENT_WEIGHT;
+        long feedScore = feedCount * FeedRankingWeight.FEED;
+        long viewScore = viewCount * FeedRankingWeight.VIEW;
+        long likeScore = likeCount * FeedRankingWeight.LIKE;
+        long commentScore = commentCount * FeedRankingWeight.COMMENT;
         long totalScore = feedScore + viewScore + likeScore + commentScore;
         return ClubFeedRankingQuery.of(rank, clubId, clubName,
                 feedScore, viewScore, likeScore, commentScore, totalScore);
@@ -111,9 +112,9 @@ public class GeneralFeedRankingService implements FeedRankingService {
     }
 
     private long calculateScore(MonthlyFeedRankingDto rawRanking) {
-        return rawRanking.getFeedCount() * FeedMonthlyRanking.FEED_WEIGHT
-                + rawRanking.getViewCount() * FeedMonthlyRanking.VIEW_WEIGHT
-                + rawRanking.getLikeCount() * FeedMonthlyRanking.LIKE_WEIGHT
-                + rawRanking.getCommentCount() * FeedMonthlyRanking.COMMENT_WEIGHT;
+        return rawRanking.getFeedCount() * FeedRankingWeight.FEED
+                + rawRanking.getViewCount() * FeedRankingWeight.VIEW
+                + rawRanking.getLikeCount() * FeedRankingWeight.LIKE
+                + rawRanking.getCommentCount() * FeedRankingWeight.COMMENT;
     }
 }

--- a/src/test/java/ddingdong/ddingdongBE/domain/feed/entity/FeedMonthlyRankingTest.java
+++ b/src/test/java/ddingdong/ddingdongBE/domain/feed/entity/FeedMonthlyRankingTest.java
@@ -13,7 +13,7 @@ class FeedMonthlyRankingTest {
     void calculateScore_appliesWeightFormula() {
         // given
         // feedCount=10, viewCount=100, likeCount=50, commentCount=20
-        // score = 10*10 + 100*1 + 50*3 + 20*5 = 100 + 100 + 150 + 100 = 450
+        // score = 10*10 + 100*3 + 50*1 + 20*5 = 100 + 300 + 50 + 100 = 550
         FeedMonthlyRanking ranking = FeedMonthlyRankingFixture.create(
                 1L, "테스트 동아리", 10, 100, 50, 20, 2025, 1, 1);
 
@@ -21,7 +21,7 @@ class FeedMonthlyRankingTest {
         long score = ranking.calculateScore();
 
         // then
-        assertThat(score).isEqualTo(450L);
+        assertThat(score).isEqualTo(550L);
     }
 
     @DisplayName("calculateScore - 모든 카운트가 0이면 점수는 0이다")
@@ -54,8 +54,8 @@ class FeedMonthlyRankingTest {
                 .build();
 
         // then
-        // score = 5*10 + 50*1 + 10*3 + 3*5 = 50 + 50 + 30 + 15 = 145
-        assertThat(ranking.getScore()).isEqualTo(145L);
+        // score = 5*10 + 50*3 + 10*1 + 3*5 = 50 + 150 + 10 + 15 = 225
+        assertThat(ranking.getScore()).isEqualTo(225L);
     }
 
     @DisplayName("assignRanking - 순위를 할당한다")


### PR DESCRIPTION
## 🚀 작업 내용

피드 월별 랭킹 점수의 가중치 상수가 두 곳에 따로 정의되어 있었고, 그중 조회수와 좋아요 가중치가 서로 뒤바뀌어 있었습니다.

- **스냅샷 저장 시점**(`FeedMonthlyRanking` 엔티티): 조회수 1, 좋아요 3
- **실시간 랭킹 조회 시점**(`GeneralFeedRankingService`): 조회수 3, 좋아요 1

같은 동아리라도 실시간 랭킹 API와 스냅샷 기반 API에서 점수와 순위가 다르게 계산되어, 사용자에게 일관되지 않은 랭킹이 노출될 수 있었습니다.

가중치를 별도 상수 클래스(`FeedRankingWeight`)로 추출하여 한 곳에서만 정의(조회수 3, 좋아요 1)하고, 엔티티와 서비스가 이를 함께 참조하도록 정리했습니다. 정정된 가중치에 맞춰 엔티티 점수 계산 테스트 기대값도 함께 갱신했습니다.

## 🤔 고민했던 내용

올바른 가중치 기준을 실시간 조회 로직(조회수 3, 좋아요 1)으로 확정했습니다. 단순히 값만 맞추면 중복 정의가 남아 같은 실수가 재발할 수 있어, 가중치를 별도 상수 클래스로 분리해 단일 출처로 통일했습니다. 엔티티 내부 상수로 두기보다 점수 가중치라는 도메인 규칙을 독립된 위치에 두어 소유 책임을 명확히 했고, 엔티티·서비스 어느 쪽도 서로에 의존하지 않고 상수만 참조하도록 했습니다.

## 💬 리뷰 중점사항

- 가중치 기준값(조회수 3, 좋아요 1)이 의도한 정책과 일치하는지 확인 부탁드립니다.
- 이미 잘못된 가중치로 저장된 과거 스냅샷 데이터의 재계산/보정이 필요한지 별도 논의가 필요합니다.
