### PR TITLE
fix: 배너 한글 깨짐 근본 원인 수정 (javac 소스 인코딩 UTF-8 고정)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -12,6 +12,12 @@ version = '0.0.1-SNAPSHOT'
 java {
 }
 
+// 빌드 환경(Docker 컨테이너 등)의 locale과 무관하게 소스의 한글 리터럴이
+// 깨지지 않도록 javac 소스 인코딩을 UTF-8로 고정한다.
+tasks.withType(JavaCompile).configureEach {
+    options.encoding = 'UTF-8'
+}
+
 jar {
     enabled = false
 }


### PR DESCRIPTION
## 🚀 작업 내용

랭킹 배너의 한글 깨짐 **근본 원인을 수정**합니다.

원인은 폰트(tofu)가 아니라 **컴파일 타임 소스 인코딩**이었습니다. `build.gradle`에 `JavaCompile` 인코딩 설정이 없어, Docker 빌드 컨테이너의 locale(C/POSIX)을 따라 UTF-8 소스가 Latin-1로 오독되었고, `BannerImageGenerator`의 하드코딩된 한글 리터럴이 mojibake로 깨졌습니다. 로컬(UTF-8)에서는 정상이라 Docker 빌드 산출물에서만 깨지는 현상이 반복됐습니다.

`JavaCompile.options.encoding`을 UTF-8로 명시 고정해 빌드 환경 locale과 무관하게 한글 리터럴이 보존되도록 합니다.

## 🤔 고민했던 내용

- 기존 시도(폰트 등록, noto-cjk 폰트 추가)는 tofu(글리프 없음)를 가정했으나, 실제 증상은 mojibake였습니다. tofu였다면 폰트 추가로 해결됐어야 하는데 안 된 것이 인코딩 문제의 신호였습니다.
- JEP 400(Java 18+ UTF-8 기본화)은 런타임 `file.encoding`만 바꾸고 **javac 소스 인코딩은 바꾸지 않으므로** JDK 버전 상향으로는 해결되지 않습니다. 따라서 빌드 설정에서 명시 고정이 필요합니다.

## 💬 리뷰 중점사항

- 배포 후 재생성 API(`POST /server/admin/banners/ranking/regenerate`)로 기존에 깨진 채 저장된 배너를 재생성해야 실제로 정상화됩니다. (인코딩 fix 배포 **후** 재생성해야 의미 있음)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * 빌드 환경에서 한글 소스 코드가 손상되는 문제를 해결했습니다. 모든 빌드 환경에서 일관된 문자 인코딩 처리를 보장합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->