### PR TITLE
[release] v1.4.14

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -12,6 +12,12 @@ version = '0.0.1-SNAPSHOT'
 java {
 }
 
+// 빌드 환경(Docker 컨테이너 등)의 locale과 무관하게 소스의 한글 리터럴이
+// 깨지지 않도록 javac 소스 인코딩을 UTF-8로 고정한다.
+tasks.withType(JavaCompile).configureEach {
+    options.encoding = 'UTF-8'
+}
+
 jar {
     enabled = false
 }


### PR DESCRIPTION
## 🚀 작업 내용

배너 한글 깨짐 **근본 원인 수정**을 운영 서버로 릴리즈합니다.

- `build.gradle`에 `JavaCompile.options.encoding = 'UTF-8'` 추가 (#415)
- main 기준 단일 변경(build.gradle 1파일)만 포함

랭킹 배너 기능·재생성 API·폰트 등 나머지는 이미 운영에 반영돼 있으며, 빠져 있던 빌드 인코딩 설정만 추가합니다. 빌드 컨테이너 locale과 무관하게 한글 리터럴이 UTF-8로 컴파일되어 mojibake가 해소됩니다.

## 🤔 고민했던 내용

- 기존 폰트/재생성 시도는 원인을 빗나갔고(폰트 아닌 빌드 인코딩), 운영에는 이미 반영된 상태였습니다. 실제 미반영분은 인코딩 설정 하나였습니다.

## 💬 리뷰 중점사항

- main 머지 시 `prod-server-deployer` 트리거 → 운영 배포
- 배포 후 `POST /server/admin/banners/ranking/regenerate` 호출로 기존 깨진 배너 재생성 (해당 API는 이미 운영에 존재)

🤖 Generated with [Claude Code](https://claude.com/claude-code)