### PR TITLE
fix: 랭킹 배너 winner 선별 및 폰트 스타일 정리

### DIFF
--- a/src/main/java/ddingdong/ddingdongBE/domain/banner/service/BannerImageGenerator.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/banner/service/BannerImageGenerator.java
@@ -8,14 +8,11 @@ import java.awt.FontMetrics;
 import java.awt.GraphicsEnvironment;
 import java.awt.Graphics2D;
 import java.awt.RenderingHints;
-import java.awt.font.TextAttribute;
 import java.awt.geom.RoundRectangle2D;
 import java.awt.image.BufferedImage;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.util.HashMap;
-import java.util.Map;
 import jakarta.annotation.PostConstruct;
 import javax.imageio.ImageIO;
 import lombok.extern.slf4j.Slf4j;
@@ -143,7 +140,7 @@ public class BannerImageGenerator {
         int textStartY = (WEB_HEIGHT - textBlockHeight) / 2;
 
         // Use the Pretendard-Bold font face without applying Java synthetic bold style.
-        Font mainFont = createStyledFont(boldBaseFont, Font.PLAIN, 36f, -0.01f);
+        Font mainFont = createStyledFont(boldBaseFont, 36f);
         graphics.setFont(mainFont);
         graphics.setColor(Color.decode("#1F2937"));
         FontMetrics mainMetrics = graphics.getFontMetrics();
@@ -151,8 +148,8 @@ public class BannerImageGenerator {
         int mainY = textStartY + mainMetrics.getAscent();
         graphics.drawString(mainText, textX, mainY);
 
-        // PC/Body/Medium2: Pretendard Medium 16px, line-height 24px, letter-spacing 1%
-        Font subFont = createStyledFont(mediumBaseFont, Font.PLAIN, 16f, 0.01f);
+        // PC/Body/Medium2: Pretendard Medium 16px, line-height 24px
+        Font subFont = createStyledFont(mediumBaseFont, 16f);
         graphics.setFont(subFont);
         graphics.setColor(Color.decode("#6B7280"));
         FontMetrics subMetrics = graphics.getFontMetrics();
@@ -162,7 +159,7 @@ public class BannerImageGenerator {
     }
 
     private void drawMobileTexts(Graphics2D graphics, String clubName, int month, int textStartY) {
-        Font mainFont = createStyledFont(boldBaseFont, Font.PLAIN, 18f, -0.01f);
+        Font mainFont = createStyledFont(boldBaseFont, 18f);
         graphics.setFont(mainFont);
         graphics.setColor(new Color(33, 33, 33));
         FontMetrics mainMetrics = graphics.getFontMetrics();
@@ -172,7 +169,7 @@ public class BannerImageGenerator {
         graphics.drawString(mainText, mainX, mainY);
 
         // Mobile/Sub: Pretendard Medium 12px, centered
-        Font subFont = createStyledFont(mediumBaseFont, Font.PLAIN, 12f, 0.01f);
+        Font subFont = createStyledFont(mediumBaseFont, 12f);
         graphics.setFont(subFont);
         graphics.setColor(new Color(100, 100, 100));
         FontMetrics subMetrics = graphics.getFontMetrics();
@@ -181,11 +178,12 @@ public class BannerImageGenerator {
         graphics.drawString(subText, subX, mainY + 20);
     }
 
-    private Font createStyledFont(Font baseFont, int style, float size, float tracking) {
-        Font sized = baseFont.deriveFont(style, size);
-        Map<TextAttribute, Object> attributes = new HashMap<>();
-        attributes.put(TextAttribute.TRACKING, tracking);
-        return sized.deriveFont(attributes);
+    // 로드한 폰트 인스턴스의 내부 스타일을 유지한 채 크기만 조정한다.
+    // style(PLAIN) 지정과 TextAttribute.TRACKING(속성 기반 레이아웃)은
+    // headless Linux AWT에서 폰트를 이름/스타일로 재탐색하게 만들어
+    // 한글 글리프가 없는 fallback 폰트로 치환(제목 tofu)되므로 사용하지 않는다.
+    private Font createStyledFont(Font baseFont, float size) {
+        return baseFont.deriveFont(size);
     }
 
     private Font loadFont(String path) {

--- a/src/main/java/ddingdong/ddingdongBE/domain/banner/service/FacadeRankingBannerServiceImpl.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/banner/service/FacadeRankingBannerServiceImpl.java
@@ -43,10 +43,18 @@ public class FacadeRankingBannerServiceImpl implements FacadeRankingBannerServic
     @Override
     @Transactional
     public void createRankingBanners(List<FeedMonthlyRanking> firstPlaceRankings) {
+        List<FeedMonthlyRanking> winners = firstPlaceRankings.stream()
+                .filter(ranking -> ranking.getScore() > 0)
+                .toList();
+        if (winners.isEmpty()) {
+            log.info("피드가 있는 랭킹 1위 동아리가 없어 배너를 생성하지 않습니다.");
+            return;
+        }
+
         deleteExistingRankingBanners();
 
-        for (FeedMonthlyRanking ranking : firstPlaceRankings) {
-            createBannerForRanking(ranking);
+        for (FeedMonthlyRanking winner : winners) {
+            createBannerForRanking(winner);
         }
     }
 

--- a/src/test/java/ddingdong/ddingdongBE/domain/banner/service/BannerImageGeneratorTest.java
+++ b/src/test/java/ddingdong/ddingdongBE/domain/banner/service/BannerImageGeneratorTest.java
@@ -3,23 +3,57 @@ package ddingdong.ddingdongBE.domain.banner.service;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.awt.Color;
+import java.awt.Font;
 import java.awt.Graphics2D;
 import java.awt.image.BufferedImage;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
+import java.lang.reflect.Field;
 import javax.imageio.ImageIO;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 class BannerImageGeneratorTest {
 
+    private static final String TITLE_TEXT = "이달의 피드 : 컴퓨터공학과 동아리 축하드립니다!";
+    private static final String SUBTITLE_TEXT = "6월의 피드는 '동아리 피드'에서 확인하실 수 있습니다.";
+
     private BannerImageGenerator bannerImageGenerator;
+
+    @BeforeAll
+    static void enableHeadless() {
+        // EB(Elastic Beanstalk) 운영 환경과 동일하게 headless AWT로 폰트 서브시스템을 초기화한다.
+        System.setProperty("java.awt.headless", "true");
+    }
 
     @BeforeEach
     void setUp() {
         bannerImageGenerator = new BannerImageGenerator();
         bannerImageGenerator.init();
+    }
+
+    @DisplayName("제목에 사용하는 굵은 폰트는 제목의 모든 한글 글리프를 가지고 있다")
+    @Test
+    void boldFontCanDisplayAllKoreanGlyphsInTitle() throws Exception {
+        Font boldFont = extractFont("boldBaseFont");
+
+        assertThat(boldFont.canDisplayUpTo(TITLE_TEXT)).isEqualTo(-1);
+    }
+
+    @DisplayName("부제목에 사용하는 중간 굵기 폰트는 부제목의 모든 한글 글리프를 가지고 있다")
+    @Test
+    void mediumFontCanDisplayAllKoreanGlyphsInSubtitle() throws Exception {
+        Font mediumFont = extractFont("mediumBaseFont");
+
+        assertThat(mediumFont.canDisplayUpTo(SUBTITLE_TEXT)).isEqualTo(-1);
+    }
+
+    private Font extractFont(String fieldName) throws Exception {
+        Field field = BannerImageGenerator.class.getDeclaredField(fieldName);
+        field.setAccessible(true);
+        return (Font) field.get(bannerImageGenerator);
     }
 
     @DisplayName("웹 배너 이미지가 정상적으로 생성된다")

--- a/src/test/java/ddingdong/ddingdongBE/domain/banner/service/FacadeRankingBannerServiceImplTest.java
+++ b/src/test/java/ddingdong/ddingdongBE/domain/banner/service/FacadeRankingBannerServiceImplTest.java
@@ -1,0 +1,126 @@
+package ddingdong.ddingdongBE.domain.banner.service;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import ddingdong.ddingdongBE.common.fixture.ClubFixture;
+import ddingdong.ddingdongBE.common.fixture.FeedMonthlyRankingFixture;
+import ddingdong.ddingdongBE.domain.banner.entity.Banner;
+import ddingdong.ddingdongBE.domain.banner.entity.BannerType;
+import ddingdong.ddingdongBE.domain.club.entity.Club;
+import ddingdong.ddingdongBE.domain.club.service.ClubService;
+import ddingdong.ddingdongBE.domain.feed.entity.FeedMonthlyRanking;
+import ddingdong.ddingdongBE.domain.feed.repository.FeedMonthlyRankingRepository;
+import ddingdong.ddingdongBE.domain.filemetadata.entity.DomainType;
+import ddingdong.ddingdongBE.domain.filemetadata.service.FileMetaDataService;
+import ddingdong.ddingdongBE.file.service.S3FileService;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class FacadeRankingBannerServiceImplTest {
+
+    private static final int TARGET_YEAR = 2026;
+    private static final int TARGET_MONTH = 6;
+
+    @InjectMocks
+    private FacadeRankingBannerServiceImpl facadeRankingBannerService;
+    @Mock
+    private BannerService bannerService;
+    @Mock
+    private ClubService clubService;
+    @Mock
+    private FileMetaDataService fileMetaDataService;
+    @Mock
+    private S3FileService s3FileService;
+    @Mock
+    private BannerImageGenerator bannerImageGenerator;
+    @Mock
+    private FeedMonthlyRankingRepository feedMonthlyRankingRepository;
+
+    @DisplayName("피드 점수가 0인 1위 동아리만 있으면 배너를 생성하지 않고 기존 배너도 삭제하지 않는다")
+    @Test
+    void createRankingBanners_allZeroScore_generatesNothing() {
+        FeedMonthlyRanking zeroRanking = FeedMonthlyRankingFixture.create(
+                1L, "피드없는동아리", 0, 0, 0, 0, TARGET_YEAR, TARGET_MONTH, 1);
+
+        facadeRankingBannerService.createRankingBanners(List.of(zeroRanking));
+
+        verify(bannerService, never()).getAllByBannerType(any());
+        verify(bannerService, never()).save(any());
+        verify(bannerImageGenerator, never()).generateWebBannerImage(any(), any(), any(), anyInt());
+    }
+
+    @DisplayName("점수가 양수인 단독 1위는 배너를 1개 생성한다")
+    @Test
+    void createRankingBanners_singleWinner_generatesOneBanner() {
+        FeedMonthlyRanking winner = FeedMonthlyRankingFixture.createWinner(
+                1L, "우승동아리", TARGET_YEAR, TARGET_MONTH);
+        stubCommonBannerCreation();
+        stubClub(1L, "우승동아리");
+
+        facadeRankingBannerService.createRankingBanners(List.of(winner));
+
+        verify(bannerService, times(1)).save(any(Banner.class));
+        verify(bannerImageGenerator, times(1)).generateWebBannerImage(any(), any(), any(), anyInt());
+    }
+
+    @DisplayName("점수가 양수인 공동 1위 2팀은 배너를 2개 생성한다")
+    @Test
+    void createRankingBanners_tiedWinners_generatesTwoBanners() {
+        FeedMonthlyRanking firstWinner = FeedMonthlyRankingFixture.createWinner(
+                1L, "동아리A", TARGET_YEAR, TARGET_MONTH);
+        FeedMonthlyRanking secondWinner = FeedMonthlyRankingFixture.createWinner(
+                2L, "동아리B", TARGET_YEAR, TARGET_MONTH);
+        stubCommonBannerCreation();
+        stubClub(1L, "동아리A");
+        stubClub(2L, "동아리B");
+
+        facadeRankingBannerService.createRankingBanners(List.of(firstWinner, secondWinner));
+
+        verify(bannerService, times(2)).save(any(Banner.class));
+        verify(bannerImageGenerator, times(2)).generateWebBannerImage(any(), any(), any(), anyInt());
+    }
+
+    @DisplayName("점수가 0인 동아리는 제외하고 점수가 양수인 동아리만 배너를 생성한다")
+    @Test
+    void createRankingBanners_mixedScore_generatesOnlyForPositiveScore() {
+        FeedMonthlyRanking winner = FeedMonthlyRankingFixture.createWinner(
+                1L, "피드있는동아리", TARGET_YEAR, TARGET_MONTH);
+        FeedMonthlyRanking zeroRanking = FeedMonthlyRankingFixture.create(
+                2L, "피드없는동아리", 0, 0, 0, 0, TARGET_YEAR, TARGET_MONTH, 1);
+        stubCommonBannerCreation();
+        stubClub(1L, "피드있는동아리");
+
+        facadeRankingBannerService.createRankingBanners(List.of(winner, zeroRanking));
+
+        verify(bannerService, times(1)).save(any(Banner.class));
+        verify(bannerImageGenerator).generateWebBannerImage(eq("피드있는동아리"), any(), any(), anyInt());
+    }
+
+    private void stubClub(Long clubId, String clubName) {
+        when(clubService.getById(clubId)).thenReturn(ClubFixture.createClub(clubName));
+    }
+
+    private void stubCommonBannerCreation() {
+        when(fileMetaDataService.getCoupledAllByDomainTypeAndEntityId(eq(DomainType.CLUB_PROFILE), any()))
+                .thenReturn(List.of());
+        when(bannerService.getAllByBannerType(BannerType.FEED_RANKING)).thenReturn(List.of());
+        when(bannerImageGenerator.generateWebBannerImage(any(), any(), any(), anyInt()))
+                .thenReturn(new byte[]{1});
+        when(bannerImageGenerator.generateMobileBannerImage(any(), any(), any(), anyInt()))
+                .thenReturn(new byte[]{1});
+        when(s3FileService.uploadBytes(any(), any(), any())).thenReturn("file-key");
+        when(bannerService.save(any(Banner.class))).thenReturn(1L);
+    }
+}


### PR DESCRIPTION
## 🚀 작업 내용

메인 랭킹 배너에서 발견된 두 가지 문제를 다룹니다.

**1. 모든 동아리가 배너로 생성되던 문제 (핵심 수정)**
해당 월에 피드가 하나도 없으면 전 동아리의 점수가 0이 되고, 공동 순위 로직상 전원이 1위로 집계되어 모든 동아리가 배너로 생성되었습니다. 배너 생성 지점에서 점수가 0보다 큰 동아리만 winner로 선별하도록 수정했습니다. 진짜 동점(점수 > 0)은 기존대로 모두 배너로 노출되고, 선별 결과가 비어 있으면 기존 배너를 삭제하지 않고 보존한 채 종료합니다. 스케줄러 경로와 재생성 API 경로가 모두 이 지점으로 수렴하므로 한 곳 수정으로 양쪽이 함께 반영됩니다.

**2. 배너 제목 렌더링 폰트 경로 정리**
로드해 등록한 Pretendard 인스턴스에 스타일을 다시 지정(PLAIN)하고 letter-spacing을 위해 속성 기반 레이아웃으로 재구성하던 과정을 제거하고, 등록된 폰트 인스턴스를 그대로 사용하도록 단순화했습니다.

## 🤔 고민했던 내용

한글 제목 깨짐(tofu)이 이 폰트 경로 때문이라는 가설을 세우고, EB 운영과 동일 계열인 헤드리스 Linux 컨테이너(`eclipse-temurin:21`, `amazoncorretto:21`)에서 변경 전/후 코드를 직접 렌더링해 대조했습니다. 결과적으로 **두 환경 모두에서 변경 전·후 코드가 한글을 정상 렌더링했고 tofu는 재현되지 않았습니다.** 따라서 이 폰트 변경은 tofu의 확정된 원인 수정이라기보다, 스타일 불일치와 불필요한 재구성이라는 취약한 경로를 제거하는 방어적 정리로 보는 것이 정확합니다. 현재 노출되는 깨진 배너는 과거 생성된 정적 이미지가 남아 있는 경우일 가능성이 있어, 재생성 API 호출로 교체 여부를 별도 확인할 필요가 있습니다.

winner 선별 로직은 점수가 0인 달 전체 제외 / 단독 1위 / 점수 양수 공동 1위 / 점수 0 혼재 케이스를 단위 테스트로 검증했고, 배너 렌더링은 폰트의 한글 글리프 보유 여부와 PNG 생성을 검증했습니다.

## 💬 리뷰 중점사항

- winner 선별 결과가 비었을 때 기존 배너를 보존하는 정책이 의도와 맞는지
- letter-spacing(코스메틱) 제거로 인한 시각적 변화 허용 여부
- 폰트 변경을 함께 포함할지, winner 선별만 우선 반영할지에 대한 의견

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Ranking banners now only generate for winners with positive scores, preventing unnecessary banner creation.
  * Improved banner text font rendering with enhanced support for Korean characters.

* **Tests**
  * Added test coverage for ranking banner service score filtering and font display validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->