### PR TITLE
[DDING-000] dev 배포 시 CloudWatch Agent config 함께 전송

### DIFF
--- a/.github/workflows/dev-server-deployer.yml
+++ b/.github/workflows/dev-server-deployer.yml
@@ -35,7 +35,10 @@ jobs:
           host: ${{ secrets.DEV_INSTANCE_HOST }}
           username: ${{ secrets.DEV_INSTANCE_USERNAME }}
           key: ${{ secrets.DEV_INSTANCE_KEY }}
-          source: "./compose-dev.yaml"
+          # compose 파일과 함께 CloudWatch Agent config 도 전송한다.
+          # compose-dev.yaml 의 cloudwatch-agent 사이드카가 ./cloudwatch/dev-cloudwatch-agent.json 을
+          # 바인드 마운트하므로, 이 파일이 없으면 Docker가 빈 디렉토리를 만들어 에이전트가 config 를 못 읽는다.
+          source: "./compose-dev.yaml,./cloudwatch/dev-cloudwatch-agent.json"
           target: "~/app/docker"
           timeout: 120s
           overwrite: true


### PR DESCRIPTION
## 🚀 작업 내용

dev 배포(CD) 워크플로우가 서버로 파일을 전송할 때 `compose-dev.yaml` 만 복사하고, CloudWatch Agent 설정 파일(`cloudwatch/dev-cloudwatch-agent.json`)은 함께 보내지 않던 문제를 수정했습니다.

`compose-dev.yaml` 의 cloudwatch-agent 사이드카는 이 설정 파일을 컨테이너로 바인드 마운트하는데, 서버에 파일이 없으면 Docker 가 해당 경로를 빈 디렉토리로 생성합니다. 그 결과 에이전트가 설정을 읽지 못하고 컨테이너가 계속 재시작됩니다. (앱 컨테이너 자체는 영향이 없어 서비스는 정상 동작했습니다.)

scp 대상에 설정 파일을 추가해 서버로 함께 전송되도록 했습니다.

## 🤔 고민했던 내용

- 디렉토리 구조(`cloudwatch/`)가 서버에서도 그대로 유지되어야 compose 의 상대 경로(`./cloudwatch/...`)와 맞아떨어져, 원본 경로를 보존하는 방식으로 전송하도록 했습니다.

## 💬 리뷰 중점사항

- dev 전용 CD 워크플로우 변경으로, 운영 배포에는 영향이 없습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **배포**
  * 개발 환경 배포 시 CloudWatch Agent 설정 파일도 서버에 함께 전송되도록 개선했습니다.
  * 설정 파일 누락으로 CloudWatch Agent가 정상적으로 구성되지 않을 수 있는 문제를 방지했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->