### PR TITLE
[DDING-000] dev 배포 시 stale CloudWatch 마운트 경로 정리

### DIFF
--- a/.github/workflows/dev-server-deployer.yml
+++ b/.github/workflows/dev-server-deployer.yml
@@ -29,6 +29,18 @@ jobs:
               --port 22 \
               --cidr ${{ steps.publicip.outputs.ip }}/32
 
+      - name: Clean stale CloudWatch mount path
+        uses: appleboy/ssh-action@v1.0.3
+        with:
+          host: ${{ secrets.DEV_INSTANCE_HOST }}
+          username: ${{ secrets.DEV_INSTANCE_USERNAME }}
+          key: ${{ secrets.DEV_INSTANCE_KEY }}
+          script: |
+            # 과거 config 파일이 없던 시절, Docker가 bind-mount 대상 파일 자리에
+            # 빈 디렉토리(cloudwatch/dev-cloudwatch-agent.json/)를 만들어 두었다.
+            # 파일이 와야 할 자리에 디렉토리가 있으면 scp untar 가 실패하므로 먼저 제거한다.
+            sudo rm -rf ~/app/docker/cloudwatch
+
       - name: Copy Docker Compose file to server
         uses: appleboy/scp-action@master
         with:


### PR DESCRIPTION
## 🚀 작업 내용

직전 PR(#422)로 CloudWatch Agent 설정 파일을 서버로 전송하도록 했으나, 배포가 실패했습니다.

원인은 설정 파일이 없던 이전 배포들에서 Docker가 bind-mount 대상 파일 자리에 빈 디렉토리를 만들어 두었기 때문입니다. 파일이 와야 할 위치에 같은 이름의 디렉토리가 있어 전송(untar) 단계가 `Is a directory` 로 실패했습니다.

파일 전송 직전에 해당 경로를 정리하는 단계를 추가했습니다. 정리 후 전송으로 항상 올바른 파일이 놓이며, 이후 배포에서도 안전하게 반복 실행됩니다.

## 💬 리뷰 중점사항

- dev 전용 CD 워크플로우 변경으로 운영 배포에는 영향이 없습니다.