### PR TITLE
[DDING-000] dev 컨테이너 재부팅 시 자동 기동 restart 정책 추가

### DIFF
--- a/compose-dev.yaml
+++ b/compose-dev.yaml
@@ -2,6 +2,8 @@ version: '3.8'
 services:
   spring:
     image: public.ecr.aws/${DEV_ECR_REGISTRY_ALIAS}/dev-ecr:${VERSION:-latest}
+    # EC2 재부팅(12h 스케줄 stop/start) 후 Docker 데몬이 컨테이너를 자동 재기동하도록 한다.
+    restart: unless-stopped
     volumes:
       - mysql-volume:/var/lib/mysql
       - app-logs:/logs
@@ -18,6 +20,8 @@ services:
 
   mysql:
     image: mysql:8.4.6
+    # EC2 재부팅(12h 스케줄 stop/start) 후 자동 재기동.
+    restart: unless-stopped
     environment:
       MYSQL_DATABASE: ddingdong
       MYSQL_ROOT_PASSWORD: ${DEV_DB_PASSWORD}


### PR DESCRIPTION
## 🚀 작업 내용

dev EC2를 매일 자동으로 켜고 끄는 12시간 스케줄링을 도입하면서, 재부팅 후 애플리케이션 컨테이너가 자동으로 다시 올라오지 않는 문제를 발견해 수정했습니다.

기존에는 cloudwatch-agent 컨테이너에만 재시작 정책이 있었고, spring/mysql 컨테이너에는 없어 인스턴스가 stop→start 될 때마다 앱이 내려간 채로 남았습니다. 두 컨테이너에 `restart: unless-stopped` 를 추가해, 스케줄에 의한 재부팅 이후에도 Docker 데몬이 컨테이너를 자동으로 기동하도록 했습니다.

## 💬 리뷰 중점사항

- dev 전용 구성 변경으로 운영에는 영향이 없습니다.
- 데이터 볼륨(mysql-volume)은 그대로 유지되어 재부팅 후에도 데이터가 보존됩니다.