### PR TITLE
[DDING-000] 배너 한글 폰트가 런타임에 풀려 깨지는 문제 수정

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,6 @@ CLAUDE.local.md
 ### Local Docs ###
 docs/local/
 .claude/plans/
+
+# 런타임에 클래스패스 폰트를 풀어두는 경로 (BannerImageGenerator)
+/fonts/

--- a/src/main/java/ddingdong/ddingdongBE/domain/banner/service/BannerImageGenerator.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/banner/service/BannerImageGenerator.java
@@ -13,10 +13,13 @@ import java.awt.image.BufferedImage;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.file.AtomicMoveNotSupportedException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import jakarta.annotation.PostConstruct;
 import javax.imageio.ImageIO;
 import lombok.extern.slf4j.Slf4j;
@@ -43,9 +46,12 @@ public class BannerImageGenerator {
     private static final String MEDIUM_FONT_PATH = "fonts/Pretendard-Medium.otf";
 
     // 배너는 매월 1일에만 생성되므로, 기동 시 로드한 폰트가 수 주간 유휴 상태로 남는다.
-    // 그 사이 외부 요인으로 폰트가 해제되면 렌더링 직전에 재로드해야 하므로 volatile 로 둔다.
-    private volatile Font boldBaseFont;
-    private volatile Font mediumBaseFont;
+    // 그 사이 외부 요인으로 폰트가 해제되면 렌더링 직전에 재로드하므로 폰트 경로별로 보관한다.
+    private final Map<String, Font> loadedFonts = new ConcurrentHashMap<>();
+
+    // 재로드는 폰트 파일을 다시 쓰는 작업이라, 같은 폰트에 대해 동시에 일어나면
+    // 한쪽이 읽는 중인 파일을 다른 쪽이 교체할 수 있다. 폰트 단위로 직렬화한다.
+    private final Map<String, Object> fontLoadLocks = new ConcurrentHashMap<>();
 
     private final Path fontDirectory;
 
@@ -59,8 +65,8 @@ public class BannerImageGenerator {
 
     @PostConstruct
     void init() {
-        this.boldBaseFont = loadFont(BOLD_FONT_PATH);
-        this.mediumBaseFont = loadFont(MEDIUM_FONT_PATH);
+        loadedFonts.put(BOLD_FONT_PATH, loadFont(BOLD_FONT_PATH));
+        loadedFonts.put(MEDIUM_FONT_PATH, loadFont(MEDIUM_FONT_PATH));
     }
 
     public byte[] generateWebBannerImage(String clubName, BufferedImage clubLogo, String category, int month) {
@@ -209,42 +215,65 @@ public class BannerImageGenerator {
     // 이름으로 재조회해 한글 글리프가 없는 fallback 폰트로 그린다(제목 tofu).
     // 따라서 앱이 소유한 경로에 폰트를 풀어두고 File 오버로드로 로드한다.
     private Font loadFont(String path) {
-        try (InputStream fontStream = getClass().getClassLoader().getResourceAsStream(path)) {
-            if (fontStream == null) {
+        // 파일을 쓰는 동안 다른 스레드가 같은 파일을 읽거나 교체하지 못하도록 폰트 단위로 잠근다.
+        synchronized (fontLoadLocks.computeIfAbsent(path, key -> new Object())) {
+            try (InputStream fontStream = getClass().getClassLoader().getResourceAsStream(path)) {
+                if (fontStream == null) {
+                    throw new BannerImageGenerationException();
+                }
+                Path extractedFont = extractFont(fontStream, path);
+                Font font = Font.createFont(Font.TRUETYPE_FONT, extractedFont.toFile());
+                GraphicsEnvironment.getLocalGraphicsEnvironment().registerFont(font);
+                return font;
+            } catch (BannerImageGenerationException e) {
+                throw e;
+            } catch (Exception e) {
+                log.error("커스텀 폰트 로드 실패 ({}): {}", path, e.getMessage());
                 throw new BannerImageGenerationException();
             }
-            Path extractedFont = extractFont(fontStream, path);
-            Font font = Font.createFont(Font.TRUETYPE_FONT, extractedFont.toFile());
-            GraphicsEnvironment.getLocalGraphicsEnvironment().registerFont(font);
-            return font;
-        } catch (BannerImageGenerationException e) {
-            throw e;
-        } catch (Exception e) {
-            log.error("커스텀 폰트 로드 실패 ({}): {}", path, e.getMessage());
-            throw new BannerImageGenerationException();
         }
     }
 
+    // 사용 중인 폰트 파일을 직접 덮어쓰면 읽는 쪽이 깨진 파일을 보게 되므로,
+    // 임시 파일에 먼저 쓰고 같은 디렉토리 안에서 원자적으로 옮긴다.
     private Path extractFont(InputStream fontStream, String path) throws IOException {
         Files.createDirectories(fontDirectory);
-        Path extractedFont = fontDirectory.resolve(Paths.get(path).getFileName().toString());
-        Files.copy(fontStream, extractedFont, StandardCopyOption.REPLACE_EXISTING);
+        String fontFileName = Paths.get(path).getFileName().toString();
+        Path extractedFont = fontDirectory.resolve(fontFileName);
+        Path temporaryFont = fontDirectory.resolve(fontFileName + ".tmp");
+
+        Files.copy(fontStream, temporaryFont, StandardCopyOption.REPLACE_EXISTING);
+        try {
+            Files.move(temporaryFont, extractedFont, StandardCopyOption.ATOMIC_MOVE);
+        } catch (AtomicMoveNotSupportedException e) {
+            Files.move(temporaryFont, extractedFont, StandardCopyOption.REPLACE_EXISTING);
+        }
         return extractedFont;
     }
 
     // 폰트가 해제되면 예외 없이 fallback 폰트로 그려져 배너가 조용히 깨진다.
     // 그리기 직전에 실제로 해당 문구를 표현할 수 있는지 확인하고, 불가능하면 재로드한다.
-    private Font usableFont(Font baseFont, String path, String text) {
-        if (canDisplayFully(baseFont, text)) {
-            return baseFont;
+    private Font usableFont(String path, String text) {
+        Font cachedFont = loadedFonts.get(path);
+        if (canDisplayFully(cachedFont, text)) {
+            return cachedFont;
         }
-        log.error("배너 폰트가 런타임에 해제되어 재로드합니다 ({})", path);
 
-        Font reloadedFont = loadFont(path);
-        if (!canDisplayFully(reloadedFont, text)) {
-            log.warn("재로드 후에도 폰트가 표현할 수 없는 문자가 있습니다 ({}): {}", path, text);
+        synchronized (fontLoadLocks.computeIfAbsent(path, key -> new Object())) {
+            // 잠금을 기다리는 동안 다른 스레드가 이미 재로드했을 수 있다.
+            Font currentFont = loadedFonts.get(path);
+            if (canDisplayFully(currentFont, text)) {
+                return currentFont;
+            }
+            log.error("배너 폰트가 런타임에 해제되어 재로드합니다 ({})", path);
+
+            Font reloadedFont = loadFont(path);
+            if (!canDisplayFully(reloadedFont, text)) {
+                log.warn("재로드 후에도 폰트가 표현할 수 없는 문자가 있습니다 ({}): {}", path, text);
+            }
+            loadedFonts.put(path, reloadedFont);
+            return reloadedFont;
         }
-        return reloadedFont;
     }
 
     private boolean canDisplayFully(Font font, String text) {
@@ -252,15 +281,11 @@ public class BannerImageGenerator {
     }
 
     private Font titleFont(float size, String text) {
-        Font reloaded = usableFont(boldBaseFont, BOLD_FONT_PATH, text);
-        this.boldBaseFont = reloaded;
-        return createStyledFont(reloaded, size);
+        return createStyledFont(usableFont(BOLD_FONT_PATH, text), size);
     }
 
     private Font bodyFont(float size, String text) {
-        Font reloaded = usableFont(mediumBaseFont, MEDIUM_FONT_PATH, text);
-        this.mediumBaseFont = reloaded;
-        return createStyledFont(reloaded, size);
+        return createStyledFont(usableFont(MEDIUM_FONT_PATH, text), size);
     }
 
     private byte[] toPngBytes(BufferedImage image) {

--- a/src/main/java/ddingdong/ddingdongBE/domain/banner/service/BannerImageGenerator.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/banner/service/BannerImageGenerator.java
@@ -13,9 +13,14 @@ import java.awt.image.BufferedImage;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardCopyOption;
 import jakarta.annotation.PostConstruct;
 import javax.imageio.ImageIO;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -37,8 +42,20 @@ public class BannerImageGenerator {
     private static final String BOLD_FONT_PATH = "fonts/Pretendard-Bold.otf";
     private static final String MEDIUM_FONT_PATH = "fonts/Pretendard-Medium.otf";
 
-    private Font boldBaseFont;
-    private Font mediumBaseFont;
+    // 배너는 매월 1일에만 생성되므로, 기동 시 로드한 폰트가 수 주간 유휴 상태로 남는다.
+    // 그 사이 외부 요인으로 폰트가 해제되면 렌더링 직전에 재로드해야 하므로 volatile 로 둔다.
+    private volatile Font boldBaseFont;
+    private volatile Font mediumBaseFont;
+
+    private final Path fontDirectory;
+
+    // JDK가 관리하는 임시 디렉토리(/tmp)가 아니라 애플리케이션이 소유한 경로에 폰트를 풀어둔다.
+    // 배포마다 새로 만들어지는 앱 디렉토리이므로 OS의 임시파일 정리 대상이 되지 않는다.
+    public BannerImageGenerator(@Value("${banner.font-directory:}") String fontDirectory) {
+        this.fontDirectory = fontDirectory.isBlank()
+                ? Paths.get(System.getProperty("user.dir"), "fonts")
+                : Paths.get(fontDirectory);
+    }
 
     @PostConstruct
     void init() {
@@ -140,40 +157,40 @@ public class BannerImageGenerator {
         int textStartY = (WEB_HEIGHT - textBlockHeight) / 2;
 
         // Use the Pretendard-Bold font face without applying Java synthetic bold style.
-        Font mainFont = createStyledFont(boldBaseFont, 36f);
+        String mainText = "이달의 피드 : " + clubName + " 축하드립니다!";
+        Font mainFont = titleFont(36f, mainText);
         graphics.setFont(mainFont);
         graphics.setColor(Color.decode("#1F2937"));
         FontMetrics mainMetrics = graphics.getFontMetrics();
-        String mainText = "이달의 피드 : " + clubName + " 축하드립니다!";
         int mainY = textStartY + mainMetrics.getAscent();
         graphics.drawString(mainText, textX, mainY);
 
         // PC/Body/Medium2: Pretendard Medium 16px, line-height 24px
-        Font subFont = createStyledFont(mediumBaseFont, 16f);
+        String subText = month + "월의 피드는 '동아리 피드'에서 확인하실 수 있습니다.";
+        Font subFont = bodyFont(16f, subText);
         graphics.setFont(subFont);
         graphics.setColor(Color.decode("#6B7280"));
         FontMetrics subMetrics = graphics.getFontMetrics();
-        String subText = month + "월의 피드는 '동아리 피드'에서 확인하실 수 있습니다.";
         int subY = textStartY + 40 + 4 + subMetrics.getAscent();
         graphics.drawString(subText, textX, subY);
     }
 
     private void drawMobileTexts(Graphics2D graphics, String clubName, int month, int textStartY) {
-        Font mainFont = createStyledFont(boldBaseFont, 18f);
+        String mainText = "이달의 피드 : " + clubName + " 축하드립니다!";
+        Font mainFont = titleFont(18f, mainText);
         graphics.setFont(mainFont);
         graphics.setColor(new Color(33, 33, 33));
         FontMetrics mainMetrics = graphics.getFontMetrics();
-        String mainText = "이달의 피드 : " + clubName + " 축하드립니다!";
         int mainX = (MOBILE_WIDTH - mainMetrics.stringWidth(mainText)) / 2;
         int mainY = textStartY + mainMetrics.getAscent();
         graphics.drawString(mainText, mainX, mainY);
 
         // Mobile/Sub: Pretendard Medium 12px, centered
-        Font subFont = createStyledFont(mediumBaseFont, 12f);
+        String subText = month + "월의 피드는 '동아리 피드'에서 확인하실 수 있습니다.";
+        Font subFont = bodyFont(12f, subText);
         graphics.setFont(subFont);
         graphics.setColor(new Color(100, 100, 100));
         FontMetrics subMetrics = graphics.getFontMetrics();
-        String subText = month + "월의 피드는 '동아리 피드'에서 확인하실 수 있습니다.";
         int subX = (MOBILE_WIDTH - subMetrics.stringWidth(subText)) / 2;
         graphics.drawString(subText, subX, mainY + 20);
     }
@@ -186,12 +203,18 @@ public class BannerImageGenerator {
         return baseFont.deriveFont(size);
     }
 
+    // Font.createFont(int, InputStream) 은 폰트를 java.io.tmpdir 의 임시파일로 복사한 뒤
+    // 글리프를 그 파일에서 지연 로딩한다. 운영(EB/Amazon Linux)에서는 임시파일 정리 데몬이
+    // 장기간 미접근 상태인 이 파일을 삭제하고, 그 뒤 렌더링하면 JDK가 폰트를 조용히 해제한 채
+    // 이름으로 재조회해 한글 글리프가 없는 fallback 폰트로 그린다(제목 tofu).
+    // 따라서 앱이 소유한 경로에 폰트를 풀어두고 File 오버로드로 로드한다.
     private Font loadFont(String path) {
         try (InputStream fontStream = getClass().getClassLoader().getResourceAsStream(path)) {
             if (fontStream == null) {
                 throw new BannerImageGenerationException();
             }
-            Font font = Font.createFont(Font.TRUETYPE_FONT, fontStream);
+            Path extractedFont = extractFont(fontStream, path);
+            Font font = Font.createFont(Font.TRUETYPE_FONT, extractedFont.toFile());
             GraphicsEnvironment.getLocalGraphicsEnvironment().registerFont(font);
             return font;
         } catch (BannerImageGenerationException e) {
@@ -200,6 +223,44 @@ public class BannerImageGenerator {
             log.error("커스텀 폰트 로드 실패 ({}): {}", path, e.getMessage());
             throw new BannerImageGenerationException();
         }
+    }
+
+    private Path extractFont(InputStream fontStream, String path) throws IOException {
+        Files.createDirectories(fontDirectory);
+        Path extractedFont = fontDirectory.resolve(Paths.get(path).getFileName().toString());
+        Files.copy(fontStream, extractedFont, StandardCopyOption.REPLACE_EXISTING);
+        return extractedFont;
+    }
+
+    // 폰트가 해제되면 예외 없이 fallback 폰트로 그려져 배너가 조용히 깨진다.
+    // 그리기 직전에 실제로 해당 문구를 표현할 수 있는지 확인하고, 불가능하면 재로드한다.
+    private Font usableFont(Font baseFont, String path, String text) {
+        if (canDisplayFully(baseFont, text)) {
+            return baseFont;
+        }
+        log.error("배너 폰트가 런타임에 해제되어 재로드합니다 ({})", path);
+
+        Font reloadedFont = loadFont(path);
+        if (!canDisplayFully(reloadedFont, text)) {
+            log.warn("재로드 후에도 폰트가 표현할 수 없는 문자가 있습니다 ({}): {}", path, text);
+        }
+        return reloadedFont;
+    }
+
+    private boolean canDisplayFully(Font font, String text) {
+        return font != null && font.canDisplayUpTo(text) < 0;
+    }
+
+    private Font titleFont(float size, String text) {
+        Font reloaded = usableFont(boldBaseFont, BOLD_FONT_PATH, text);
+        this.boldBaseFont = reloaded;
+        return createStyledFont(reloaded, size);
+    }
+
+    private Font bodyFont(float size, String text) {
+        Font reloaded = usableFont(mediumBaseFont, MEDIUM_FONT_PATH, text);
+        this.mediumBaseFont = reloaded;
+        return createStyledFont(reloaded, size);
     }
 
     private byte[] toPngBytes(BufferedImage image) {

--- a/src/main/java/ddingdong/ddingdongBE/domain/banner/service/BannerImageGenerator.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/banner/service/BannerImageGenerator.java
@@ -4,6 +4,7 @@ import ddingdong.ddingdongBE.common.exception.BannerException.BannerImageGenerat
 import ddingdong.ddingdongBE.domain.banner.entity.ClubCategoryColor;
 import java.awt.Color;
 import java.awt.Font;
+import java.awt.FontFormatException;
 import java.awt.FontMetrics;
 import java.awt.GraphicsEnvironment;
 import java.awt.Graphics2D;
@@ -13,11 +14,9 @@ import java.awt.image.BufferedImage;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.nio.file.AtomicMoveNotSupportedException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.nio.file.StandardCopyOption;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import jakarta.annotation.PostConstruct;
@@ -49,8 +48,10 @@ public class BannerImageGenerator {
     // 그 사이 외부 요인으로 폰트가 해제되면 렌더링 직전에 재로드하므로 폰트 경로별로 보관한다.
     private final Map<String, Font> loadedFonts = new ConcurrentHashMap<>();
 
-    // 재로드는 폰트 파일을 다시 쓰는 작업이라, 같은 폰트에 대해 동시에 일어나면
-    // 한쪽이 읽는 중인 파일을 다른 쪽이 교체할 수 있다. 폰트 단위로 직렬화한다.
+    // 추출해둔 폰트 파일의 위치. 재로드 시 이 파일을 그대로 다시 읽어 backing file 을 교체하지 않는다.
+    private final Map<String, Path> extractedFontFiles = new ConcurrentHashMap<>();
+
+    // 재로드가 같은 폰트에 대해 동시에 일어나지 않도록 폰트 단위로 직렬화한다.
     private final Map<String, Object> fontLoadLocks = new ConcurrentHashMap<>();
 
     private final Path fontDirectory;
@@ -214,16 +215,16 @@ public class BannerImageGenerator {
     // 장기간 미접근 상태인 이 파일을 삭제하고, 그 뒤 렌더링하면 JDK가 폰트를 조용히 해제한 채
     // 이름으로 재조회해 한글 글리프가 없는 fallback 폰트로 그린다(제목 tofu).
     // 따라서 앱이 소유한 경로에 폰트를 풀어두고 File 오버로드로 로드한다.
+    // 클래스패스의 폰트를 새 파일로 추출한 뒤 로드한다. 최초 로드와, 추출본이 못 쓰게 된 경우에만 쓴다.
     private Font loadFont(String path) {
-        // 파일을 쓰는 동안 다른 스레드가 같은 파일을 읽거나 교체하지 못하도록 폰트 단위로 잠근다.
         synchronized (fontLoadLocks.computeIfAbsent(path, key -> new Object())) {
             try (InputStream fontStream = getClass().getClassLoader().getResourceAsStream(path)) {
                 if (fontStream == null) {
                     throw new BannerImageGenerationException();
                 }
                 Path extractedFont = extractFont(fontStream, path);
-                Font font = Font.createFont(Font.TRUETYPE_FONT, extractedFont.toFile());
-                GraphicsEnvironment.getLocalGraphicsEnvironment().registerFont(font);
+                Font font = createFontFrom(extractedFont);
+                extractedFontFiles.put(path, extractedFont);
                 return font;
             } catch (BannerImageGenerationException e) {
                 throw e;
@@ -234,20 +235,41 @@ public class BannerImageGenerator {
         }
     }
 
-    // 사용 중인 폰트 파일을 직접 덮어쓰면 읽는 쪽이 깨진 파일을 보게 되므로,
-    // 임시 파일에 먼저 쓰고 같은 디렉토리 안에서 원자적으로 옮긴다.
+    // 이미 추출해둔 파일이 온전하면 그 파일에서 다시 만든다. 렌더링 중인 다른 스레드가 같은 파일을
+    // backing file 로 쓰고 있을 수 있으므로 교체하지 않는다.
+    // 파일이 사라졌거나 손상된 경우에만 새 경로에 추출하고, 기존 파일은 그대로 둔다.
+    private Font reloadFont(String path) {
+        synchronized (fontLoadLocks.computeIfAbsent(path, key -> new Object())) {
+            Path extractedFont = extractedFontFiles.get(path);
+            if (extractedFont != null) {
+                try {
+                    return createFontFrom(extractedFont);
+                } catch (Exception e) {
+                    log.warn("추출해둔 폰트 파일을 읽을 수 없어 새로 추출합니다 ({}): {}", extractedFont, e.getMessage());
+                }
+            }
+            return loadFont(path);
+        }
+    }
+
+    private Font createFontFrom(Path fontFile) throws IOException, FontFormatException {
+        Font font = Font.createFont(Font.TRUETYPE_FONT, fontFile.toFile());
+        GraphicsEnvironment.getLocalGraphicsEnvironment().registerFont(font);
+        return font;
+    }
+
+    // 이미 쓰이고 있을 수 있는 파일을 덮어쓰지 않도록, 비어 있는 경로를 찾아 추출한다.
     private Path extractFont(InputStream fontStream, String path) throws IOException {
         Files.createDirectories(fontDirectory);
         String fontFileName = Paths.get(path).getFileName().toString();
-        Path extractedFont = fontDirectory.resolve(fontFileName);
-        Path temporaryFont = fontDirectory.resolve(fontFileName + ".tmp");
 
-        Files.copy(fontStream, temporaryFont, StandardCopyOption.REPLACE_EXISTING);
-        try {
-            Files.move(temporaryFont, extractedFont, StandardCopyOption.ATOMIC_MOVE);
-        } catch (AtomicMoveNotSupportedException e) {
-            Files.move(temporaryFont, extractedFont, StandardCopyOption.REPLACE_EXISTING);
+        Path extractedFont = fontDirectory.resolve(fontFileName);
+        int sequence = 1;
+        while (Files.exists(extractedFont)) {
+            extractedFont = fontDirectory.resolve(sequence++ + "-" + fontFileName);
         }
+
+        Files.copy(fontStream, extractedFont);
         return extractedFont;
     }
 
@@ -267,7 +289,7 @@ public class BannerImageGenerator {
             }
             log.error("배너 폰트가 런타임에 해제되어 재로드합니다 ({})", path);
 
-            Font reloadedFont = loadFont(path);
+            Font reloadedFont = reloadFont(path);
             if (!canDisplayFully(reloadedFont, text)) {
                 log.warn("재로드 후에도 폰트가 표현할 수 없는 문자가 있습니다 ({}): {}", path, text);
             }

--- a/src/test/java/ddingdong/ddingdongBE/domain/banner/service/BannerImageGeneratorTest.java
+++ b/src/test/java/ddingdong/ddingdongBE/domain/banner/service/BannerImageGeneratorTest.java
@@ -9,8 +9,10 @@ import java.awt.image.BufferedImage;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.lang.reflect.Field;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.attribute.FileTime;
 import java.util.Map;
 import javax.imageio.ImageIO;
 import org.junit.jupiter.api.BeforeAll;
@@ -110,6 +112,57 @@ class BannerImageGeneratorTest {
         assertThat(loadedFont(MEDIUM_FONT_PATH)).isNotInstanceOf(UndisplayableFont.class);
         assertThat(loadedFont(MEDIUM_FONT_PATH).canDisplayUpTo(SUBTITLE_TEXT)).isEqualTo(-1);
         assertThat(result.length).isGreaterThan(0);
+    }
+
+    @DisplayName("폰트를 재로드해도 이미 추출해둔 폰트 파일은 교체되지 않는다")
+    @Test
+    void keepsExtractedFontFileIntactOnReload() throws Exception {
+        // given - 렌더링 중인 다른 스레드가 이 파일을 backing file 로 쓰고 있을 수 있다
+        Path extractedFont = extractedFontFile(BOLD_FONT_PATH);
+        FileTime modifiedTimeBefore = Files.getLastModifiedTime(extractedFont);
+        long fontFilesBefore = countFontFiles();
+        overrideLoadedFont(BOLD_FONT_PATH, new UndisplayableFont());
+
+        // when
+        bannerImageGenerator.generateWebBannerImage("테스트동아리", createTestLogo(), "학술", 2);
+
+        // then
+        assertThat(extractedFontFile(BOLD_FONT_PATH)).isEqualTo(extractedFont);
+        assertThat(Files.getLastModifiedTime(extractedFont)).isEqualTo(modifiedTimeBefore);
+        assertThat(countFontFiles()).isEqualTo(fontFilesBefore);
+    }
+
+    @DisplayName("추출해둔 폰트 파일이 손상되면 덮어쓰지 않고 새 파일로 추출해 한글을 정상 렌더링한다")
+    @Test
+    void extractsNewFontFileWithoutOverwritingCorruptedOne() throws Exception {
+        // given
+        Path corruptedFont = extractedFontFile(BOLD_FONT_PATH);
+        byte[] corruptedContent = "not a font".getBytes(StandardCharsets.UTF_8);
+        Files.write(corruptedFont, corruptedContent);
+        long fontFilesBefore = countFontFiles();
+        overrideLoadedFont(BOLD_FONT_PATH, new UndisplayableFont());
+
+        // when
+        byte[] result = bannerImageGenerator.generateWebBannerImage("테스트동아리", createTestLogo(), "학술", 2);
+
+        // then
+        assertThat(Files.readAllBytes(corruptedFont)).isEqualTo(corruptedContent);
+        assertThat(extractedFontFile(BOLD_FONT_PATH)).isNotEqualTo(corruptedFont);
+        assertThat(countFontFiles()).isEqualTo(fontFilesBefore + 1);
+        assertKoreanTextRendered(readImage(result), 360, 70, 450, 55);
+    }
+
+    private long countFontFiles() throws Exception {
+        try (var files = Files.list(fontDirectory)) {
+            return files.filter(Files::isRegularFile).count();
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private Path extractedFontFile(String fontPath) throws Exception {
+        Field field = BannerImageGenerator.class.getDeclaredField("extractedFontFiles");
+        field.setAccessible(true);
+        return ((Map<String, Path>) field.get(bannerImageGenerator)).get(fontPath);
     }
 
     // 논리 폰트(Dialog)는 실행 환경에 한글 폰트가 있으면 한글을 표현할 수 있어

--- a/src/test/java/ddingdong/ddingdongBE/domain/banner/service/BannerImageGeneratorTest.java
+++ b/src/test/java/ddingdong/ddingdongBE/domain/banner/service/BannerImageGeneratorTest.java
@@ -9,11 +9,14 @@ import java.awt.image.BufferedImage;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.lang.reflect.Field;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import javax.imageio.ImageIO;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 class BannerImageGeneratorTest {
 
@@ -21,6 +24,9 @@ class BannerImageGeneratorTest {
     private static final String SUBTITLE_TEXT = "6월의 피드는 '동아리 피드'에서 확인하실 수 있습니다.";
 
     private BannerImageGenerator bannerImageGenerator;
+
+    @TempDir
+    Path fontDirectory;
 
     @BeforeAll
     static void enableHeadless() {
@@ -30,7 +36,7 @@ class BannerImageGeneratorTest {
 
     @BeforeEach
     void setUp() {
-        bannerImageGenerator = new BannerImageGenerator();
+        bannerImageGenerator = new BannerImageGenerator(fontDirectory.toString());
         bannerImageGenerator.init();
     }
 
@@ -48,6 +54,63 @@ class BannerImageGeneratorTest {
         Font mediumFont = extractFont("mediumBaseFont");
 
         assertThat(mediumFont.canDisplayUpTo(SUBTITLE_TEXT)).isEqualTo(-1);
+    }
+
+    @DisplayName("폰트는 지정된 경로에 풀리며, OS 정리 대상인 JDK 임시 폰트파일을 만들지 않는다")
+    @Test
+    void fontsAreExtractedIntoGivenDirectoryWithoutJdkTempFiles() throws Exception {
+        // given - Font.createFont(int, InputStream) 이 만드는 임시파일("+~JF*.tmp") 목록을 미리 확보한다
+        Path systemTempDirectory = Path.of(System.getProperty("java.io.tmpdir"));
+        long tempFontFilesBefore = countJdkTempFontFiles(systemTempDirectory);
+
+        // when
+        Path anotherFontDirectory = Files.createDirectory(fontDirectory.resolve("reloaded"));
+        new BannerImageGenerator(anotherFontDirectory.toString()).init();
+
+        // then
+        assertThat(Files.exists(anotherFontDirectory.resolve("Pretendard-Bold.otf"))).isTrue();
+        assertThat(Files.exists(anotherFontDirectory.resolve("Pretendard-Medium.otf"))).isTrue();
+        assertThat(countJdkTempFontFiles(systemTempDirectory)).isEqualTo(tempFontFilesBefore);
+    }
+
+    private long countJdkTempFontFiles(Path directory) throws Exception {
+        try (var files = Files.list(directory)) {
+            return files.filter(file -> file.getFileName().toString().startsWith("+~JF")).count();
+        }
+    }
+
+    @DisplayName("제목 폰트가 런타임에 해제되어도 제목의 한글이 네모로 깨지지 않는다")
+    @Test
+    void reloadsTitleFontWhenItIsReleasedAtRuntime() throws Exception {
+        // given - 한글 글리프가 없는 fallback 폰트로 치환해 폰트가 해제된 상황을 만든다
+        overrideFont("boldBaseFont", new Font(Font.DIALOG, Font.PLAIN, 1));
+
+        // when
+        byte[] result = bannerImageGenerator.generateWebBannerImage("테스트동아리", createTestLogo(), "학술", 2);
+
+        // then
+        assertThat(extractFont("boldBaseFont").canDisplayUpTo(TITLE_TEXT)).isEqualTo(-1);
+        assertKoreanTextRendered(readImage(result), 360, 70, 450, 55);
+    }
+
+    @DisplayName("부제목 폰트가 런타임에 해제되어도 부제목의 한글이 네모로 깨지지 않는다")
+    @Test
+    void reloadsSubtitleFontWhenItIsReleasedAtRuntime() throws Exception {
+        // given
+        overrideFont("mediumBaseFont", new Font(Font.DIALOG, Font.PLAIN, 1));
+
+        // when
+        byte[] result = bannerImageGenerator.generateWebBannerImage("테스트동아리", createTestLogo(), "학술", 2);
+
+        // then
+        assertThat(extractFont("mediumBaseFont").canDisplayUpTo(SUBTITLE_TEXT)).isEqualTo(-1);
+        assertThat(result.length).isGreaterThan(0);
+    }
+
+    private void overrideFont(String fieldName, Font font) throws Exception {
+        Field field = BannerImageGenerator.class.getDeclaredField(fieldName);
+        field.setAccessible(true);
+        field.set(bannerImageGenerator, font);
     }
 
     private Font extractFont(String fieldName) throws Exception {

--- a/src/test/java/ddingdong/ddingdongBE/domain/banner/service/BannerImageGeneratorTest.java
+++ b/src/test/java/ddingdong/ddingdongBE/domain/banner/service/BannerImageGeneratorTest.java
@@ -11,6 +11,7 @@ import java.io.IOException;
 import java.lang.reflect.Field;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Map;
 import javax.imageio.ImageIO;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
@@ -22,6 +23,8 @@ class BannerImageGeneratorTest {
 
     private static final String TITLE_TEXT = "이달의 피드 : 컴퓨터공학과 동아리 축하드립니다!";
     private static final String SUBTITLE_TEXT = "6월의 피드는 '동아리 피드'에서 확인하실 수 있습니다.";
+    private static final String BOLD_FONT_PATH = "fonts/Pretendard-Bold.otf";
+    private static final String MEDIUM_FONT_PATH = "fonts/Pretendard-Medium.otf";
 
     private BannerImageGenerator bannerImageGenerator;
 
@@ -43,7 +46,7 @@ class BannerImageGeneratorTest {
     @DisplayName("제목에 사용하는 굵은 폰트는 제목의 모든 한글 글리프를 가지고 있다")
     @Test
     void boldFontCanDisplayAllKoreanGlyphsInTitle() throws Exception {
-        Font boldFont = extractFont("boldBaseFont");
+        Font boldFont = loadedFont(BOLD_FONT_PATH);
 
         assertThat(boldFont.canDisplayUpTo(TITLE_TEXT)).isEqualTo(-1);
     }
@@ -51,7 +54,7 @@ class BannerImageGeneratorTest {
     @DisplayName("부제목에 사용하는 중간 굵기 폰트는 부제목의 모든 한글 글리프를 가지고 있다")
     @Test
     void mediumFontCanDisplayAllKoreanGlyphsInSubtitle() throws Exception {
-        Font mediumFont = extractFont("mediumBaseFont");
+        Font mediumFont = loadedFont(MEDIUM_FONT_PATH);
 
         assertThat(mediumFont.canDisplayUpTo(SUBTITLE_TEXT)).isEqualTo(-1);
     }
@@ -82,14 +85,15 @@ class BannerImageGeneratorTest {
     @DisplayName("제목 폰트가 런타임에 해제되어도 제목의 한글이 네모로 깨지지 않는다")
     @Test
     void reloadsTitleFontWhenItIsReleasedAtRuntime() throws Exception {
-        // given - 한글 글리프가 없는 fallback 폰트로 치환해 폰트가 해제된 상황을 만든다
-        overrideFont("boldBaseFont", new Font(Font.DIALOG, Font.PLAIN, 1));
+        // given - 어떤 문자도 표현하지 못하는 폰트로 바꿔 폰트가 해제된 상황을 만든다
+        overrideLoadedFont(BOLD_FONT_PATH, new UndisplayableFont());
 
         // when
         byte[] result = bannerImageGenerator.generateWebBannerImage("테스트동아리", createTestLogo(), "학술", 2);
 
         // then
-        assertThat(extractFont("boldBaseFont").canDisplayUpTo(TITLE_TEXT)).isEqualTo(-1);
+        assertThat(loadedFont(BOLD_FONT_PATH)).isNotInstanceOf(UndisplayableFont.class);
+        assertThat(loadedFont(BOLD_FONT_PATH).canDisplayUpTo(TITLE_TEXT)).isEqualTo(-1);
         assertKoreanTextRendered(readImage(result), 360, 70, 450, 55);
     }
 
@@ -97,26 +101,44 @@ class BannerImageGeneratorTest {
     @Test
     void reloadsSubtitleFontWhenItIsReleasedAtRuntime() throws Exception {
         // given
-        overrideFont("mediumBaseFont", new Font(Font.DIALOG, Font.PLAIN, 1));
+        overrideLoadedFont(MEDIUM_FONT_PATH, new UndisplayableFont());
 
         // when
         byte[] result = bannerImageGenerator.generateWebBannerImage("테스트동아리", createTestLogo(), "학술", 2);
 
         // then
-        assertThat(extractFont("mediumBaseFont").canDisplayUpTo(SUBTITLE_TEXT)).isEqualTo(-1);
+        assertThat(loadedFont(MEDIUM_FONT_PATH)).isNotInstanceOf(UndisplayableFont.class);
+        assertThat(loadedFont(MEDIUM_FONT_PATH).canDisplayUpTo(SUBTITLE_TEXT)).isEqualTo(-1);
         assertThat(result.length).isGreaterThan(0);
     }
 
-    private void overrideFont(String fieldName, Font font) throws Exception {
-        Field field = BannerImageGenerator.class.getDeclaredField(fieldName);
-        field.setAccessible(true);
-        field.set(bannerImageGenerator, font);
+    // 논리 폰트(Dialog)는 실행 환경에 한글 폰트가 있으면 한글을 표현할 수 있어
+    // 재로드 경로가 실행되지 않는다. 어떤 문자도 표현하지 못하는 폰트로 상황을 고정한다.
+    private static final class UndisplayableFont extends Font {
+
+        private UndisplayableFont() {
+            super(Font.DIALOG, Font.PLAIN, 1);
+        }
+
+        @Override
+        public int canDisplayUpTo(String str) {
+            return 0;
+        }
     }
 
-    private Font extractFont(String fieldName) throws Exception {
-        Field field = BannerImageGenerator.class.getDeclaredField(fieldName);
+    private void overrideLoadedFont(String fontPath, Font font) throws Exception {
+        loadedFonts().put(fontPath, font);
+    }
+
+    private Font loadedFont(String fontPath) throws Exception {
+        return loadedFonts().get(fontPath);
+    }
+
+    @SuppressWarnings("unchecked")
+    private Map<String, Font> loadedFonts() throws Exception {
+        Field field = BannerImageGenerator.class.getDeclaredField("loadedFonts");
         field.setAccessible(true);
-        return (Font) field.get(bannerImageGenerator);
+        return (Map<String, Font>) field.get(bannerImageGenerator);
     }
 
     @DisplayName("웹 배너 이미지가 정상적으로 생성된다")


### PR DESCRIPTION
## 🚀 작업 내용

배너 제목의 한글이 네모(tofu)로 렌더링되는 문제를 수정했습니다.

**원인**

폰트를 `InputStream`으로 로드하면 JDK가 임시 디렉토리에 파일을 복사해두고 글리프는 그릴 때 읽습니다. 배너는 월 1회만 생성돼 이 파일이 수 주간 방치되고, 그 사이 임시파일 정리 데몬이 지우면 그리는 시점에 폰트가 조용히 해제되어 한글 글리프가 없는 대체 폰트로 그려집니다.

배포 직후에는 파일이 갓 만들어져 있어 정상으로 보이고, 실제 문제는 다음 월간 배치에서 드러납니다. 그동안 수정이 반복해서 무효화된 이유입니다.

**수정**

- 폰트를 앱이 소유한 경로에 풀고 파일로 로드 (임시파일 정리 대상에서 제외)
- 한번 푼 파일은 프로세스 생존 동안 그대로 두고, 복구 시 그 파일에서 폰트만 다시 생성
- 파일이 없거나 손상된 경우에만 새 경로에 추출 (기존 파일은 덮어쓰지 않음)
- 그리기 직전 문구 표현 가능 여부를 확인해 불가능하면 복구
- 복구는 폰트 단위로 직렬화 + double-check
- 해제 감지 시 에러 로그

## 🤔 고민했던 내용

**파일 교체를 안전하게 vs 아예 안 하기**

복구를 폰트 단위로 잠가도, 이미 로드된 폰트로 렌더링 중인 스레드는 그 잠금에 참여하지 않아 자신의 backing file 이 교체되는 상황을 겪습니다. 안전한 교체 방법을 찾는 대신 교체 자체를 없앴습니다.

**캐싱 유지**

월 1회 실행이라 캐싱 이득은 없지만, 문제는 캐싱이 아니라 캐싱한 대상이 사라질 수 있다는 점이었습니다. 구조를 유지하고 복구만 추가하는 쪽이 변경 범위가 작다고 봤습니다.

**설정 기본값**

`banner.font-directory` 기본값을 프로퍼티 중첩으로 두면 해석 실패 시 기동 자체가 막혀, Java에서 결정하도록 했습니다.

**테스트 유효성**

해제 상황을 논리 폰트로 재현했더니 한글 폰트가 있는 환경에서는 복구 경로가 실행되지 않아, macOS에서 테스트 2건이 헛돌고 있었습니다. 어떤 문자도 표현하지 못하는 폰트로 고정했습니다.

## 💬 리뷰 중점사항

- 폰트를 푸는 위치(앱 작업 디렉토리 하위)가 적절한지
- 표현 가능 여부 확인을 매 렌더링마다 수행하는데, 월 1회 기준으로 문제없다고 판단했습니다
- 파일을 다시 푼 경우 이전 파일을 지우지 않고 남겨둡니다. 정리 시점을 따로 두는 게 나을지 의견 주세요

### 검증

- 배너 이미지 생성 테스트 12건 통과 (회귀 5건 추가)
- 복구 로직과 파일 보존 로직을 각각 되돌려 해당 테스트가 실패하고, 원복 시 다시 통과하는 것 확인
- 시스템 폰트 없는 컨테이너에서 렌더링 확인
- 대체 폰트로 그렸을 때 한글이 사라지고 문장부호만 남는 것을 재현해 운영 이미지와 동일함을 확인
- 동시 복구 반복 실행 확인

전체 테스트는 로컬 Docker 문제로 TestContainers 기반이 실행되지 않았습니다. CI 결과로 확인 부탁드립니다.

### 배포 관련

- 이미 생성된 이미지는 이 수정으로 바뀌지 않아 재생성 API로 운영 배너를 교체했고, 화면 반영까지 확인했습니다.
- 다음 자동 생성은 9월 1일이며, 그 전에 배포되어야 재발하지 않습니다.
