### PR TITLE
[DDING-000] 폼지 지원자 수가 캐시에 묶여 갱신되지 않는 문제 수정

### DIFF
--- a/src/main/java/ddingdong/ddingdongBE/domain/form/controller/UserFormController.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/form/controller/UserFormController.java
@@ -24,9 +24,9 @@ public class UserFormController implements UserFormApi {
     }
 
     @Override
-    @Cacheable(value = "formsCache", key = "'form_' + #root.args[0] + '_' + #root.args[1]")
     public UserFormResponse getForm(Long formId, String section) {
         UserFormQuery query = facadeUserFormService.getUserForm(formId, section);
-        return UserFormResponse.from(query);
+        int applicationCount = facadeUserFormService.getApplicationCount(formId);
+        return UserFormResponse.from(query, applicationCount);
     }
 }

--- a/src/main/java/ddingdong/ddingdongBE/domain/form/controller/dto/response/UserFormResponse.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/form/controller/dto/response/UserFormResponse.java
@@ -58,7 +58,7 @@ public record UserFormResponse(
         }
     }
 
-    public static UserFormResponse from(UserFormQuery userFormQuery) {
+    public static UserFormResponse from(UserFormQuery userFormQuery, int applicationCount) {
         List<UserFormFieldListResponse> responses = userFormQuery.formFields().stream()
                 .map(UserFormFieldListResponse::from)
                 .toList();
@@ -66,7 +66,7 @@ public record UserFormResponse(
                 .clubName(userFormQuery.clubName())
                 .title(userFormQuery.title())
                 .description(userFormQuery.description())
-                .applicationCount(userFormQuery.applicationCount())
+                .applicationCount(applicationCount)
                 .startDate(userFormQuery.startDate())
                 .endDate(userFormQuery.endDate())
                 .formFields(responses)

--- a/src/main/java/ddingdong/ddingdongBE/domain/form/service/FacadeUserFormService.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/form/service/FacadeUserFormService.java
@@ -8,4 +8,6 @@ public interface FacadeUserFormService {
     FormSectionQuery getFormSection(Long formId);
 
     UserFormQuery getUserForm(Long formId, String section);
+
+    int getApplicationCount(Long formId);
 }

--- a/src/main/java/ddingdong/ddingdongBE/domain/form/service/FacadeUserFormServiceImpl.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/form/service/FacadeUserFormServiceImpl.java
@@ -7,6 +7,7 @@ import ddingdong.ddingdongBE.domain.form.service.dto.query.FormSectionQuery;
 import ddingdong.ddingdongBE.domain.form.service.dto.query.UserFormQuery;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -26,11 +27,17 @@ public class FacadeUserFormServiceImpl implements FacadeUserFormService {
     }
 
     @Override
+    @Cacheable(value = "formsCache", key = "'form_' + #root.args[0] + '_' + #root.args[1]")
     public UserFormQuery getUserForm(Long formId, String section) {
         Form form = formService.getById(formId);
         Club club = form.getClub();
         List<FormField> formFields = formFieldService.getAllByFormAndSection(form, section);
-        int applicationCount = formStatisticService.getTotalApplicationCountByForm(form);
-        return UserFormQuery.from(club, form, applicationCount, formFields);
+        return UserFormQuery.from(club, form, formFields);
+    }
+
+    @Override
+    public int getApplicationCount(Long formId) {
+        Form form = formService.getById(formId);
+        return formStatisticService.getTotalApplicationCountByForm(form);
     }
 }

--- a/src/main/java/ddingdong/ddingdongBE/domain/form/service/dto/query/UserFormQuery.java
+++ b/src/main/java/ddingdong/ddingdongBE/domain/form/service/dto/query/UserFormQuery.java
@@ -13,13 +13,12 @@ public record UserFormQuery(
         String clubName,
         String title,
         String description,
-        int applicationCount,
         LocalDate startDate,
         LocalDate endDate,
         List<UserFormFieldListQuery> formFields
 ) {
 
-    public static UserFormQuery from(Club club, Form form, int applicationCount, List<FormField> formFields) {
+    public static UserFormQuery from(Club club, Form form, List<FormField> formFields) {
         List<UserFormFieldListQuery> formFieldListQueries = formFields.stream()
                 .map(UserFormFieldListQuery::from)
                 .toList();
@@ -28,7 +27,6 @@ public record UserFormQuery(
                 .clubName(club.getName())
                 .title(form.getTitle())
                 .description(form.getDescription())
-                .applicationCount(applicationCount)
                 .startDate(form.getStartDate())
                 .endDate(form.getEndDate())
                 .formFields(formFieldListQueries)

--- a/src/test/java/ddingdong/ddingdongBE/domain/form/service/FacadeUserFormServiceImplTest.java
+++ b/src/test/java/ddingdong/ddingdongBE/domain/form/service/FacadeUserFormServiceImplTest.java
@@ -2,6 +2,7 @@ package ddingdong.ddingdongBE.domain.form.service;
 
 import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
 
+import ddingdong.ddingdongBE.common.fixture.FormApplicationFixture;
 import ddingdong.ddingdongBE.common.support.TestContainerSupport;
 import ddingdong.ddingdongBE.domain.club.entity.Club;
 import ddingdong.ddingdongBE.domain.club.repository.ClubRepository;
@@ -12,6 +13,7 @@ import ddingdong.ddingdongBE.domain.form.repository.FormFieldRepository;
 import ddingdong.ddingdongBE.domain.form.repository.FormRepository;
 import ddingdong.ddingdongBE.domain.form.service.dto.query.FormSectionQuery;
 import ddingdong.ddingdongBE.domain.form.service.dto.query.UserFormQuery;
+import ddingdong.ddingdongBE.domain.formapplication.repository.FormApplicationRepository;
 import ddingdong.ddingdongBE.domain.user.entity.Role;
 import ddingdong.ddingdongBE.domain.user.entity.User;
 import ddingdong.ddingdongBE.domain.user.repository.UserRepository;
@@ -41,6 +43,9 @@ class FacadeUserFormServiceImplTest extends TestContainerSupport {
 
   @Autowired
   private FormFieldRepository formFieldRepository;
+
+  @Autowired
+  private FormApplicationRepository formApplicationRepository;
 
   private User savedUser;
   private Club savedClub;
@@ -102,6 +107,26 @@ class FacadeUserFormServiceImplTest extends TestContainerSupport {
 
     // then
     assertThat(userFormQuery.formFields().get(0).id()).isEqualTo(savedFormField1.getId());
+  }
+
+  @DisplayName("폼지를 이미 조회한 뒤 지원서가 접수되어도 지원자 수는 즉시 반영된다.")
+  @Test
+  void getApplicationCountIsNotStale() {
+    // given
+    createFormField("질문1", 1, savedSections.get(0), savedForm);
+    String selectedSection = savedSections.get(0);
+
+    facadeUserFormService.getUserForm(savedForm.getId(), selectedSection);
+    int countBeforeApplication = facadeUserFormService.getApplicationCount(savedForm.getId());
+
+    // when
+    formApplicationRepository.save(FormApplicationFixture.create(savedForm));
+    facadeUserFormService.getUserForm(savedForm.getId(), selectedSection);
+    int countAfterApplication = facadeUserFormService.getApplicationCount(savedForm.getId());
+
+    // then
+    assertThat(countBeforeApplication).isZero();
+    assertThat(countAfterApplication).isEqualTo(1);
   }
 
   private FormField createFormField(String question, int order, String section, Form form) {


### PR DESCRIPTION
## 🚀 작업 내용

폼지 상세 조회에 표시되는 지원자 수가 갱신되지 않는 문제를 수정했습니다.

**원인**

폼지 상세 조회는 응답 전체가 캐싱되고 있었고, 지원자 수도 그 응답에 담겨 함께 캐싱됐습니다. 만료 시간은 폼 마감일까지 남은 시간과 하루 중 짧은 쪽이라, 모집 기간에는 사실상 하루 단위로만 갱신됩니다. 게다가 캐시를 비우는 시점이 폼 생성·수정·삭제뿐이어서, 정작 지원자 수를 바꾸는 지원서 접수는 캐시를 전혀 건드리지 않았습니다.

그래서 같은 24시간 안에 들어온 사람들은 그 사이 몇 명이 지원했든 모두 같은 숫자를 보게 됩니다. 시간차를 두고 지원한 두 사람이 동일한 지원자 수를 본 것이 이 경우입니다.

**수정**

지원자 수를 캐시 경계 밖으로 뺐습니다. 폼 제목·설명·모집 기간·질문 목록은 자주 바뀌지 않으니 캐싱을 그대로 두고, 매 요청 달라지는 지원자 수만 실시간으로 조회해 응답을 조립합니다.

캐싱 위치는 컨트롤러에서 서비스 계층으로 내렸습니다. 컨트롤러에 캐시가 걸려 있으면 응답이 통째로 캐싱돼 지원자 수만 빼낼 방법이 없기 때문입니다. 캐시 키 형식과 만료 정책은 그대로여서 기존 무효화 동작에는 영향이 없습니다.

API 응답 형태는 변하지 않아 프론트 수정은 필요 없습니다.

## 🤔 고민했던 내용

**지원서 접수 시 캐시를 비우는 방안**

가장 간단하지만 캐시를 통째로 지우는 방식이라, 모집 기간에 지원이 몰리면 폼 캐시가 계속 초기화됩니다. 폼별로만 지우려 해도 캐시 키에 섹션이 포함돼 있어 특정 폼의 항목만 골라낼 수 없습니다. 캐싱 대상에서 지원자 수를 빼는 쪽이 캐시 이득을 지키면서 정확도를 얻는다고 봤습니다.

**짧은 TTL을 가진 별도 캐시**

부하와 정확도의 절충안이지만 지연이 남습니다. 지원자 수 조회는 form_id 인덱스를 타는 단순 집계라 매 요청 수행해도 부담이 크지 않다고 판단해 선택하지 않았습니다.

**회귀 테스트가 실제로 버그를 잡는지 확인**

추가한 테스트에 의미가 있는지 보려고 지원자 수 조회에 캐시를 일부러 다시 붙여 실행했고, 해당 테스트만 실패하는 것을 확인한 뒤 되돌렸습니다.

## 💬 리뷰 중점사항

- 컨트롤러가 Facade를 두 번 호출하는 구조가 괜찮은지 봐주세요. 한 번의 호출로 묶으면 같은 빈 안에서의 자기 호출이 되어 캐시 프록시를 타지 않습니다.
- 캐시 무효화 설정에 전체 삭제 옵션과 키가 함께 지정된 곳이 두 군데 있습니다. 전체 삭제가 켜져 있으면 키는 평가되지 않아 지금 동작에는 문제가 없지만, 키에 붙은 `_*`가 와일드카드로 동작한다고 오해할 여지가 있습니다. 이번 문제와는 무관해 범위에서 제외했고, 별도로 정리하면 좋겠습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * 폼 상세 정보에 최신 지원자 수가 표시됩니다.
  * 지원서 접수 후 폼 상세 조회 시 지원자 수가 즉시 갱신됩니다.

* **버그 수정**
  * 폼 상세 정보에 오래된 지원자 수가 표시될 수 있는 문제를 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->